### PR TITLE
Fix -Wconversion, -Wshadow, -Wparenthesis issues

### DIFF
--- a/lib/shared/notstd/task_queue.cxx
+++ b/lib/shared/notstd/task_queue.cxx
@@ -46,12 +46,12 @@ task_queue::get_dispatcher() const noexcept
 }
 
 void
-task_queue::stop(pending_task_action pending_task_action) noexcept
+task_queue::stop(pending_task_action pending_action) noexcept
 {
     {
         std::scoped_lock runnables_changed_lock{ m_runnables_changed_gate };
 
-        switch (pending_task_action) {
+        switch (pending_action) {
         case pending_task_action::cancel:
             m_state = state::canceling;
             break;

--- a/lib/shared/tlv/TlvBer.cxx
+++ b/lib/shared/tlv/TlvBer.cxx
@@ -325,8 +325,8 @@ TlvBer::Builder::Build()
 void
 TlvBer::Builder::ValidateTag()
 {
-    if ((m_type == TlvBer::Type::Constructed) && (!m_data.empty()) ||
-        (m_type == TlvBer::Type::Primitive) && (!m_valuesConstructed.empty())) {
+    if (((m_type == TlvBer::Type::Constructed) && !m_data.empty()) ||
+        ((m_type == TlvBer::Type::Primitive) && !m_valuesConstructed.empty())) {
         throw InvalidTlvBerTagException();
     }
 }

--- a/lib/shared/tlv/include/TlvSimple.hxx
+++ b/lib/shared/tlv/include/TlvSimple.hxx
@@ -14,8 +14,8 @@ namespace encoding
 class TlvSimple : public Tlv
 {
 private:
-    static constexpr auto OneByteLengthMinimumSize = 2;
-    static constexpr auto ThreeByteLengthMinimumSize = 4;
+    static constexpr std::size_t OneByteLengthMinimumSize = 2;
+    static constexpr std::size_t ThreeByteLengthMinimumSize = 4;
 
     const std::vector<uint8_t> m_tag;
     const std::vector<uint8_t> m_value;

--- a/tests/unit/TestNearObjectDeviceControllerDiscoveryAgent.cxx
+++ b/tests/unit/TestNearObjectDeviceControllerDiscoveryAgent.cxx
@@ -47,7 +47,7 @@ protected:
 struct NearObjectDeviceTest :
     public NearObjectDeviceController
 {
-    explicit NearObjectDeviceTest(uint64_t deviceId) :
+    explicit NearObjectDeviceTest(uint8_t deviceId) :
         DeviceId(deviceId)
     {}
 
@@ -125,6 +125,8 @@ TEST_CASE("near object device discovery agent can be created", "[basic][service]
 
     SECTION("discovery event callback provides correct presence and device for added device")
     {
+        using nearobject::service::NearObjectDevicePresence;
+
         const auto deviceToAdd = std::make_shared<test::NearObjectDeviceTest>(0x1);
         discoveryAgentTest.RegisterDiscoveryEventCallback([&](auto&& presence, auto&& deviceAdded) {
             REQUIRE(*deviceToAdd == *deviceAdded);
@@ -135,6 +137,8 @@ TEST_CASE("near object device discovery agent can be created", "[basic][service]
 
     SECTION("discovery event callback provides correct presence and device for removed device")
     {
+        using nearobject::service::NearObjectDevicePresence;
+
         const auto deviceToRemove = std::make_shared<test::NearObjectDeviceTest>(0x1);
         discoveryAgentTest.RegisterDiscoveryEventCallback([&](auto&& presence, auto&& deviceRemoved) {
             REQUIRE(*deviceToRemove == *deviceRemoved);

--- a/tests/unit/TestTlvBer.cxx
+++ b/tests/unit/TestTlvBer.cxx
@@ -22,7 +22,7 @@ std::vector<uint8_t>
 getOctets(size_t length)
 {
     std::independent_bits_engine<std::mt19937, CHAR_BIT * sizeof(uint8_t), uint16_t> engine(
-        std::chrono::system_clock::now().time_since_epoch().count());
+        static_cast<uint16_t>(std::chrono::system_clock::now().time_since_epoch().count()));
 
     std::vector<uint8_t> holder(length);
     std::generate(std::begin(holder), std::end(holder), [&engine] {

--- a/tests/unit/uwb/protocols/fira/TestUwbFiraUwbCapability.cxx
+++ b/tests/unit/uwb/protocols/fira/TestUwbFiraUwbCapability.cxx
@@ -159,15 +159,15 @@ TEST_CASE("Encoding into a TlvBer", "[basic]")
     const auto values = tlv->GetValues();
     REQUIRE(values.size() == TestUwbCapability::tagAndExpected.size());
 
-    for (auto [tag, expected] : TestUwbCapability::tagAndExpected) {
+    for (const auto& [tagExpected, valueExpected] : TestUwbCapability::tagAndExpected) {
         // verify that the tag exists in the values
         bool wefoundit = false;
         for (const auto& subtlv : values) {
-            wefoundit = (subtlv.GetTag().size() == 1) and (subtlv.GetTag()[0] == notstd::to_underlying(tag));
+            wefoundit = (subtlv.GetTag().size() == 1) and (subtlv.GetTag()[0] == notstd::to_underlying(tagExpected));
             if (wefoundit) {
                 // validate the value
                 const auto tlvValue = subtlv.GetValue();
-                REQUIRE(std::equal(std::cbegin(expected), std::cend(expected), std::cbegin(tlvValue), std::cend(tlvValue)));
+                REQUIRE(std::equal(std::cbegin(valueExpected), std::cend(valueExpected), std::cbegin(tlvValue), std::cend(tlvValue)));
                 break;
             }
         }


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Reduce compiler warnings emitted.

### Technical Details

* Resolve the following warnings:
   - `-Wconversion`
   - `-Wshadow`
   - `-Wparenthesis`
 
### Test Results

All unit tests pass on both Linux and Windows.

### Reviewer Focus

None

### Future Work

* Fix `-fpermissive` issues.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
