### PR TITLE
Update cpp-lint workflow configuration for ignored libs and embedded clang-tidy file

### DIFF
--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           style: file
           lines-changed-only: true
+          ignore: '.github|lib/shared/notstd|windows/shared/notstd'
 
       - name: Compliance check
         if: steps.linter.outputs.checks-failed > 0

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -17,6 +17,7 @@ jobs:
           style: file
           lines-changed-only: true
           ignore: '.github|lib/shared/notstd|windows/shared/notstd'
+          tidy-checks: ''
 
       - name: Compliance check
         if: steps.linter.outputs.checks-failed > 0


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [X] Infrastructure

### Goals

* Disable lint checks on `notstd` libs since we use a different coding style for those.
* Enforce repo `.clang-tidy` file checks with cpp-lint workflow.

### Technical Details

* Add cpp-lint workflow `ignore` option with `notstd` directories.
* Add cpp-lint workflow `clang-tidy` option with empty value, enabling use of repo-embedded `.clang-tidy` file.


## Test Results

None, this will be tested on the next PR.

### Reviewer Focus

None

### Future Work

The `.clang-tidy` file needs to be modified such that external dependencies such as CLI11 and Catch2 are ignored. Since these files are compiled and get included in the `compile_commands.json` file, it's unclear how to do this.

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
