### PR TITLE
Replace use of SFINAE with constraints

### DIFF
--- a/lib/shared/notstd/include/notstd/tostring.hxx
+++ b/lib/shared/notstd/include/notstd/tostring.hxx
@@ -29,18 +29,20 @@ struct empty_value_provider
  * @brief Helper implementing global operator << which passes the result of
  * ToString() to the output stream.
  * 
- * @tparam HasToStringT The type which implements a ToString() function returning std::string
+ * @tparam CharT 
+ * @tparam Traits 
+ * @tparam ElementT The type which implements a ToString() function returning std::string
  * @param stream 
  * @param ref 
- * @return std::ostream& 
+ * @return requires& 
  */
 template <
     typename CharT,
     typename Traits,
-    typename HasToStringT,
-    typename = typename std::enable_if<std::is_member_function_pointer<decltype(&HasToStringT::ToString)>::value>::type>
+    typename ElementT>
+requires std::is_member_function_pointer_v<decltype(&ElementT::ToString)>
 std::ostream&
-operator<<(std::basic_ostream<CharT, Traits>& stream, const HasToStringT& ref)
+operator<<(std::basic_ostream<CharT, Traits>& stream, const ElementT& ref)
 {
     stream << ref.ToString();
     return stream;
@@ -50,22 +52,24 @@ operator<<(std::basic_ostream<CharT, Traits>& stream, const HasToStringT& ref)
  * @brief Helper implementing global operator <<, wrapping optional types whose
  * value type defines a ToString() function.
  * 
- * @tparam HasToStringT The type which implements a ToString() function returning std::string
+ * @tparam CharT 
+ * @tparam Traits 
+ * @tparam ElementT The type which implements a ToString() function returning std::string
  * @tparam EmptyValueProviderT The type providing the value to pass to the
  * output stream if the specified object does not contain a value. Defaults to
  * empty_value_provider
  * @param stream 
  * @param ref 
- * @return std::ostream& 
+ * @return requires& 
  */
 template <
     typename CharT,
     typename Traits,
-    typename HasToStringT,
-    typename = typename std::enable_if<std::is_member_function_pointer<decltype(&HasToStringT::ToString)>::value>::type,
+    typename ElementT,
     typename EmptyValueProviderT = detail::empty_value_provider>
+requires std::is_member_function_pointer_v<decltype(&ElementT::ToString)>
 std::ostream&
-operator<<(std::basic_ostream<CharT, Traits>& stream, const std::optional<HasToStringT>& ref)
+operator<<(std::basic_ostream<CharT, Traits>& stream, const std::optional<ElementT>& ref)
 {
     ref.has_value()
         ? stream << ref.value()

--- a/lib/shared/notstd/include/notstd/tostring.hxx
+++ b/lib/shared/notstd/include/notstd/tostring.hxx
@@ -34,7 +34,7 @@ struct empty_value_provider
  * @tparam ElementT The type which implements a ToString() function returning std::string
  * @param stream 
  * @param ref 
- * @return requires& 
+ * @return std::ostream& 
  */
 template <
     typename CharT,
@@ -60,7 +60,7 @@ operator<<(std::basic_ostream<CharT, Traits>& stream, const ElementT& ref)
  * empty_value_provider
  * @param stream 
  * @param ref 
- * @return requires& 
+ * @return std::ostream& 
  */
 template <
     typename CharT,


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Make templated code easier to understand.

### Technical Details

* Replace complex SFINAE via `std::enable_if` with c++ 20 constraints.

### Test Results

All unit tests pass on both Linux and Windows.

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
