### PR TITLE
Eliminate all warnings

### DIFF
--- a/lib/uwb/include/uwb/UwbSession.hxx
+++ b/lib/uwb/include/uwb/UwbSession.hxx
@@ -56,6 +56,11 @@ public:
     UwbSession(std::weak_ptr<UwbSessionEventCallbacks> callbacks);
 
     /**
+     * @brief Destroy the UwbSession object.
+     */
+    virtual ~UwbSession() = default;
+
+    /**
      * @brief Get the unique session id.
      * 
      * @return uint32_t 

--- a/lib/uwb/include/uwb/protocols/fira/StaticRangingInfo.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/StaticRangingInfo.hxx
@@ -35,6 +35,9 @@ struct StaticRangingInfo
         StaticStsIv = 0x81,
     };
 
+    auto
+    operator<=>(const StaticRangingInfo& other) const = default;
+
     uint16_t VendorId;
     std::array<uint8_t, InitializationVectorLength> InitializationVector;
 };

--- a/lib/uwb/include/uwb/protocols/fira/UwbConfiguration.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/UwbConfiguration.hxx
@@ -145,36 +145,36 @@ struct UwbConfiguration
     static UwbConfiguration
     FromDataObject(const encoding::TlvBer& tlv);
 
-    uint32_t firaPhyVersion{ 0 };
-    uint32_t firaMacVersion{ 0 };
-    DeviceRole deviceRole{ DeviceRoleDefault };
-    RangingConfiguration rangingConfiguration{ RangingConfigurationDefault };
-    StsConfiguration stsConfiguration{ StsConfigurationDefault };
-    MultiNodeMode multiNodeMode{ MultiNodeModeDefault };
-    RangingMode rangingTimeStruct{ RangingTimeStructDefault };
-    SchedulingMode schedulingMode{ ScheduledModeDefault };
-    bool hoppingMode{ HoppingModeDefault };
-    bool blockStriding{ BlockStridingDefault };
-    uint32_t uwbInitiationTime{ UwbInitiationTimeDefault };
-    Channel channel{ Channel::C9 };
-    StsPacketConfiguration rframeConfig{ RFrameConfigDefault };
-    ConvolutionalCodeConstraintLength convolutionalCodeConstraintLength{ CcConstraintLengthDefault };
-    PrfMode prfMode{ PrfModeDefault };
-    uint8_t sp0PhySetNumber{ Sp0PhySetNumberDefault };
-    uint8_t sp1PhySetNumber{ Sp0PhySetNumberDefault };
-    uint8_t sp3PhySetNumber{ Sp0PhySetNumberDefault };
-    uint8_t preableCodeIndex{ PreableCodeIndexDefault };
-    std::unordered_set<ResultReportConfiguration> resultReportConfigurations{ ResultReportConfigurationsDefault };
-    UwbMacAddressType macAddressMode{ MacAddressModeDefault };
-    std::optional<UwbMacAddress> controleeShortMacAddress;
-    UwbMacAddress controllerMacAddress;
-    uint8_t slotsPerRangingRound{ 0 };
-    uint8_t maxContentionPhaseLength{ 0 };
-    uint8_t slotDuration{ 0 };
-    uint16_t rangingInterval{ 0 };
-    uint8_t keyRotationRate{ KeyRotationRateDefault };
-    UwbMacAddressFcsType macAddressFcsType{ MacFcsTypeDefault };
-    uint16_t maxRangingRoundRetry{ MaxRrRetryDefault };
+    uint32_t _firaPhyVersion{ 0 };
+    uint32_t _firaMacVersion{ 0 };
+    DeviceRole _deviceRole{ DeviceRoleDefault };
+    RangingConfiguration _rangingConfiguration{ RangingConfigurationDefault };
+    StsConfiguration _stsConfiguration{ StsConfigurationDefault };
+    MultiNodeMode _multiNodeMode{ MultiNodeModeDefault };
+    RangingMode _rangingTimeStruct{ RangingTimeStructDefault };
+    SchedulingMode _schedulingMode{ ScheduledModeDefault };
+    bool _hoppingMode{ HoppingModeDefault };
+    bool _blockStriding{ BlockStridingDefault };
+    uint32_t _uwbInitiationTime{ UwbInitiationTimeDefault };
+    Channel _channel{ Channel::C9 };
+    StsPacketConfiguration _rframeConfig{ RFrameConfigDefault };
+    ConvolutionalCodeConstraintLength _convolutionalCodeConstraintLength{ CcConstraintLengthDefault };
+    PrfMode _prfMode{ PrfModeDefault };
+    uint8_t _sp0PhySetNumber{ Sp0PhySetNumberDefault };
+    uint8_t _sp1PhySetNumber{ Sp0PhySetNumberDefault };
+    uint8_t _sp3PhySetNumber{ Sp0PhySetNumberDefault };
+    uint8_t _preableCodeIndex{ PreableCodeIndexDefault };
+    std::unordered_set<ResultReportConfiguration> _resultReportConfigurations{ ResultReportConfigurationsDefault };
+    UwbMacAddressType _macAddressMode{ MacAddressModeDefault };
+    std::optional<UwbMacAddress> _controleeShortMacAddress;
+    UwbMacAddress _controllerMacAddress;
+    uint8_t _slotsPerRangingRound{ 0 };
+    uint8_t _maxContentionPhaseLength{ 0 };
+    uint8_t _slotDuration{ 0 };
+    uint16_t _rangingInterval{ 0 };
+    uint8_t _keyRotationRate{ KeyRotationRateDefault };
+    UwbMacAddressFcsType _macAddressFcsType{ MacFcsTypeDefault };
+    uint16_t _maxRangingRoundRetry{ MaxRrRetryDefault };
 
     std::optional<uint32_t>
     GetFiraPhyVersion() const noexcept;
@@ -311,36 +311,36 @@ struct hash<uwb::protocol::fira::UwbConfiguration>
     {
         std::size_t value = 0;
         notstd::hash_combine(value,
-            uwbConfiguration.firaPhyVersion,
-            uwbConfiguration.firaMacVersion,
-            uwbConfiguration.deviceRole,
-            uwbConfiguration.rangingConfiguration,
-            uwbConfiguration.stsConfiguration,
-            uwbConfiguration.multiNodeMode,
-            uwbConfiguration.rangingTimeStruct,
-            uwbConfiguration.schedulingMode,
-            uwbConfiguration.hoppingMode,
-            uwbConfiguration.blockStriding,
-            uwbConfiguration.uwbInitiationTime,
-            uwbConfiguration.channel,
-            uwbConfiguration.rframeConfig,
-            uwbConfiguration.convolutionalCodeConstraintLength,
-            uwbConfiguration.prfMode,
-            uwbConfiguration.sp0PhySetNumber,
-            uwbConfiguration.sp1PhySetNumber,
-            uwbConfiguration.sp3PhySetNumber,
-            uwbConfiguration.preableCodeIndex,
-            notstd::hash_range(std::cbegin(uwbConfiguration.resultReportConfigurations), std::cend(uwbConfiguration.resultReportConfigurations)),
-            uwbConfiguration.macAddressMode,
-            uwbConfiguration.controleeShortMacAddress,
-            uwbConfiguration.controllerMacAddress,
-            uwbConfiguration.slotsPerRangingRound,
-            uwbConfiguration.maxContentionPhaseLength,
-            uwbConfiguration.slotDuration,
-            uwbConfiguration.rangingInterval,
-            uwbConfiguration.keyRotationRate,
-            uwbConfiguration.macAddressFcsType,
-            uwbConfiguration.maxRangingRoundRetry);
+            uwbConfiguration._firaPhyVersion,
+            uwbConfiguration._firaMacVersion,
+            uwbConfiguration._deviceRole,
+            uwbConfiguration._rangingConfiguration,
+            uwbConfiguration._stsConfiguration,
+            uwbConfiguration._multiNodeMode,
+            uwbConfiguration._rangingTimeStruct,
+            uwbConfiguration._schedulingMode,
+            uwbConfiguration._hoppingMode,
+            uwbConfiguration._blockStriding,
+            uwbConfiguration._uwbInitiationTime,
+            uwbConfiguration._channel,
+            uwbConfiguration._rframeConfig,
+            uwbConfiguration._convolutionalCodeConstraintLength,
+            uwbConfiguration._prfMode,
+            uwbConfiguration._sp0PhySetNumber,
+            uwbConfiguration._sp1PhySetNumber,
+            uwbConfiguration._sp3PhySetNumber,
+            uwbConfiguration._preableCodeIndex,
+            notstd::hash_range(std::cbegin(uwbConfiguration._resultReportConfigurations), std::cend(uwbConfiguration._resultReportConfigurations)),
+            uwbConfiguration._macAddressMode,
+            uwbConfiguration._controleeShortMacAddress,
+            uwbConfiguration._controllerMacAddress,
+            uwbConfiguration._slotsPerRangingRound,
+            uwbConfiguration._maxContentionPhaseLength,
+            uwbConfiguration._slotDuration,
+            uwbConfiguration._rangingInterval,
+            uwbConfiguration._keyRotationRate,
+            uwbConfiguration._macAddressFcsType,
+            uwbConfiguration._maxRangingRoundRetry);
         return value;
     }
 };

--- a/lib/uwb/include/uwb/protocols/fira/UwbConfiguration.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/UwbConfiguration.hxx
@@ -128,9 +128,6 @@ struct UwbConfiguration
     bool
     operator==(const UwbConfiguration& other) const noexcept = default;
 
-    auto
-    operator<=>(const UwbConfiguration& other) const = default;
-
     /**
      * @brief Convert this object into a FiRa Data Object (DO).
      *

--- a/lib/uwb/include/uwb/protocols/fira/UwbConfiguration.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/UwbConfiguration.hxx
@@ -128,6 +128,9 @@ struct UwbConfiguration
     bool
     operator==(const UwbConfiguration& other) const noexcept = default;
 
+    auto
+    operator<=>(const UwbConfiguration& other) const = default;
+
     /**
      * @brief Convert this object into a FiRa Data Object (DO).
      *

--- a/lib/uwb/include/uwb/protocols/fira/UwbSessionData.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/UwbSessionData.hxx
@@ -52,22 +52,6 @@ struct UwbSessionData
     UwbSessionData() = default;
 
     /**
-     * @brief Default equality operator.
-     *
-     * @param other
-     * @return true
-     * @return false
-     */
-    bool
-    operator==(const UwbSessionData& other) const noexcept = default;
-
-    /**
-     * @brief Default three-way comparison operator. 
-     */
-    auto
-    operator<=>(const UwbSessionData& other) const noexcept = default;
-
-    /**
      * @brief Convert this object into a FiRa Data Object (DO).
      *
      * @return std::unique_ptr<encoding::TlvBer>

--- a/tests/unit/uwb/protocols/fira/TestUwbFiraUwbConfiguration.cxx
+++ b/tests/unit/uwb/protocols/fira/TestUwbFiraUwbConfiguration.cxx
@@ -30,11 +30,11 @@ TEST_CASE("UwbConfiguration can be used in unordered_containers", "[basic][conta
     using namespace uwb::protocol::fira;
 
     UwbConfiguration uwbConfigurationDeviceRoleInitiator{};
-    uwbConfigurationDeviceRoleInitiator.deviceRole = DeviceRole::Initiator;
+    uwbConfigurationDeviceRoleInitiator._deviceRole = DeviceRole::Initiator;
     UwbConfiguration uwbConfigurationDeviceRoleResponder{};
-    uwbConfigurationDeviceRoleResponder.deviceRole = DeviceRole::Responder;
+    uwbConfigurationDeviceRoleResponder._deviceRole = DeviceRole::Responder;
     UwbConfiguration uwbConfigurationHoppingMode{};
-    uwbConfigurationHoppingMode.hoppingMode = true;
+    uwbConfigurationHoppingMode._hoppingMode = true;
 
     const std::initializer_list<UwbConfiguration> UwbConfigurations = {
         uwbConfigurationDeviceRoleInitiator,

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -182,36 +182,36 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App *parent)
 
     // TODO is there a way to put all the enums into a list of [optionName, optionDestination, optionMap] so we don't have to create the initializer list each time
     // TODO get rid of these strings, instead use a macro to extract the enum name
-    rangeStartApp->add_option("--DeviceRole", m_cliData->SessionData.uwbConfiguration.deviceRole)->transform(CLI::CheckedTransformer(detail::DeviceRoleMap))->capture_default_str();
-    rangeStartApp->add_option("--RangingMethod", m_cliData->SessionData.uwbConfiguration.rangingConfiguration.Method)->transform(CLI::CheckedTransformer(detail::RangingMethodMap))->capture_default_str();
-    rangeStartApp->add_option("--MeasurementReportMode", m_cliData->SessionData.uwbConfiguration.rangingConfiguration.ReportMode)->transform(CLI::CheckedTransformer(detail::MeasurementReportModeMap))->capture_default_str();
-    rangeStartApp->add_option("--StsConfiguration", m_cliData->SessionData.uwbConfiguration.stsConfiguration)->transform(CLI::CheckedTransformer(detail::StsConfigurationMap))->capture_default_str();
-    rangeStartApp->add_option("--MultiNodeMode", m_cliData->SessionData.uwbConfiguration.multiNodeMode)->transform(CLI::CheckedTransformer(detail::MultiNodeModeMap))->capture_default_str();
-    rangeStartApp->add_option("--RangingMode", m_cliData->SessionData.uwbConfiguration.rangingTimeStruct)->transform(CLI::CheckedTransformer(detail::RangingModeMap))->capture_default_str();
-    rangeStartApp->add_option("--SchedulingMode", m_cliData->SessionData.uwbConfiguration.schedulingMode)->transform(CLI::CheckedTransformer(detail::SchedulingModeMap))->capture_default_str();
-    rangeStartApp->add_option("--Channel", m_cliData->SessionData.uwbConfiguration.channel)->transform(CLI::CheckedTransformer(detail::ChannelMap))->capture_default_str();
-    rangeStartApp->add_option("--StsPacketConfiguration", m_cliData->SessionData.uwbConfiguration.rframeConfig)->transform(CLI::CheckedTransformer(detail::StsPacketConfigurationMap))->capture_default_str();
-    rangeStartApp->add_option("--ConvolutionalCodeConstraintLength", m_cliData->SessionData.uwbConfiguration.convolutionalCodeConstraintLength)->transform(CLI::CheckedTransformer(detail::ConvolutionalCodeConstraintLengthMap))->capture_default_str();
-    rangeStartApp->add_option("--PrfMode", m_cliData->SessionData.uwbConfiguration.prfMode)->transform(CLI::CheckedTransformer(detail::PrfModeMap))->capture_default_str();
-    rangeStartApp->add_option("--UwbMacAddressFcsType", m_cliData->SessionData.uwbConfiguration.macAddressFcsType)->transform(CLI::CheckedTransformer(detail::UwbMacAddressFcsTypeMap))->capture_default_str();
+    rangeStartApp->add_option("--DeviceRole", m_cliData->SessionData.uwbConfiguration._deviceRole)->transform(CLI::CheckedTransformer(detail::DeviceRoleMap))->capture_default_str();
+    rangeStartApp->add_option("--RangingMethod", m_cliData->SessionData.uwbConfiguration._rangingConfiguration.Method)->transform(CLI::CheckedTransformer(detail::RangingMethodMap))->capture_default_str();
+    rangeStartApp->add_option("--MeasurementReportMode", m_cliData->SessionData.uwbConfiguration._rangingConfiguration.ReportMode)->transform(CLI::CheckedTransformer(detail::MeasurementReportModeMap))->capture_default_str();
+    rangeStartApp->add_option("--StsConfiguration", m_cliData->SessionData.uwbConfiguration._stsConfiguration)->transform(CLI::CheckedTransformer(detail::StsConfigurationMap))->capture_default_str();
+    rangeStartApp->add_option("--MultiNodeMode", m_cliData->SessionData.uwbConfiguration._multiNodeMode)->transform(CLI::CheckedTransformer(detail::MultiNodeModeMap))->capture_default_str();
+    rangeStartApp->add_option("--RangingMode", m_cliData->SessionData.uwbConfiguration._rangingTimeStruct)->transform(CLI::CheckedTransformer(detail::RangingModeMap))->capture_default_str();
+    rangeStartApp->add_option("--SchedulingMode", m_cliData->SessionData.uwbConfiguration._schedulingMode)->transform(CLI::CheckedTransformer(detail::SchedulingModeMap))->capture_default_str();
+    rangeStartApp->add_option("--Channel", m_cliData->SessionData.uwbConfiguration._channel)->transform(CLI::CheckedTransformer(detail::ChannelMap))->capture_default_str();
+    rangeStartApp->add_option("--StsPacketConfiguration", m_cliData->SessionData.uwbConfiguration._rframeConfig)->transform(CLI::CheckedTransformer(detail::StsPacketConfigurationMap))->capture_default_str();
+    rangeStartApp->add_option("--ConvolutionalCodeConstraintLength", m_cliData->SessionData.uwbConfiguration._convolutionalCodeConstraintLength)->transform(CLI::CheckedTransformer(detail::ConvolutionalCodeConstraintLengthMap))->capture_default_str();
+    rangeStartApp->add_option("--PrfMode", m_cliData->SessionData.uwbConfiguration._prfMode)->transform(CLI::CheckedTransformer(detail::PrfModeMap))->capture_default_str();
+    rangeStartApp->add_option("--UwbMacAddressFcsType", m_cliData->SessionData.uwbConfiguration._macAddressFcsType)->transform(CLI::CheckedTransformer(detail::UwbMacAddressFcsTypeMap))->capture_default_str();
 
     // booleans
     rangeStartApp->add_flag("--controller,!--controlee", m_cliData->HostIsController, "default is controlee")->capture_default_str();
-    rangeStartApp->add_flag("--HoppingMode", m_cliData->SessionData.uwbConfiguration.hoppingMode)->capture_default_str();
-    rangeStartApp->add_flag("--BlockStriding", m_cliData->SessionData.uwbConfiguration.blockStriding)->capture_default_str();
+    rangeStartApp->add_flag("--HoppingMode", m_cliData->SessionData.uwbConfiguration._hoppingMode)->capture_default_str();
+    rangeStartApp->add_flag("--BlockStriding", m_cliData->SessionData.uwbConfiguration._blockStriding)->capture_default_str();
 
     // TODO check for int sizes when parsing input
-    rangeStartApp->add_option("--UwbInitiationTime", m_cliData->SessionData.uwbConfiguration.uwbInitiationTime, "uint32_t")->capture_default_str();
-    rangeStartApp->add_option("--Sp0PhySetNumber", m_cliData->SessionData.uwbConfiguration.sp0PhySetNumber, "uint8_t")->capture_default_str();
-    rangeStartApp->add_option("--Sp1PhySetNumber", m_cliData->SessionData.uwbConfiguration.sp1PhySetNumber, "uint8_t")->capture_default_str();
-    rangeStartApp->add_option("--Sp3PhySetNumber", m_cliData->SessionData.uwbConfiguration.sp3PhySetNumber, "uint8_t")->capture_default_str();
-    rangeStartApp->add_option("--PreableCodeIndex", m_cliData->SessionData.uwbConfiguration.preableCodeIndex, "uint8_t")->capture_default_str();
-    rangeStartApp->add_option("--SlotsPerRangingRound", m_cliData->SessionData.uwbConfiguration.slotsPerRangingRound, "uint8_t")->capture_default_str();
-    rangeStartApp->add_option("--MaxContentionPhaseLength", m_cliData->SessionData.uwbConfiguration.maxContentionPhaseLength, "uint8_t")->capture_default_str();
-    rangeStartApp->add_option("--SlotDuration", m_cliData->SessionData.uwbConfiguration.slotDuration, "uint8_t")->capture_default_str();
-    rangeStartApp->add_option("--RangingInterval", m_cliData->SessionData.uwbConfiguration.rangingInterval, "uint16_t")->capture_default_str();
-    rangeStartApp->add_option("--KeyRotationRate", m_cliData->SessionData.uwbConfiguration.keyRotationRate, "uint8_t")->capture_default_str();
-    rangeStartApp->add_option("--MaxRangingRoundRetry", m_cliData->SessionData.uwbConfiguration.maxRangingRoundRetry, "uint16_t")->capture_default_str();
+    rangeStartApp->add_option("--UwbInitiationTime", m_cliData->SessionData.uwbConfiguration._uwbInitiationTime, "uint32_t")->capture_default_str();
+    rangeStartApp->add_option("--Sp0PhySetNumber", m_cliData->SessionData.uwbConfiguration._sp0PhySetNumber, "uint8_t")->capture_default_str();
+    rangeStartApp->add_option("--Sp1PhySetNumber", m_cliData->SessionData.uwbConfiguration._sp1PhySetNumber, "uint8_t")->capture_default_str();
+    rangeStartApp->add_option("--Sp3PhySetNumber", m_cliData->SessionData.uwbConfiguration._sp3PhySetNumber, "uint8_t")->capture_default_str();
+    rangeStartApp->add_option("--PreableCodeIndex", m_cliData->SessionData.uwbConfiguration._preableCodeIndex, "uint8_t")->capture_default_str();
+    rangeStartApp->add_option("--SlotsPerRangingRound", m_cliData->SessionData.uwbConfiguration._slotsPerRangingRound, "uint8_t")->capture_default_str();
+    rangeStartApp->add_option("--MaxContentionPhaseLength", m_cliData->SessionData.uwbConfiguration._maxContentionPhaseLength, "uint8_t")->capture_default_str();
+    rangeStartApp->add_option("--SlotDuration", m_cliData->SessionData.uwbConfiguration._slotDuration, "uint8_t")->capture_default_str();
+    rangeStartApp->add_option("--RangingInterval", m_cliData->SessionData.uwbConfiguration._rangingInterval, "uint16_t")->capture_default_str();
+    rangeStartApp->add_option("--KeyRotationRate", m_cliData->SessionData.uwbConfiguration._keyRotationRate, "uint8_t")->capture_default_str();
+    rangeStartApp->add_option("--MaxRangingRoundRetry", m_cliData->SessionData.uwbConfiguration._maxRangingRoundRetry, "uint16_t")->capture_default_str();
 
     // strings
     rangeStartApp->add_option("--FiraPhyVersion", m_cliData->PhyVersionString)->capture_default_str();
@@ -223,17 +223,17 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App *parent)
 
         for (const auto& [optionName, optionSelected] :
             std::initializer_list<std::tuple<std::string_view, std::string_view>>{
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration.deviceRole),
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration.rangingConfiguration.Method),
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration.rangingConfiguration.ReportMode),
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration.stsConfiguration),
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration.multiNodeMode),
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration.rangingTimeStruct),
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration.channel),
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration.rframeConfig),
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration.convolutionalCodeConstraintLength),
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration.prfMode),
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration.macAddressFcsType) }) {
+                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._deviceRole),
+                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._rangingConfiguration.Method),
+                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._rangingConfiguration.ReportMode),
+                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._stsConfiguration),
+                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._multiNodeMode),
+                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._rangingTimeStruct),
+                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._channel),
+                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._rframeConfig),
+                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._convolutionalCodeConstraintLength),
+                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._prfMode),
+                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._macAddressFcsType) }) {
             std::cout << optionName << "::" << optionSelected << std::endl;
         }
         if (!m_cliData->MacVersionString.empty()) {
@@ -241,7 +241,7 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App *parent)
             if (not result) {
                 std::cout << "could not parse MacVersionString" << std::endl;
             } else {
-                m_cliData->SessionData.uwbConfiguration.firaMacVersion = result.value();
+                m_cliData->SessionData.uwbConfiguration._firaMacVersion = result.value();
             }
         }
         if (!m_cliData->PhyVersionString.empty()) {
@@ -249,7 +249,7 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App *parent)
             if (not result) {
                 std::cout << "could not parse PhyVersionString" << std::endl;
             } else {
-                m_cliData->SessionData.uwbConfiguration.firaPhyVersion = result.value();
+                m_cliData->SessionData.uwbConfiguration._firaPhyVersion = result.value();
             }
         }
 
@@ -258,13 +258,13 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App *parent)
             if (not result) {
                 std::cout << "could not parse ResultReportConfiguration" << std::endl;
             } else {
-                m_cliData->SessionData.uwbConfiguration.resultReportConfigurations = result.value();
+                m_cliData->SessionData.uwbConfiguration._resultReportConfigurations = result.value();
             }
         }
 
-        std::cout << "FiRa MAC Version: " << std::setfill('0') << std::showbase << std::setw(8) << std::left << std::hex << m_cliData->SessionData.uwbConfiguration.firaMacVersion << std::endl;
-        std::cout << "FiRa PHY Version: " << std::setfill('0') << std::showbase << std::setw(8) << std::left << std::hex << m_cliData->SessionData.uwbConfiguration.firaPhyVersion << std::endl;
-        std::cout << "ResultReportConfigurations: " << uwb::protocol::fira::ResultReportConfigurationToString(m_cliData->SessionData.uwbConfiguration.resultReportConfigurations) << std::endl;
+        std::cout << "FiRa MAC Version: " << std::setfill('0') << std::showbase << std::setw(8) << std::left << std::hex << m_cliData->SessionData.uwbConfiguration._firaMacVersion << std::endl;
+        std::cout << "FiRa PHY Version: " << std::setfill('0') << std::showbase << std::setw(8) << std::left << std::hex << m_cliData->SessionData.uwbConfiguration._firaPhyVersion << std::endl;
+        std::cout << "ResultReportConfigurations: " << uwb::protocol::fira::ResultReportConfigurationToString(m_cliData->SessionData.uwbConfiguration._resultReportConfigurations) << std::endl;
     });
 
     rangeStartApp->final_callback([this] {


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Move codebase to zero warnings.

### Technical Details

* Fix all remaining instances of `-Wshadow` and `-Wdefaulted-function-deleted`.
* Remove default impls of operators `==` and `<=>` that were being implicitly deleted.

### Test Results

All unit tests pass on both Linux and Windows.

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
