### PR TITLE
Use std::variant for UwbConfiguration property container

### DIFF
--- a/lib/uwb/include/uwb/protocols/fira/UwbConfiguration.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/UwbConfiguration.hxx
@@ -106,7 +106,7 @@ struct UwbConfiguration
     static const std::unordered_set<ResultReportConfiguration> ResultReportConfigurationsDefault;
 
     /**
-     * @brief Variant for all possible property types. 
+     * @brief Variant for all possible property types.
      */
     using ParameterTypesVariant = std::variant<
         bool,
@@ -127,8 +127,7 @@ struct UwbConfiguration
         uwb::UwbMacAddress,
         uwb::UwbMacAddressFcsType,
         uwb::UwbMacAddressType,
-        std::unordered_set<uwb::protocol::fira::ResultReportConfiguration>
-    >;
+        std::unordered_set<uwb::protocol::fira::ResultReportConfiguration>>;
 
     /**
      * @brief Creates a new UwbConfiguration builder object.
@@ -167,8 +166,8 @@ struct UwbConfiguration
 
     /**
      * @brief The map of parameter tags and their values from the configuration object.
-     * 
-     * @return const std::unordered_map<uwb::protocol::fira::UwbConfiguration::ParameterTag, ParameterTypesVariant>& 
+     *
+     * @return const std::unordered_map<uwb::protocol::fira::UwbConfiguration::ParameterTag, ParameterTypesVariant>&
      */
     const std::unordered_map<uwb::protocol::fira::UwbConfiguration::ParameterTag, ParameterTypesVariant>&
     GetValueMap() const noexcept;
@@ -282,7 +281,6 @@ private:
             ? std::optional<T>(std::get<T>(it->second))
             : std::nullopt;
     }
-
 
 private:
     std::unordered_map<ParameterTag, ParameterTypesVariant> m_values{};

--- a/lib/uwb/include/uwb/protocols/fira/UwbConfiguration.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/UwbConfiguration.hxx
@@ -2,13 +2,13 @@
 #ifndef UWB_CONFIGURATION_HXX
 #define UWB_CONFIGURATION_HXX
 
-#include <any>
 #include <compare>
 #include <cstdint>
 #include <functional>
 #include <memory>
 #include <optional>
 #include <unordered_set>
+#include <variant>
 
 #include <TlvBer.hxx>
 #include <notstd/hash.hxx>
@@ -106,6 +106,31 @@ struct UwbConfiguration
     static const std::unordered_set<ResultReportConfiguration> ResultReportConfigurationsDefault;
 
     /**
+     * @brief Variant for all possible property types. 
+     */
+    using ParameterTypesVariant = std::variant<
+        bool,
+        uint8_t,
+        uint16_t,
+        uint32_t,
+        uwb::protocol::fira::Channel,
+        uwb::protocol::fira::ConvolutionalCodeConstraintLength,
+        uwb::protocol::fira::DeviceRole,
+        uwb::protocol::fira::MultiNodeMode,
+        uwb::protocol::fira::PrfMode,
+        uwb::protocol::fira::RangingMethod,
+        uwb::protocol::fira::RangingMode,
+        uwb::protocol::fira::ResultReportConfiguration,
+        uwb::protocol::fira::SchedulingMode,
+        uwb::protocol::fira::StsConfiguration,
+        uwb::protocol::fira::StsPacketConfiguration,
+        uwb::UwbMacAddress,
+        uwb::UwbMacAddressFcsType,
+        uwb::UwbMacAddressType,
+        std::unordered_set<uwb::protocol::fira::ResultReportConfiguration>
+    >;
+
+    /**
      * @brief Creates a new UwbConfiguration builder object.
      *
      * @return UwbConfiguration::Builder
@@ -121,7 +146,7 @@ struct UwbConfiguration
      * @return false
      */
     bool
-    operator==(const UwbConfiguration& other) const noexcept;
+    operator==(const UwbConfiguration& other) const noexcept = default;
 
     /**
      * @brief Convert this object into a FiRa Data Object (DO).
@@ -142,10 +167,10 @@ struct UwbConfiguration
 
     /**
      * @brief The map of parameter tags and their values from the configuration object.
-     *
-     * @return const std::unordered_map<uwb::protocol::fira::UwbConfiguration::ParameterTag, std::any>&
+     * 
+     * @return const std::unordered_map<uwb::protocol::fira::UwbConfiguration::ParameterTag, ParameterTypesVariant>& 
      */
-    const std::unordered_map<uwb::protocol::fira::UwbConfiguration::ParameterTag, std::any>&
+    const std::unordered_map<uwb::protocol::fira::UwbConfiguration::ParameterTag, ParameterTypesVariant>&
     GetValueMap() const noexcept;
 
     std::optional<uint32_t>
@@ -254,12 +279,13 @@ private:
     {
         auto it = m_values.find(tag);
         return (it != std::cend(m_values))
-            ? std::optional<T>(std::any_cast<T>(it->second))
+            ? std::optional<T>(std::get<T>(it->second))
             : std::nullopt;
     }
 
+
 private:
-    std::unordered_map<ParameterTag, std::any> m_values{};
+    std::unordered_map<ParameterTag, ParameterTypesVariant> m_values{};
 };
 
 } // namespace uwb::protocol::fira

--- a/lib/uwb/include/uwb/protocols/fira/UwbConfigurationBuilder.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/UwbConfigurationBuilder.hxx
@@ -248,7 +248,7 @@ public:
 
 private:
     UwbConfiguration m_uwbConfiguration;
-    std::unordered_map<uwb::protocol::fira::UwbConfiguration::ParameterTag, std::any>& m_values;
+    std::unordered_map<uwb::protocol::fira::UwbConfiguration::ParameterTag, uwb::protocol::fira::UwbConfiguration::ParameterTypesVariant>& m_values;
 };
 
 } // namespace uwb::protocol::fira

--- a/lib/uwb/protocols/fira/UwbConfiguration.cxx
+++ b/lib/uwb/protocols/fira/UwbConfiguration.cxx
@@ -150,7 +150,7 @@ UwbConfiguration::GetResultReportConfigurations() const noexcept
 {
     auto it = m_values.find(ParameterTag::ResultReportConfig);
     return (it != std::cend(m_values))
-        ? std::any_cast<std::unordered_set<ResultReportConfiguration>>(it->second)
+        ? std::get<std::unordered_set<ResultReportConfiguration>>(it->second)
         : std::unordered_set<ResultReportConfiguration>{};
 }
 
@@ -214,46 +214,8 @@ UwbConfiguration::GetMaxRangingRoundRetry() const noexcept
     return GetValue<uint16_t>(ParameterTag::MaxRrRetry);
 }
 
-const std::unordered_map<UwbConfiguration::ParameterTag, std::any>&
+const std::unordered_map<UwbConfiguration::ParameterTag, UwbConfiguration::ParameterTypesVariant>&
 UwbConfiguration::GetValueMap() const noexcept
 {
     return m_values;
-}
-
-bool
-UwbConfiguration::operator==(const UwbConfiguration& other) const noexcept
-{
-    // clang-format off
-    return 
-        GetFiraPhyVersion() == other.GetFiraPhyVersion() &&
-        GetFiraMacVersion() == other.GetFiraMacVersion() &&
-        GetDeviceRole() == GetDeviceRole() &&
-        GetRangingMethod() == other.GetRangingMethod() &&
-        GetStsConfiguration() == other.GetStsConfiguration() &&
-        GetMultiNodeMode() == other.GetMultiNodeMode() &&
-        GetRangingTimeStruct() == other.GetRangingTimeStruct() &&
-        GetSchedulingMode() == other.GetSchedulingMode() &&
-        GetHoppingMode() == other.GetHoppingMode() &&
-        GetBlockStriding() == other.GetBlockStriding() &&
-        GetUwbInitiationTime()== other.GetUwbInitiationTime() &&
-        GetChannel() == other.GetChannel() &&
-        GetRFrameConfig() == other.GetRFrameConfig() &&
-        GetConvolutionalCodeConstraintLength() == other.GetConvolutionalCodeConstraintLength() &&
-        GetPrfMode() == other.GetPrfMode() &&
-        GetSp0PhySetNumber() == other.GetSp0PhySetNumber() &&
-        GetSp1PhySetNumber() == other.GetSp1PhySetNumber() &&
-        GetSp3PhySetNumber() == other.GetSp3PhySetNumber() &&
-        GetPreableCodeIndex() == other.GetPreableCodeIndex() &&
-        GetResultReportConfigurations() == other.GetResultReportConfigurations() &&
-        GetMacAddressMode() == other.GetMacAddressMode() &&
-        GetControleeShortMacAddress() == other.GetControleeShortMacAddress() &&
-        GetControllerMacAddress() == other.GetControllerMacAddress() &&
-        GetSlotsPerRangingRound() == other.GetSlotsPerRangingRound() &&
-        GetMaxContentionPhaseLength() == other.GetMaxContentionPhaseLength() &&
-        GetSlotDuration() == other.GetSlotDuration() &&
-        GetRangingInterval() == other.GetRangingInterval() &&
-        GetKeyRotationRate() == other.GetKeyRotationRate() &&
-        GetMacAddressFcsType() == other.GetMacAddressFcsType() &&
-        GetMaxRangingRoundRetry() == other.GetMaxRangingRoundRetry();
-    // clang-format on
 }

--- a/lib/uwb/protocols/fira/UwbConfigurationBuilder.cxx
+++ b/lib/uwb/protocols/fira/UwbConfigurationBuilder.cxx
@@ -276,11 +276,8 @@ UwbConfiguration::Builder::Supports() noexcept
 UwbConfiguration::Builder&
 UwbConfiguration::Builder::AddResultReportConfiguration(uwb::protocol::fira::ResultReportConfiguration resultReportConfiguration) noexcept
 {
-    if (!m_values[ParameterTag::ResultReportConfig].has_value()) {
-        m_values[ParameterTag::ResultReportConfig].emplace<std::unordered_set<uwb::protocol::fira::ResultReportConfiguration>>();
-    }
-
-    auto& resultReportConfigurations = std::any_cast<std::unordered_set<uwb::protocol::fira::ResultReportConfiguration>&>(m_values[ParameterTag::ResultReportConfig]);
+    auto [it, _] = m_values.insert( { ParameterTag::ResultReportConfig, std::unordered_set<uwb::protocol::fira::ResultReportConfiguration>{} });
+    auto& resultReportConfigurations = std::get<std::unordered_set<uwb::protocol::fira::ResultReportConfiguration>>(it->second);
     resultReportConfigurations.insert(std::move(resultReportConfiguration));
 
     return *this;

--- a/lib/uwb/protocols/fira/UwbConfigurationBuilder.cxx
+++ b/lib/uwb/protocols/fira/UwbConfigurationBuilder.cxx
@@ -276,7 +276,7 @@ UwbConfiguration::Builder::Supports() noexcept
 UwbConfiguration::Builder&
 UwbConfiguration::Builder::AddResultReportConfiguration(uwb::protocol::fira::ResultReportConfiguration resultReportConfiguration) noexcept
 {
-    auto [it, _] = m_values.insert( { ParameterTag::ResultReportConfig, std::unordered_set<uwb::protocol::fira::ResultReportConfiguration>{} });
+    auto [it, _] = m_values.insert({ ParameterTag::ResultReportConfig, std::unordered_set<uwb::protocol::fira::ResultReportConfiguration>{} });
     auto& resultReportConfigurations = std::get<std::unordered_set<uwb::protocol::fira::ResultReportConfiguration>>(it->second);
     resultReportConfigurations.insert(std::move(resultReportConfiguration));
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

* Enforce type-safety when working with `UwbConfiguration`.
 
### Technical Details

* Direct replacement of `std::any` with `std::variant`, swapping `std::any_cast<T>` with `std::get<T>`.
* Restore default `operator==()` implementation.

### Test Results

Unit tests pass on both Linux and Windows.

### Reviewer Focus

None

### Future Work

Consider how this can make CLI parsing code more generic.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
