### PR TITLE
Cli11staticiv

### DIFF
--- a/lib/uwb/include/uwb/protocols/fira/StaticRangingInfo.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/StaticRangingInfo.hxx
@@ -5,6 +5,7 @@
 #include <array>
 #include <cstdint>
 #include <iterator>
+#include <string>
 
 #include <notstd/hash.hxx>
 

--- a/lib/uwb/protocols/fira/StaticRangingInfo.cxx
+++ b/lib/uwb/protocols/fira/StaticRangingInfo.cxx
@@ -9,8 +9,8 @@ uwb::protocol::fira::StaticRangingInfo::ToString() const {
     ss << "{" << std::endl;
     ss << "VendorId: " << VendorId << std::endl;
     ss << "InitializationVector: " << std::hex << std::setw(2) << std::setfill('0') << std::showbase << std::internal;
-    for(const auto i: InitializationVector) {
-        ss << i << " ";
+    for (const auto i : InitializationVector) {
+        ss << +i << " ";
     }
     ss << std::endl;
     ss << "}" << std::endl;

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -217,7 +217,7 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App *parent)
     rangeStartApp->add_option("--StaticRangingVendorId", m_cliData->StaticRanging.VendorId, "uint16_t. If --SecureRangingInfo* options are used, this option will be overridden")->capture_default_str();
 
     // arrays
-    rangeStartApp->add_option("--StaticRangingInitializationVector", m_cliData->StaticRanging.InitializationVector, "array of uint16_t. If --SecureRangingInfo* options are used, this option will be overridden")->capture_default_str();
+    rangeStartApp->add_option("--StaticRangingInitializationVector", m_cliData->StaticRanging.InitializationVector, "array of uint8_t. If --SecureRangingInfo* options are used, this option will be overridden")->delimiter(':');
 
     // strings
     rangeStartApp->add_option("--FiraPhyVersion", m_cliData->PhyVersionString)->capture_default_str();
@@ -269,13 +269,7 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App *parent)
         }
 
         m_cliData->SessionData.staticRangingInfo = m_cliData->StaticRanging;
-        std::cout << "StaticRangingInfo: " << m_cliData->StaticRanging;
-        std::cout << "DEBUG: " << m_cliData->StaticRanging.InitializationVector[0] << std::endl;
-        std::cout << "DEBUG: " << m_cliData->StaticRanging.InitializationVector[1] << std::endl;
-        std::cout << "DEBUG: " << m_cliData->StaticRanging.InitializationVector[2] << std::endl;
-        std::cout << "DEBUG: " << m_cliData->StaticRanging.InitializationVector[3] << std::endl;
-        std::cout << "DEBUG: " << m_cliData->StaticRanging.InitializationVector[4] << std::endl;
-        std::cout << "DEBUG: " << m_cliData->StaticRanging.InitializationVector[5] << std::endl;
+        std::cout << "DEBUG StaticRangingInfo: " << m_cliData->StaticRanging << std::endl;
 
         std::cout << "FiRa MAC Version: " << std::setfill('0') << std::showbase << std::setw(8) << std::left << std::hex << m_cliData->SessionData.uwbConfiguration._firaMacVersion << std::endl;
         std::cout << "FiRa PHY Version: " << std::setfill('0') << std::showbase << std::setw(8) << std::left << std::hex << m_cliData->SessionData.uwbConfiguration._firaPhyVersion << std::endl;


### PR DESCRIPTION
* Fix missing `<string>` header.
* Force integer promotion of `uint8_t` values being passed to `std::ostream` to prevent ascii extended ASCII values being printed.
* Add `:` delimiter for `--StaticRangingInitializationVector` option.
