### PR TITLE
Fix -fpermissive issues

### DIFF
--- a/lib/uwb/include/uwb/protocols/fira/UwbConfiguration.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/UwbConfiguration.hxx
@@ -145,36 +145,36 @@ struct UwbConfiguration
     static UwbConfiguration
     FromDataObject(const encoding::TlvBer& tlv);
 
-    uint32_t FiraPhyVersion{ 0 };
-    uint32_t FiraMacVersion{ 0 };
-    DeviceRole DeviceRole{ DeviceRoleDefault };
-    RangingConfiguration RangingConfiguration{ RangingConfigurationDefault };
-    StsConfiguration StsConfiguration{ StsConfigurationDefault };
-    MultiNodeMode MultiNodeMode{ MultiNodeModeDefault };
-    RangingMode RangingTimeStruct{ RangingTimeStructDefault };
-    SchedulingMode SchedulingMode{ ScheduledModeDefault };
-    bool HoppingMode{ HoppingModeDefault };
-    bool BlockStriding{ BlockStridingDefault };
-    uint32_t UwbInitiationTime{ UwbInitiationTimeDefault };
-    Channel Channel{ Channel::C9 };
-    StsPacketConfiguration RFrameConfig{ RFrameConfigDefault };
-    ConvolutionalCodeConstraintLength ConvolutionalCodeConstraintLength{ CcConstraintLengthDefault };
-    PrfMode PrfMode{ PrfModeDefault };
-    uint8_t Sp0PhySetNumber{ Sp0PhySetNumberDefault };
-    uint8_t Sp1PhySetNumber{ Sp0PhySetNumberDefault };
-    uint8_t Sp3PhySetNumber{ Sp0PhySetNumberDefault };
-    uint8_t PreableCodeIndex{ PreableCodeIndexDefault };
-    std::unordered_set<ResultReportConfiguration> ResultReportConfigurations{ ResultReportConfigurationsDefault };
-    UwbMacAddressType MacAddressMode{ MacAddressModeDefault };
-    std::optional<UwbMacAddress> ControleeShortMacAddress;
-    UwbMacAddress ControllerMacAddress;
-    uint8_t SlotsPerRangingRound{ 0 };
-    uint8_t MaxContentionPhaseLength{ 0 };
-    uint8_t SlotDuration{ 0 };
-    uint16_t RangingInterval{ 0 };
-    uint8_t KeyRotationRate{ KeyRotationRateDefault };
-    UwbMacAddressFcsType MacAddressFcsType{ MacFcsTypeDefault };
-    uint16_t MaxRangingRoundRetry{ MaxRrRetryDefault };
+    uint32_t firaPhyVersion{ 0 };
+    uint32_t firaMacVersion{ 0 };
+    DeviceRole deviceRole{ DeviceRoleDefault };
+    RangingConfiguration rangingConfiguration{ RangingConfigurationDefault };
+    StsConfiguration stsConfiguration{ StsConfigurationDefault };
+    MultiNodeMode multiNodeMode{ MultiNodeModeDefault };
+    RangingMode rangingTimeStruct{ RangingTimeStructDefault };
+    SchedulingMode schedulingMode{ ScheduledModeDefault };
+    bool hoppingMode{ HoppingModeDefault };
+    bool blockStriding{ BlockStridingDefault };
+    uint32_t uwbInitiationTime{ UwbInitiationTimeDefault };
+    Channel channel{ Channel::C9 };
+    StsPacketConfiguration rframeConfig{ RFrameConfigDefault };
+    ConvolutionalCodeConstraintLength convolutionalCodeConstraintLength{ CcConstraintLengthDefault };
+    PrfMode prfMode{ PrfModeDefault };
+    uint8_t sp0PhySetNumber{ Sp0PhySetNumberDefault };
+    uint8_t sp1PhySetNumber{ Sp0PhySetNumberDefault };
+    uint8_t sp3PhySetNumber{ Sp0PhySetNumberDefault };
+    uint8_t preableCodeIndex{ PreableCodeIndexDefault };
+    std::unordered_set<ResultReportConfiguration> resultReportConfigurations{ ResultReportConfigurationsDefault };
+    UwbMacAddressType macAddressMode{ MacAddressModeDefault };
+    std::optional<UwbMacAddress> controleeShortMacAddress;
+    UwbMacAddress controllerMacAddress;
+    uint8_t slotsPerRangingRound{ 0 };
+    uint8_t maxContentionPhaseLength{ 0 };
+    uint8_t slotDuration{ 0 };
+    uint16_t rangingInterval{ 0 };
+    uint8_t keyRotationRate{ KeyRotationRateDefault };
+    UwbMacAddressFcsType macAddressFcsType{ MacFcsTypeDefault };
+    uint16_t maxRangingRoundRetry{ MaxRrRetryDefault };
 
     std::optional<uint32_t>
     GetFiraPhyVersion() const noexcept;
@@ -311,36 +311,36 @@ struct hash<uwb::protocol::fira::UwbConfiguration>
     {
         std::size_t value = 0;
         notstd::hash_combine(value,
-            uwbConfiguration.FiraPhyVersion,
-            uwbConfiguration.FiraMacVersion,
-            uwbConfiguration.DeviceRole,
-            uwbConfiguration.RangingConfiguration,
-            uwbConfiguration.StsConfiguration,
-            uwbConfiguration.MultiNodeMode,
-            uwbConfiguration.RangingTimeStruct,
-            uwbConfiguration.SchedulingMode,
-            uwbConfiguration.HoppingMode,
-            uwbConfiguration.BlockStriding,
-            uwbConfiguration.UwbInitiationTime,
-            uwbConfiguration.Channel,
-            uwbConfiguration.RFrameConfig,
-            uwbConfiguration.ConvolutionalCodeConstraintLength,
-            uwbConfiguration.PrfMode,
-            uwbConfiguration.Sp0PhySetNumber,
-            uwbConfiguration.Sp1PhySetNumber,
-            uwbConfiguration.Sp3PhySetNumber,
-            uwbConfiguration.PreableCodeIndex,
-            notstd::hash_range(std::cbegin(uwbConfiguration.ResultReportConfigurations), std::cend(uwbConfiguration.ResultReportConfigurations)),
-            uwbConfiguration.MacAddressMode,
-            uwbConfiguration.ControleeShortMacAddress,
-            uwbConfiguration.ControllerMacAddress,
-            uwbConfiguration.SlotsPerRangingRound,
-            uwbConfiguration.MaxContentionPhaseLength,
-            uwbConfiguration.SlotDuration,
-            uwbConfiguration.RangingInterval,
-            uwbConfiguration.KeyRotationRate,
-            uwbConfiguration.MacAddressFcsType,
-            uwbConfiguration.MaxRangingRoundRetry);
+            uwbConfiguration.firaPhyVersion,
+            uwbConfiguration.firaMacVersion,
+            uwbConfiguration.deviceRole,
+            uwbConfiguration.rangingConfiguration,
+            uwbConfiguration.stsConfiguration,
+            uwbConfiguration.multiNodeMode,
+            uwbConfiguration.rangingTimeStruct,
+            uwbConfiguration.schedulingMode,
+            uwbConfiguration.hoppingMode,
+            uwbConfiguration.blockStriding,
+            uwbConfiguration.uwbInitiationTime,
+            uwbConfiguration.channel,
+            uwbConfiguration.rframeConfig,
+            uwbConfiguration.convolutionalCodeConstraintLength,
+            uwbConfiguration.prfMode,
+            uwbConfiguration.sp0PhySetNumber,
+            uwbConfiguration.sp1PhySetNumber,
+            uwbConfiguration.sp3PhySetNumber,
+            uwbConfiguration.preableCodeIndex,
+            notstd::hash_range(std::cbegin(uwbConfiguration.resultReportConfigurations), std::cend(uwbConfiguration.resultReportConfigurations)),
+            uwbConfiguration.macAddressMode,
+            uwbConfiguration.controleeShortMacAddress,
+            uwbConfiguration.controllerMacAddress,
+            uwbConfiguration.slotsPerRangingRound,
+            uwbConfiguration.maxContentionPhaseLength,
+            uwbConfiguration.slotDuration,
+            uwbConfiguration.rangingInterval,
+            uwbConfiguration.keyRotationRate,
+            uwbConfiguration.macAddressFcsType,
+            uwbConfiguration.maxRangingRoundRetry);
         return value;
     }
 };

--- a/lib/uwb/include/uwb/protocols/fira/UwbSessionData.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/UwbSessionData.hxx
@@ -84,13 +84,13 @@ struct UwbSessionData
     static UwbSessionData
     FromDataObject(const encoding::TlvBer& tlv);
 
-    uint16_t SessionDataVersion{ 0 };
-    uint32_t SessionId{ 0 };
-    uint32_t SubSessionId{ 0 };
-    UwbConfiguration UwbConfiguration{};
-    std::optional<StaticRangingInfo> StaticRangingInfo;
-    std::optional<SecureRangingInfo> SecureRangingInfo;
-    bool UwbConfigurationAvailable{ false };
+    uint16_t sessionDataVersion{ 0 };
+    uint32_t sessionId{ 0 };
+    uint32_t subSessionId{ 0 };
+    UwbConfiguration uwbConfiguration{};
+    std::optional<StaticRangingInfo> staticRangingInfo;
+    std::optional<SecureRangingInfo> secureRangingInfo;
+    bool uwbConfigurationAvailable{ false };
 };
 
 } // namespace uwb::protocol::fira
@@ -105,13 +105,13 @@ struct hash<uwb::protocol::fira::UwbSessionData>
     {
         std::size_t value = 0;
         notstd::hash_combine(value,
-            uwbSessionData.SessionDataVersion,
-            uwbSessionData.SessionId,
-            uwbSessionData.SubSessionId,
-            uwbSessionData.UwbConfiguration,
-            uwbSessionData.StaticRangingInfo,
-            uwbSessionData.SecureRangingInfo,
-            uwbSessionData.UwbConfigurationAvailable);
+            uwbSessionData.sessionDataVersion,
+            uwbSessionData.sessionId,
+            uwbSessionData.subSessionId,
+            uwbSessionData.uwbConfiguration,
+            uwbSessionData.staticRangingInfo,
+            uwbSessionData.secureRangingInfo,
+            uwbSessionData.uwbConfigurationAvailable);
         return value;
     }
 };

--- a/tests/unit/uwb/protocols/fira/TestUwbFiraUwbConfiguration.cxx
+++ b/tests/unit/uwb/protocols/fira/TestUwbFiraUwbConfiguration.cxx
@@ -30,11 +30,11 @@ TEST_CASE("UwbConfiguration can be used in unordered_containers", "[basic][conta
     using namespace uwb::protocol::fira;
 
     UwbConfiguration uwbConfigurationDeviceRoleInitiator{};
-    uwbConfigurationDeviceRoleInitiator.DeviceRole = DeviceRole::Initiator;
+    uwbConfigurationDeviceRoleInitiator.deviceRole = DeviceRole::Initiator;
     UwbConfiguration uwbConfigurationDeviceRoleResponder{};
-    uwbConfigurationDeviceRoleResponder.DeviceRole = DeviceRole::Responder;
+    uwbConfigurationDeviceRoleResponder.deviceRole = DeviceRole::Responder;
     UwbConfiguration uwbConfigurationHoppingMode{};
-    uwbConfigurationHoppingMode.HoppingMode = true;
+    uwbConfigurationHoppingMode.hoppingMode = true;
 
     const std::initializer_list<UwbConfiguration> UwbConfigurations = {
         uwbConfigurationDeviceRoleInitiator,

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -164,9 +164,9 @@ NearObjectCli::AddSubcommandUwbRange(CLI::App *parent)
     auto rangeApp = parent->add_subcommand("range", "commands related to ranging")->require_subcommand()->fallthrough();
 
     // options
-    rangeApp->add_option("--SessionDataVersion", m_cliData->SessionData.SessionDataVersion)->capture_default_str();
-    rangeApp->add_option("--SessionId", m_cliData->SessionData.SessionId)->capture_default_str();
-    rangeApp->add_option("--SubSessionId", m_cliData->SessionData.SubSessionId)->capture_default_str();
+    rangeApp->add_option("--SessionDataVersion", m_cliData->SessionData.sessionDataVersion)->capture_default_str();
+    rangeApp->add_option("--SessionId", m_cliData->SessionData.sessionId)->capture_default_str();
+    rangeApp->add_option("--SubSessionId", m_cliData->SessionData.subSessionId)->capture_default_str();
 
     // sub-commands
     m_rangeStartApp = AddSubcommandUwbRangeStart(rangeApp);
@@ -182,36 +182,36 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App *parent)
 
     // TODO is there a way to put all the enums into a list of [optionName, optionDestination, optionMap] so we don't have to create the initializer list each time
     // TODO get rid of these strings, instead use a macro to extract the enum name
-    rangeStartApp->add_option("--DeviceRole", m_cliData->SessionData.UwbConfiguration.DeviceRole)->transform(CLI::CheckedTransformer(detail::DeviceRoleMap))->capture_default_str();
-    rangeStartApp->add_option("--RangingMethod", m_cliData->SessionData.UwbConfiguration.RangingConfiguration.Method)->transform(CLI::CheckedTransformer(detail::RangingMethodMap))->capture_default_str();
-    rangeStartApp->add_option("--MeasurementReportMode", m_cliData->SessionData.UwbConfiguration.RangingConfiguration.ReportMode)->transform(CLI::CheckedTransformer(detail::MeasurementReportModeMap))->capture_default_str();
-    rangeStartApp->add_option("--StsConfiguration", m_cliData->SessionData.UwbConfiguration.StsConfiguration)->transform(CLI::CheckedTransformer(detail::StsConfigurationMap))->capture_default_str();
-    rangeStartApp->add_option("--MultiNodeMode", m_cliData->SessionData.UwbConfiguration.MultiNodeMode)->transform(CLI::CheckedTransformer(detail::MultiNodeModeMap))->capture_default_str();
-    rangeStartApp->add_option("--RangingMode", m_cliData->SessionData.UwbConfiguration.RangingTimeStruct)->transform(CLI::CheckedTransformer(detail::RangingModeMap))->capture_default_str();
-    rangeStartApp->add_option("--SchedulingMode", m_cliData->SessionData.UwbConfiguration.SchedulingMode)->transform(CLI::CheckedTransformer(detail::SchedulingModeMap))->capture_default_str();
-    rangeStartApp->add_option("--Channel", m_cliData->SessionData.UwbConfiguration.Channel)->transform(CLI::CheckedTransformer(detail::ChannelMap))->capture_default_str();
-    rangeStartApp->add_option("--StsPacketConfiguration", m_cliData->SessionData.UwbConfiguration.RFrameConfig)->transform(CLI::CheckedTransformer(detail::StsPacketConfigurationMap))->capture_default_str();
-    rangeStartApp->add_option("--ConvolutionalCodeConstraintLength", m_cliData->SessionData.UwbConfiguration.ConvolutionalCodeConstraintLength)->transform(CLI::CheckedTransformer(detail::ConvolutionalCodeConstraintLengthMap))->capture_default_str();
-    rangeStartApp->add_option("--PrfMode", m_cliData->SessionData.UwbConfiguration.PrfMode)->transform(CLI::CheckedTransformer(detail::PrfModeMap))->capture_default_str();
-    rangeStartApp->add_option("--UwbMacAddressFcsType", m_cliData->SessionData.UwbConfiguration.MacAddressFcsType)->transform(CLI::CheckedTransformer(detail::UwbMacAddressFcsTypeMap))->capture_default_str();
+    rangeStartApp->add_option("--DeviceRole", m_cliData->SessionData.uwbConfiguration.deviceRole)->transform(CLI::CheckedTransformer(detail::DeviceRoleMap))->capture_default_str();
+    rangeStartApp->add_option("--RangingMethod", m_cliData->SessionData.uwbConfiguration.rangingConfiguration.Method)->transform(CLI::CheckedTransformer(detail::RangingMethodMap))->capture_default_str();
+    rangeStartApp->add_option("--MeasurementReportMode", m_cliData->SessionData.uwbConfiguration.rangingConfiguration.ReportMode)->transform(CLI::CheckedTransformer(detail::MeasurementReportModeMap))->capture_default_str();
+    rangeStartApp->add_option("--StsConfiguration", m_cliData->SessionData.uwbConfiguration.stsConfiguration)->transform(CLI::CheckedTransformer(detail::StsConfigurationMap))->capture_default_str();
+    rangeStartApp->add_option("--MultiNodeMode", m_cliData->SessionData.uwbConfiguration.multiNodeMode)->transform(CLI::CheckedTransformer(detail::MultiNodeModeMap))->capture_default_str();
+    rangeStartApp->add_option("--RangingMode", m_cliData->SessionData.uwbConfiguration.rangingTimeStruct)->transform(CLI::CheckedTransformer(detail::RangingModeMap))->capture_default_str();
+    rangeStartApp->add_option("--SchedulingMode", m_cliData->SessionData.uwbConfiguration.schedulingMode)->transform(CLI::CheckedTransformer(detail::SchedulingModeMap))->capture_default_str();
+    rangeStartApp->add_option("--Channel", m_cliData->SessionData.uwbConfiguration.channel)->transform(CLI::CheckedTransformer(detail::ChannelMap))->capture_default_str();
+    rangeStartApp->add_option("--StsPacketConfiguration", m_cliData->SessionData.uwbConfiguration.rframeConfig)->transform(CLI::CheckedTransformer(detail::StsPacketConfigurationMap))->capture_default_str();
+    rangeStartApp->add_option("--ConvolutionalCodeConstraintLength", m_cliData->SessionData.uwbConfiguration.convolutionalCodeConstraintLength)->transform(CLI::CheckedTransformer(detail::ConvolutionalCodeConstraintLengthMap))->capture_default_str();
+    rangeStartApp->add_option("--PrfMode", m_cliData->SessionData.uwbConfiguration.prfMode)->transform(CLI::CheckedTransformer(detail::PrfModeMap))->capture_default_str();
+    rangeStartApp->add_option("--UwbMacAddressFcsType", m_cliData->SessionData.uwbConfiguration.macAddressFcsType)->transform(CLI::CheckedTransformer(detail::UwbMacAddressFcsTypeMap))->capture_default_str();
 
     // booleans
     rangeStartApp->add_flag("--controller,!--controlee", m_cliData->HostIsController, "default is controlee")->capture_default_str();
-    rangeStartApp->add_flag("--HoppingMode", m_cliData->SessionData.UwbConfiguration.HoppingMode)->capture_default_str();
-    rangeStartApp->add_flag("--BlockStriding", m_cliData->SessionData.UwbConfiguration.BlockStriding)->capture_default_str();
+    rangeStartApp->add_flag("--HoppingMode", m_cliData->SessionData.uwbConfiguration.hoppingMode)->capture_default_str();
+    rangeStartApp->add_flag("--BlockStriding", m_cliData->SessionData.uwbConfiguration.blockStriding)->capture_default_str();
 
     // TODO check for int sizes when parsing input
-    rangeStartApp->add_option("--UwbInitiationTime", m_cliData->SessionData.UwbConfiguration.UwbInitiationTime, "uint32_t")->capture_default_str();
-    rangeStartApp->add_option("--Sp0PhySetNumber", m_cliData->SessionData.UwbConfiguration.Sp0PhySetNumber, "uint8_t")->capture_default_str();
-    rangeStartApp->add_option("--Sp1PhySetNumber", m_cliData->SessionData.UwbConfiguration.Sp1PhySetNumber, "uint8_t")->capture_default_str();
-    rangeStartApp->add_option("--Sp3PhySetNumber", m_cliData->SessionData.UwbConfiguration.Sp3PhySetNumber, "uint8_t")->capture_default_str();
-    rangeStartApp->add_option("--PreableCodeIndex", m_cliData->SessionData.UwbConfiguration.PreableCodeIndex, "uint8_t")->capture_default_str();
-    rangeStartApp->add_option("--SlotsPerRangingRound", m_cliData->SessionData.UwbConfiguration.SlotsPerRangingRound, "uint8_t")->capture_default_str();
-    rangeStartApp->add_option("--MaxContentionPhaseLength", m_cliData->SessionData.UwbConfiguration.MaxContentionPhaseLength, "uint8_t")->capture_default_str();
-    rangeStartApp->add_option("--SlotDuration", m_cliData->SessionData.UwbConfiguration.SlotDuration, "uint8_t")->capture_default_str();
-    rangeStartApp->add_option("--RangingInterval", m_cliData->SessionData.UwbConfiguration.RangingInterval, "uint16_t")->capture_default_str();
-    rangeStartApp->add_option("--KeyRotationRate", m_cliData->SessionData.UwbConfiguration.KeyRotationRate, "uint8_t")->capture_default_str();
-    rangeStartApp->add_option("--MaxRangingRoundRetry", m_cliData->SessionData.UwbConfiguration.MaxRangingRoundRetry, "uint16_t")->capture_default_str();
+    rangeStartApp->add_option("--UwbInitiationTime", m_cliData->SessionData.uwbConfiguration.uwbInitiationTime, "uint32_t")->capture_default_str();
+    rangeStartApp->add_option("--Sp0PhySetNumber", m_cliData->SessionData.uwbConfiguration.sp0PhySetNumber, "uint8_t")->capture_default_str();
+    rangeStartApp->add_option("--Sp1PhySetNumber", m_cliData->SessionData.uwbConfiguration.sp1PhySetNumber, "uint8_t")->capture_default_str();
+    rangeStartApp->add_option("--Sp3PhySetNumber", m_cliData->SessionData.uwbConfiguration.sp3PhySetNumber, "uint8_t")->capture_default_str();
+    rangeStartApp->add_option("--PreableCodeIndex", m_cliData->SessionData.uwbConfiguration.preableCodeIndex, "uint8_t")->capture_default_str();
+    rangeStartApp->add_option("--SlotsPerRangingRound", m_cliData->SessionData.uwbConfiguration.slotsPerRangingRound, "uint8_t")->capture_default_str();
+    rangeStartApp->add_option("--MaxContentionPhaseLength", m_cliData->SessionData.uwbConfiguration.maxContentionPhaseLength, "uint8_t")->capture_default_str();
+    rangeStartApp->add_option("--SlotDuration", m_cliData->SessionData.uwbConfiguration.slotDuration, "uint8_t")->capture_default_str();
+    rangeStartApp->add_option("--RangingInterval", m_cliData->SessionData.uwbConfiguration.rangingInterval, "uint16_t")->capture_default_str();
+    rangeStartApp->add_option("--KeyRotationRate", m_cliData->SessionData.uwbConfiguration.keyRotationRate, "uint8_t")->capture_default_str();
+    rangeStartApp->add_option("--MaxRangingRoundRetry", m_cliData->SessionData.uwbConfiguration.maxRangingRoundRetry, "uint16_t")->capture_default_str();
 
     // strings
     rangeStartApp->add_option("--FiraPhyVersion", m_cliData->PhyVersionString)->capture_default_str();
@@ -223,17 +223,17 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App *parent)
 
         for (const auto& [optionName, optionSelected] :
             std::initializer_list<std::tuple<std::string_view, std::string_view>>{
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.UwbConfiguration.DeviceRole),
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.UwbConfiguration.RangingConfiguration.Method),
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.UwbConfiguration.RangingConfiguration.ReportMode),
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.UwbConfiguration.StsConfiguration),
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.UwbConfiguration.MultiNodeMode),
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.UwbConfiguration.RangingTimeStruct),
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.UwbConfiguration.Channel),
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.UwbConfiguration.RFrameConfig),
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.UwbConfiguration.ConvolutionalCodeConstraintLength),
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.UwbConfiguration.PrfMode),
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.UwbConfiguration.MacAddressFcsType) }) {
+                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration.deviceRole),
+                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration.rangingConfiguration.Method),
+                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration.rangingConfiguration.ReportMode),
+                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration.stsConfiguration),
+                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration.multiNodeMode),
+                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration.rangingTimeStruct),
+                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration.channel),
+                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration.rframeConfig),
+                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration.convolutionalCodeConstraintLength),
+                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration.prfMode),
+                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration.macAddressFcsType) }) {
             std::cout << optionName << "::" << optionSelected << std::endl;
         }
         if (!m_cliData->MacVersionString.empty()) {
@@ -241,7 +241,7 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App *parent)
             if (not result) {
                 std::cout << "could not parse MacVersionString" << std::endl;
             } else {
-                m_cliData->SessionData.UwbConfiguration.FiraMacVersion = result.value();
+                m_cliData->SessionData.uwbConfiguration.firaMacVersion = result.value();
             }
         }
         if (!m_cliData->PhyVersionString.empty()) {
@@ -249,7 +249,7 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App *parent)
             if (not result) {
                 std::cout << "could not parse PhyVersionString" << std::endl;
             } else {
-                m_cliData->SessionData.UwbConfiguration.FiraPhyVersion = result.value();
+                m_cliData->SessionData.uwbConfiguration.firaPhyVersion = result.value();
             }
         }
 
@@ -258,13 +258,13 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App *parent)
             if (not result) {
                 std::cout << "could not parse ResultReportConfiguration" << std::endl;
             } else {
-                m_cliData->SessionData.UwbConfiguration.ResultReportConfigurations = result.value();
+                m_cliData->SessionData.uwbConfiguration.resultReportConfigurations = result.value();
             }
         }
 
-        std::cout << "FiRa MAC Version: " << std::setfill('0') << std::showbase << std::setw(8) << std::left << std::hex << m_cliData->SessionData.UwbConfiguration.FiraMacVersion << std::endl;
-        std::cout << "FiRa PHY Version: " << std::setfill('0') << std::showbase << std::setw(8) << std::left << std::hex << m_cliData->SessionData.UwbConfiguration.FiraPhyVersion << std::endl;
-        std::cout << "ResultReportConfigurations: " << uwb::protocol::fira::ResultReportConfigurationToString(m_cliData->SessionData.UwbConfiguration.ResultReportConfigurations) << std::endl;
+        std::cout << "FiRa MAC Version: " << std::setfill('0') << std::showbase << std::setw(8) << std::left << std::hex << m_cliData->SessionData.uwbConfiguration.firaMacVersion << std::endl;
+        std::cout << "FiRa PHY Version: " << std::setfill('0') << std::showbase << std::setw(8) << std::left << std::hex << m_cliData->SessionData.uwbConfiguration.firaPhyVersion << std::endl;
+        std::cout << "ResultReportConfigurations: " << uwb::protocol::fira::ResultReportConfigurationToString(m_cliData->SessionData.uwbConfiguration.resultReportConfigurations) << std::endl;
     });
 
     rangeStartApp->final_callback([this] {

--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -22,7 +22,7 @@ UwbSession::ConfigureImpl(const uwb::protocol::fira::UwbSessionData& uwbSessionD
     
     // Populate the session initialization command argument.
     UWB_SESSION_INIT sessionInit;
-    sessionInit.sessionId = uwbSessionData.SessionId;
+    sessionInit.sessionId = uwbSessionData.sessionId;
     sessionInit.sessionType = UWB_SESSION_TYPE_RANGING_SESSION;
 
     // Request a new session from the driver.
@@ -31,7 +31,7 @@ UwbSession::ConfigureImpl(const uwb::protocol::fira::UwbSessionData& uwbSessionD
         // TODO: handle this
     }
 
-    m_sessionId = uwbSessionData.SessionId;
+    m_sessionId = uwbSessionData.sessionId;
 }
 
 void


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Move codebase to zero warnings.

### Technical Details

* Fix all `-fpermissive` issues where a type name was used as a public member name.

### Test Results

All unit tests pass on both Linux and Windows.

### Reviewer Focus

None

### Future Work

The renaming above does not conform to the style guidelines; this should eventually be corrected. 

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
