### PR TITLE
Fix additional warnings emitted by clang

### DIFF
--- a/lib/nearobject/NearObjectIdentityTokenUwb.cxx
+++ b/lib/nearobject/NearObjectIdentityTokenUwb.cxx
@@ -40,7 +40,7 @@ NearObjectIdentityTokenUwb::UniqueFromToken(std::span<const uint8_t> token)
     // copy/move a serialized object into it. nlohmann must support some way of
     // dynamically allocating the object instead. Needs further investigation.
     auto instance = std::make_unique<NearObjectIdentityTokenUwb>();
-    *instance = std::move(NearObjectIdentityTokenUwb::FromToken(token));
+    *instance = NearObjectIdentityTokenUwb::FromToken(token);
     return instance;
 }
 

--- a/lib/shared/tlv/include/TlvBer.hxx
+++ b/lib/shared/tlv/include/TlvBer.hxx
@@ -278,7 +278,7 @@ public:
 
         // advance the dataIt to once past the tag
         std::advance(dataIt, 1);
-        bytesParsed = std::distance(std::cbegin(data), dataIt);
+        bytesParsed = static_cast<std::size_t>(std::distance(std::cbegin(data), dataIt));
 
         return Tlv::ParseResult::Succeeded;
     }
@@ -340,7 +340,7 @@ public:
 
         // Advance the dataIt to once passed the length encoding.
         std::advance(dataIt, 1);
-        bytesParsed = std::distance(std::cbegin(data), dataIt);
+        bytesParsed = static_cast<std::size_t>(std::distance(std::cbegin(data), dataIt));
 
         return Tlv::ParseResult::Succeeded;
     }
@@ -365,7 +365,7 @@ public:
             return Tlv::ParseResult::Failed;
         }
 
-        valueOutput = { std::cbegin(data), std::cbegin(data) + length };
+        valueOutput = { std::cbegin(data), std::cbegin(data) + static_cast<long>(length) };
         bytesParsed = length;
 
         return Tlv::ParseResult::Succeeded;

--- a/tests/unit/TestNearObjectIdentityTokenUwb.cxx
+++ b/tests/unit/TestNearObjectIdentityTokenUwb.cxx
@@ -152,7 +152,6 @@ ValidateTokenStabilityExternal(const NearObjectIdentityTokenUwb& identityTokenUw
 {
     const auto tokenValueOne = identityTokenUwbOne.GetToken();
     const auto identityTokenUwbTwo = NearObjectIdentityTokenUwb::FromToken(tokenValueOne);
-    const auto tokenValueTwo = identityTokenUwbTwo.GetToken();
     REQUIRE(identityTokenUwbOne == identityTokenUwbTwo);
 }
 } // namespace nearobject::test
@@ -205,7 +204,6 @@ TEST_CASE("near object uwb identity token binds uwb mac address", "[basic]")
         auto uwbMacAddressShort = MakeAddressShort();
         NearObjectIdentityTokenUwb identityTokenUwb{ uwbMacAddressShort };
         REQUIRE(identityTokenUwb.GetMacAddress() == uwbMacAddressShort);
-        auto token = identityTokenUwb.GetToken();
         REQUIRE(identityTokenUwb.GetMacAddress() == uwbMacAddressShort);
     }
 
@@ -221,7 +219,6 @@ TEST_CASE("near object uwb identity token binds uwb mac address", "[basic]")
         auto uwbMacAddressExtended = MakeAddressExtended();
         NearObjectIdentityTokenUwb identityTokenUwb{ uwbMacAddressExtended };
         REQUIRE(identityTokenUwb.GetMacAddress() == uwbMacAddressExtended);
-        auto token = identityTokenUwb.GetToken();
         REQUIRE(identityTokenUwb.GetMacAddress() == uwbMacAddressExtended);
     }
 }
@@ -236,7 +233,6 @@ TEST_CASE("near object uwb identity token retrieval does not mutate attributes",
         auto uwbMacAddressShort = MakeAddressShort();
         NearObjectIdentityTokenUwb identityTokenUwb{ uwbMacAddressShort };
         REQUIRE(identityTokenUwb.GetMacAddress() == uwbMacAddressShort);
-        auto token = identityTokenUwb.GetToken();
         REQUIRE(identityTokenUwb.GetMacAddress() == uwbMacAddressShort);
     }
 
@@ -245,7 +241,6 @@ TEST_CASE("near object uwb identity token retrieval does not mutate attributes",
         auto uwbMacAddressExtended = MakeAddressExtended();
         NearObjectIdentityTokenUwb identityTokenUwb{ uwbMacAddressExtended };
         REQUIRE(identityTokenUwb.GetMacAddress() == uwbMacAddressExtended);
-        auto token = identityTokenUwb.GetToken();
         REQUIRE(identityTokenUwb.GetMacAddress() == uwbMacAddressExtended);
     }
 }

--- a/tests/unit/TestNearObjectSessionIdGeneratorRandom.cxx
+++ b/tests/unit/TestNearObjectSessionIdGeneratorRandom.cxx
@@ -51,11 +51,10 @@ TEST_CASE("session identifiers can be generated", "[basic]")
 
     SECTION("sequence of session ids can be generated")
     {
-        uint32_t sessionId = 0;
         NearObjectSessionIdGeneratorRandom generator{};
 
         for (auto i = 0; i < test::NumSessionIdsToGenerate; i++) {
-            REQUIRE_NOTHROW(sessionId = generator.GetNext());
+            REQUIRE_NOTHROW(generator.GetNext());
         }
     }
 

--- a/tests/unit/uwb/TestUwbDevice.cxx
+++ b/tests/unit/uwb/TestUwbDevice.cxx
@@ -36,7 +36,7 @@ struct UwbDeviceTestBase : public uwb::UwbDevice
 struct UwbDeviceTestDerivedOne : UwbDeviceTestBase
 {
     explicit UwbDeviceTestDerivedOne(uint8_t id) :
-        UwbDeviceTestBase(static_cast<uint16_t>(id) << 8)
+        UwbDeviceTestBase(static_cast<uint16_t>(id << 8UL))
     {}
 
     bool

--- a/tools/cli/NearObjectCliUwbSessionEventCallbacks.cxx
+++ b/tools/cli/NearObjectCliUwbSessionEventCallbacks.cxx
@@ -8,7 +8,7 @@ using namespace nearobject::cli;
 using namespace strings::ostream_operators;
 
 void
-NearObjectCliUwbSessionEventCallbacks::OnSessionEnded(::uwb::UwbSession* session, ::uwb::UwbSessionEndReason reason)
+NearObjectCliUwbSessionEventCallbacks::OnSessionEnded(::uwb::UwbSession* session, ::uwb::UwbSessionEndReason /* reason */)
 {
     std::cout << "Session with id="
               << std::hex << std::setw(8) << std::setfill('0') << std::showbase << std::internal << session->GetId() << ": Session Ended" << std::endl;


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Move closer to zero compiler warnings.

### Technical Details

* Fix some unused variables.
* Fix some possible loss of precision instances.
* Fix change in signedness instances.
* Fix a `-Wpessimizing-move` instance.

### Test Results

All unit tests pass on both Linux and Windows.

### Reviewer Focus

None

### Future Work

* Some additional `-Wshadow` instances introduced from the previous PR need fixing.
* Some instances of `-Wdefaulted-function-deleted` for operator `<=>` need fixing.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
