### PR TITLE
Add support for StaticRangingInfo via cli

### DIFF
--- a/lib/uwb/include/uwb/protocols/fira/StaticRangingInfo.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/StaticRangingInfo.hxx
@@ -14,7 +14,7 @@ namespace uwb::protocol::fira
 struct StaticRangingInfo
 {
     /**
-     * @brief See FiRa Consortium MAC Technical Requirements v1.3.0, 
+     * @brief See FiRa Consortium MAC Technical Requirements v1.3.0,
      * Section D.1.8 STS, Figure 19, page 70.
      */
     static constexpr auto InitializationVectorLength = 6;

--- a/lib/uwb/include/uwb/protocols/fira/StaticRangingInfo.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/StaticRangingInfo.hxx
@@ -38,6 +38,9 @@ struct StaticRangingInfo
     auto
     operator<=>(const StaticRangingInfo& other) const = default;
 
+    std::string
+    ToString() const;
+
     uint16_t VendorId;
     std::array<uint8_t, InitializationVectorLength> InitializationVector;
 };

--- a/lib/uwb/include/uwb/protocols/fira/UwbSessionData.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/UwbSessionData.hxx
@@ -9,8 +9,8 @@
 #include <TlvBer.hxx>
 #include <notstd/hash.hxx>
 
-#include <uwb/protocols/fira/StaticRangingInfo.hxx>
 #include <uwb/protocols/fira/SecureRangingInfo.hxx>
+#include <uwb/protocols/fira/StaticRangingInfo.hxx>
 #include <uwb/protocols/fira/UwbConfiguration.hxx>
 
 namespace uwb::protocol::fira

--- a/lib/uwb/protocols/fira/CMakeLists.txt
+++ b/lib/uwb/protocols/fira/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(uwb-proto-fira
         ${CMAKE_CURRENT_LIST_DIR}/ControleePreference.cxx
         ${CMAKE_CURRENT_LIST_DIR}/FiraDevice.cxx
         ${CMAKE_CURRENT_LIST_DIR}/RangingConfiguration.cxx
+        ${CMAKE_CURRENT_LIST_DIR}/StaticRangingInfo.cxx
         ${CMAKE_CURRENT_LIST_DIR}/UwbCapability.cxx
         ${CMAKE_CURRENT_LIST_DIR}/UwbConfiguration.cxx
         ${CMAKE_CURRENT_LIST_DIR}/UwbConfigurationBuilder.cxx

--- a/lib/uwb/protocols/fira/StaticRangingInfo.cxx
+++ b/lib/uwb/protocols/fira/StaticRangingInfo.cxx
@@ -1,0 +1,18 @@
+
+#include <uwb/protocols/fira/StaticRangingInfo.hxx>
+#include <sstream>
+#include <iomanip>
+
+std::string
+uwb::protocol::fira::StaticRangingInfo::ToString() const {
+    std::ostringstream ss;
+    ss << "{" << std::endl;
+    ss << "VendorId: " << VendorId << std::endl;
+    ss << "InitializationVector: " << std::hex << std::setw(2) << std::setfill('0') << std::showbase << std::internal;
+    for(const auto i: InitializationVector) {
+        ss << i << " ";
+    }
+    ss << std::endl;
+    ss << "}" << std::endl;
+    return ss.str();
+}

--- a/lib/uwb/protocols/fira/StaticRangingInfo.cxx
+++ b/lib/uwb/protocols/fira/StaticRangingInfo.cxx
@@ -7,13 +7,11 @@ std::string
 uwb::protocol::fira::StaticRangingInfo::ToString() const
 {
     std::ostringstream ss;
-    ss << "{" << std::endl;
     ss << "VendorId: " << VendorId << std::endl;
     ss << "InitializationVector: " << std::hex << std::setw(2) << std::setfill('0') << std::showbase << std::internal;
     for (const auto i : InitializationVector) {
         ss << +i << " ";
     }
     ss << std::endl;
-    ss << "}" << std::endl;
     return ss.str();
 }

--- a/lib/uwb/protocols/fira/StaticRangingInfo.cxx
+++ b/lib/uwb/protocols/fira/StaticRangingInfo.cxx
@@ -1,10 +1,11 @@
 
-#include <uwb/protocols/fira/StaticRangingInfo.hxx>
-#include <sstream>
 #include <iomanip>
+#include <sstream>
+#include <uwb/protocols/fira/StaticRangingInfo.hxx>
 
 std::string
-uwb::protocol::fira::StaticRangingInfo::ToString() const {
+uwb::protocol::fira::StaticRangingInfo::ToString() const
+{
     std::ostringstream ss;
     ss << "{" << std::endl;
     ss << "VendorId: " << VendorId << std::endl;

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -6,8 +6,8 @@
 #include <vector>
 
 #include <magic_enum.hpp>
-#include <notstd/tostring.hxx>
 #include <nearobject/cli/NearObjectCli.hxx>
+#include <notstd/tostring.hxx>
 
 using namespace nearobject::cli;
 using namespace strings::ostream_operators;
@@ -148,7 +148,7 @@ const std::unordered_map<std::string, uwb::protocol::fira::ResultReportConfigura
 } // namespace detail
 
 CLI::App*
-NearObjectCli::AddSubcommandUwb(CLI::App *parent)
+NearObjectCli::AddSubcommandUwb(CLI::App* parent)
 {
     // top-level command
     auto uwbApp = parent->add_subcommand("uwb", "commands related to uwb")->require_subcommand()->fallthrough();
@@ -160,7 +160,7 @@ NearObjectCli::AddSubcommandUwb(CLI::App *parent)
 }
 
 CLI::App*
-NearObjectCli::AddSubcommandUwbRange(CLI::App *parent)
+NearObjectCli::AddSubcommandUwbRange(CLI::App* parent)
 {
     // top-level command
     auto rangeApp = parent->add_subcommand("range", "commands related to ranging")->require_subcommand()->fallthrough();
@@ -178,7 +178,7 @@ NearObjectCli::AddSubcommandUwbRange(CLI::App *parent)
 }
 
 CLI::App*
-NearObjectCli::AddSubcommandUwbRangeStart(CLI::App *parent)
+NearObjectCli::AddSubcommandUwbRangeStart(CLI::App* parent)
 {
     auto rangeStartApp = parent->add_subcommand("start", "start ranging. Please refer to Table 53 of the FiRa CSML spec for more info on the options")->fallthrough();
 
@@ -269,7 +269,7 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App *parent)
         }
 
         m_cliData->SessionData.staticRangingInfo = m_cliData->StaticRanging;
-        std::cout << "DEBUG StaticRangingInfo: " << m_cliData->StaticRanging << std::endl;
+        std::cout << "StaticRangingInfo: " << m_cliData->SessionData.staticRangingInfo << std::endl;
 
         std::cout << "FiRa MAC Version: " << std::setfill('0') << std::showbase << std::setw(8) << std::left << std::hex << m_cliData->SessionData.uwbConfiguration._firaMacVersion << std::endl;
         std::cout << "FiRa PHY Version: " << std::setfill('0') << std::showbase << std::setw(8) << std::left << std::hex << m_cliData->SessionData.uwbConfiguration._firaPhyVersion << std::endl;
@@ -289,7 +289,7 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App *parent)
 }
 
 CLI::App*
-NearObjectCli::AddSubcommandUwbRangeStop(CLI::App *parent)
+NearObjectCli::AddSubcommandUwbRangeStop(CLI::App* parent)
 {
     // top-level command
     auto rangeStopApp = parent->add_subcommand("stop", "stop ranging")->fallthrough();

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -269,7 +269,7 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App* parent)
         }
 
         m_cliData->SessionData.staticRangingInfo = m_cliData->StaticRanging;
-        std::cout << "StaticRangingInfo: " << m_cliData->SessionData.staticRangingInfo << std::endl;
+        std::cout << "StaticRangingInfo: {" << m_cliData->SessionData.staticRangingInfo << "}" << std::endl;
 
         std::cout << "FiRa MAC Version: " << std::setfill('0') << std::showbase << std::setw(8) << std::left << std::hex << m_cliData->SessionData.uwbConfiguration._firaMacVersion << std::endl;
         std::cout << "FiRa PHY Version: " << std::setfill('0') << std::showbase << std::setw(8) << std::left << std::hex << m_cliData->SessionData.uwbConfiguration._firaPhyVersion << std::endl;

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -6,9 +6,11 @@
 #include <vector>
 
 #include <magic_enum.hpp>
+#include <notstd/tostring.hxx>
 #include <nearobject/cli/NearObjectCli.hxx>
 
 using namespace nearobject::cli;
+using namespace strings::ostream_operators;
 
 NearObjectCli::NearObjectCli(std::shared_ptr<NearObjectCliData> cliData, std::shared_ptr<NearObjectCliHandler> cliHandler) :
     m_cliData(cliData),
@@ -182,18 +184,18 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App *parent)
 
     // TODO is there a way to put all the enums into a list of [optionName, optionDestination, optionMap] so we don't have to create the initializer list each time
     // TODO get rid of these strings, instead use a macro to extract the enum name
-    rangeStartApp->add_option("--DeviceRole", m_cliData->SessionData.uwbConfiguration._deviceRole)->transform(CLI::CheckedTransformer(detail::DeviceRoleMap))->capture_default_str();
-    rangeStartApp->add_option("--RangingMethod", m_cliData->SessionData.uwbConfiguration._rangingConfiguration.Method)->transform(CLI::CheckedTransformer(detail::RangingMethodMap))->capture_default_str();
-    rangeStartApp->add_option("--MeasurementReportMode", m_cliData->SessionData.uwbConfiguration._rangingConfiguration.ReportMode)->transform(CLI::CheckedTransformer(detail::MeasurementReportModeMap))->capture_default_str();
-    rangeStartApp->add_option("--StsConfiguration", m_cliData->SessionData.uwbConfiguration._stsConfiguration)->transform(CLI::CheckedTransformer(detail::StsConfigurationMap))->capture_default_str();
-    rangeStartApp->add_option("--MultiNodeMode", m_cliData->SessionData.uwbConfiguration._multiNodeMode)->transform(CLI::CheckedTransformer(detail::MultiNodeModeMap))->capture_default_str();
-    rangeStartApp->add_option("--RangingMode", m_cliData->SessionData.uwbConfiguration._rangingTimeStruct)->transform(CLI::CheckedTransformer(detail::RangingModeMap))->capture_default_str();
-    rangeStartApp->add_option("--SchedulingMode", m_cliData->SessionData.uwbConfiguration._schedulingMode)->transform(CLI::CheckedTransformer(detail::SchedulingModeMap))->capture_default_str();
-    rangeStartApp->add_option("--Channel", m_cliData->SessionData.uwbConfiguration._channel)->transform(CLI::CheckedTransformer(detail::ChannelMap))->capture_default_str();
-    rangeStartApp->add_option("--StsPacketConfiguration", m_cliData->SessionData.uwbConfiguration._rframeConfig)->transform(CLI::CheckedTransformer(detail::StsPacketConfigurationMap))->capture_default_str();
-    rangeStartApp->add_option("--ConvolutionalCodeConstraintLength", m_cliData->SessionData.uwbConfiguration._convolutionalCodeConstraintLength)->transform(CLI::CheckedTransformer(detail::ConvolutionalCodeConstraintLengthMap))->capture_default_str();
-    rangeStartApp->add_option("--PrfMode", m_cliData->SessionData.uwbConfiguration._prfMode)->transform(CLI::CheckedTransformer(detail::PrfModeMap))->capture_default_str();
-    rangeStartApp->add_option("--UwbMacAddressFcsType", m_cliData->SessionData.uwbConfiguration._macAddressFcsType)->transform(CLI::CheckedTransformer(detail::UwbMacAddressFcsTypeMap))->capture_default_str();
+    rangeStartApp->add_option("--DeviceRole", m_cliData->SessionData.uwbConfiguration._deviceRole)->transform(CLI::CheckedTransformer(::detail::DeviceRoleMap))->capture_default_str();
+    rangeStartApp->add_option("--RangingMethod", m_cliData->SessionData.uwbConfiguration._rangingConfiguration.Method)->transform(CLI::CheckedTransformer(::detail::RangingMethodMap))->capture_default_str();
+    rangeStartApp->add_option("--MeasurementReportMode", m_cliData->SessionData.uwbConfiguration._rangingConfiguration.ReportMode)->transform(CLI::CheckedTransformer(::detail::MeasurementReportModeMap))->capture_default_str();
+    rangeStartApp->add_option("--StsConfiguration", m_cliData->SessionData.uwbConfiguration._stsConfiguration)->transform(CLI::CheckedTransformer(::detail::StsConfigurationMap))->capture_default_str();
+    rangeStartApp->add_option("--MultiNodeMode", m_cliData->SessionData.uwbConfiguration._multiNodeMode)->transform(CLI::CheckedTransformer(::detail::MultiNodeModeMap))->capture_default_str();
+    rangeStartApp->add_option("--RangingMode", m_cliData->SessionData.uwbConfiguration._rangingTimeStruct)->transform(CLI::CheckedTransformer(::detail::RangingModeMap))->capture_default_str();
+    rangeStartApp->add_option("--SchedulingMode", m_cliData->SessionData.uwbConfiguration._schedulingMode)->transform(CLI::CheckedTransformer(::detail::SchedulingModeMap))->capture_default_str();
+    rangeStartApp->add_option("--Channel", m_cliData->SessionData.uwbConfiguration._channel)->transform(CLI::CheckedTransformer(::detail::ChannelMap))->capture_default_str();
+    rangeStartApp->add_option("--StsPacketConfiguration", m_cliData->SessionData.uwbConfiguration._rframeConfig)->transform(CLI::CheckedTransformer(::detail::StsPacketConfigurationMap))->capture_default_str();
+    rangeStartApp->add_option("--ConvolutionalCodeConstraintLength", m_cliData->SessionData.uwbConfiguration._convolutionalCodeConstraintLength)->transform(CLI::CheckedTransformer(::detail::ConvolutionalCodeConstraintLengthMap))->capture_default_str();
+    rangeStartApp->add_option("--PrfMode", m_cliData->SessionData.uwbConfiguration._prfMode)->transform(CLI::CheckedTransformer(::detail::PrfModeMap))->capture_default_str();
+    rangeStartApp->add_option("--UwbMacAddressFcsType", m_cliData->SessionData.uwbConfiguration._macAddressFcsType)->transform(CLI::CheckedTransformer(::detail::UwbMacAddressFcsTypeMap))->capture_default_str();
 
     // booleans
     rangeStartApp->add_flag("--controller,!--controlee", m_cliData->HostIsController, "default is controlee")->capture_default_str();
@@ -212,28 +214,32 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App *parent)
     rangeStartApp->add_option("--RangingInterval", m_cliData->SessionData.uwbConfiguration._rangingInterval, "uint16_t")->capture_default_str();
     rangeStartApp->add_option("--KeyRotationRate", m_cliData->SessionData.uwbConfiguration._keyRotationRate, "uint8_t")->capture_default_str();
     rangeStartApp->add_option("--MaxRangingRoundRetry", m_cliData->SessionData.uwbConfiguration._maxRangingRoundRetry, "uint16_t")->capture_default_str();
+    rangeStartApp->add_option("--StaticRangingVendorId", m_cliData->StaticRanging.VendorId, "uint16_t. If --SecureRangingInfo* options are used, this option will be overridden")->capture_default_str();
+
+    // arrays
+    rangeStartApp->add_option("--StaticRangingInitializationVector", m_cliData->StaticRanging.InitializationVector, "array of uint16_t. If --SecureRangingInfo* options are used, this option will be overridden")->capture_default_str();
 
     // strings
     rangeStartApp->add_option("--FiraPhyVersion", m_cliData->PhyVersionString)->capture_default_str();
     rangeStartApp->add_option("--FiraMacVersion", m_cliData->MacVersionString)->capture_default_str();
     rangeStartApp->add_option("--ResultReportConfiguration", m_cliData->ResultReportConfigurationString)->capture_default_str();
 
-    rangeStartApp->parse_complete_callback([&] {
+    rangeStartApp->parse_complete_callback([this] {
         std::cout << "Selected parameters:" << std::endl;
 
         for (const auto& [optionName, optionSelected] :
             std::initializer_list<std::tuple<std::string_view, std::string_view>>{
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._deviceRole),
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._rangingConfiguration.Method),
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._rangingConfiguration.ReportMode),
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._stsConfiguration),
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._multiNodeMode),
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._rangingTimeStruct),
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._channel),
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._rframeConfig),
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._convolutionalCodeConstraintLength),
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._prfMode),
-                detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._macAddressFcsType) }) {
+                ::detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._deviceRole),
+                ::detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._rangingConfiguration.Method),
+                ::detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._rangingConfiguration.ReportMode),
+                ::detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._stsConfiguration),
+                ::detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._multiNodeMode),
+                ::detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._rangingTimeStruct),
+                ::detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._channel),
+                ::detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._rframeConfig),
+                ::detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._convolutionalCodeConstraintLength),
+                ::detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._prfMode),
+                ::detail::GetEnumTypeAndValue(m_cliData->SessionData.uwbConfiguration._macAddressFcsType) }) {
             std::cout << optionName << "::" << optionSelected << std::endl;
         }
         if (!m_cliData->MacVersionString.empty()) {
@@ -254,13 +260,22 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App *parent)
         }
 
         if (!m_cliData->ResultReportConfigurationString.empty()) {
-            auto result = uwb::protocol::fira::StringToResultReportConfiguration(m_cliData->ResultReportConfigurationString, detail::ResultReportConfigurationMap);
+            auto result = uwb::protocol::fira::StringToResultReportConfiguration(m_cliData->ResultReportConfigurationString, ::detail::ResultReportConfigurationMap);
             if (not result) {
                 std::cout << "could not parse ResultReportConfiguration" << std::endl;
             } else {
                 m_cliData->SessionData.uwbConfiguration._resultReportConfigurations = result.value();
             }
         }
+
+        m_cliData->SessionData.staticRangingInfo = m_cliData->StaticRanging;
+        std::cout << "StaticRangingInfo: " << m_cliData->StaticRanging;
+        std::cout << "DEBUG: " << m_cliData->StaticRanging.InitializationVector[0] << std::endl;
+        std::cout << "DEBUG: " << m_cliData->StaticRanging.InitializationVector[1] << std::endl;
+        std::cout << "DEBUG: " << m_cliData->StaticRanging.InitializationVector[2] << std::endl;
+        std::cout << "DEBUG: " << m_cliData->StaticRanging.InitializationVector[3] << std::endl;
+        std::cout << "DEBUG: " << m_cliData->StaticRanging.InitializationVector[4] << std::endl;
+        std::cout << "DEBUG: " << m_cliData->StaticRanging.InitializationVector[5] << std::endl;
 
         std::cout << "FiRa MAC Version: " << std::setfill('0') << std::showbase << std::setw(8) << std::left << std::hex << m_cliData->SessionData.uwbConfiguration._firaMacVersion << std::endl;
         std::cout << "FiRa PHY Version: " << std::setfill('0') << std::showbase << std::setw(8) << std::left << std::hex << m_cliData->SessionData.uwbConfiguration._firaPhyVersion << std::endl;

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -214,10 +214,10 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App* parent)
     rangeStartApp->add_option("--RangingInterval", m_cliData->SessionData.uwbConfiguration._rangingInterval, "uint16_t")->capture_default_str();
     rangeStartApp->add_option("--KeyRotationRate", m_cliData->SessionData.uwbConfiguration._keyRotationRate, "uint8_t")->capture_default_str();
     rangeStartApp->add_option("--MaxRangingRoundRetry", m_cliData->SessionData.uwbConfiguration._maxRangingRoundRetry, "uint16_t")->capture_default_str();
-    rangeStartApp->add_option("--StaticRangingVendorId", m_cliData->StaticRanging.VendorId, "uint16_t. If --SecureRangingInfo* options are used, this option will be overridden")->capture_default_str();
+    rangeStartApp->add_option("--StaticRangingInfoVendorId", m_cliData->StaticRanging.VendorId, "uint16_t. If --SecureRangingInfo* options are used, this option will be overridden")->capture_default_str();
 
     // arrays
-    rangeStartApp->add_option("--StaticRangingInitializationVector", m_cliData->StaticRanging.InitializationVector, "array of uint8_t. If --SecureRangingInfo* options are used, this option will be overridden")->delimiter(':');
+    rangeStartApp->add_option("--StaticRangingInfoInitializationVector", m_cliData->StaticRanging.InitializationVector, "array of uint8_t. If --SecureRangingInfo* options are used, this option will be overridden")->delimiter(':');
 
     // strings
     rangeStartApp->add_option("--FiraPhyVersion", m_cliData->PhyVersionString)->capture_default_str();

--- a/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
@@ -20,6 +20,8 @@ struct NearObjectCliData
     std::string PhyVersionString;
     std::string ResultReportConfigurationString;
 
+    uwb::protocol::fira::StaticRangingInfo StaticRanging{};
+
     bool HostIsController{ false };
     uwb::protocol::fira::UwbSessionData SessionData{};
 };


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Adds support for entering StaticRangingInfo via cli

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
