### PR TITLE
Add missing field initializers

### DIFF
--- a/linux/nearobjectd/Main.cxx
+++ b/linux/nearobjectd/Main.cxx
@@ -58,7 +58,7 @@ main(int argc, char *argv[])
 
     // Create service.
     auto service = NearObjectService::Create({ std::move(profileManager),
-        std::move(deviceManager) });
+        std::move(deviceManager), nullptr });
 
     // Start service runtime.
     ServiceRuntime nearObjectServiceRuntime{};

--- a/tests/unit/TestNearObjectService.cxx
+++ b/tests/unit/TestNearObjectService.cxx
@@ -37,6 +37,7 @@ TEST_CASE("near object service can be created", "[basic][service]")
             auto service = NearObjectService::Create({
                 nullptr,
                 NearObjectDeviceControllerManager::Create(),
+                nullptr,
             });
         }
         {


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Fix `-Wmissing-field-intiializers warnings.

### Technical Details

* Initialize missing fields for `NearObjectService` aggregate construction.

### Test Results

All unit tests pass on both Linux and Windows.

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
