### PR TITLE
Remove explicit definition of ostream<< operator for UwbMacAddress

### DIFF
--- a/lib/uwb/UwbMacAddress.cxx
+++ b/lib/uwb/UwbMacAddress.cxx
@@ -140,10 +140,3 @@ uwb::operator>>(std::istream& stream, UwbMacAddress& uwbMacAddress) noexcept
 
     return stream;
 }
-
-std::ostream&
-uwb::operator<<(std::ostream& stream, const UwbMacAddress& uwbMacAddress) noexcept
-{
-    stream << uwbMacAddress.ToString();
-    return stream;
-}

--- a/lib/uwb/include/uwb/UwbMacAddress.hxx
+++ b/lib/uwb/include/uwb/UwbMacAddress.hxx
@@ -409,9 +409,6 @@ operator==(const UwbMacAddress&, const UwbMacAddress&) noexcept;
 std::istream&
 operator>>(std::istream& stream, UwbMacAddress& uwbMacAddress) noexcept;
 
-std::ostream&
-operator<<(std::ostream& stream, const UwbMacAddress& uwbMacAddress) noexcept;
-
 } // namespace uwb
 
 namespace std


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Ensure other types in the `uwb` namespace can make use of `string::ostream_operators`.

### Technical Details

* Remove definition of `operator<<` from `UwbMacAddress` as it causes template deduction to fail for other types in the namespace when using `string::ostream_operators`.

### Test Results

All unit tests pass on both Linux and Windows.

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
