### PR TITLE
Add cpp-linter workflow

### DIFF
--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -1,0 +1,22 @@
+name: cpp-linter
+
+on: 
+  pull_request:
+    branches: [ "develop" ]
+
+jobs:
+  cpp-linter:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cpp-linter/cpp-linter-action@v2.3.0
+        id: linter
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          style: file
+
+      - name: Fail fast?!
+        if: steps.linter.outputs.checks-failed > 0
+        run: echo "Some files failed the linting checks!"
+        run: exit 1


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [X] Infrastructure

### Goals

Enable use of clang-format in PRs for CI.

### Technical Details

* Add workflow for `cpp-linter`, which uses invokes clang-format with the the embedded `.clang-format` file on changes in PRs.

### Test Results

This has not been tested yet.

### Reviewer Focus

None

### Future Work

Possibly enable this in CI.

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
