### PR TITLE
Prevent invalid types in UwbAppConfigurationParameter

### DIFF
--- a/windows/devices/uwb/include/windows/devices/uwb/UwbAppConfiguration.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbAppConfiguration.hxx
@@ -2,11 +2,13 @@
 #ifndef UWB_APP_CONFIGURATION_HXX
 #define UWB_APP_CONFIGURATION_HXX
 
+#include <concepts>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <memory>
 #include <tuple>
+#include <type_traits>
 
 #include <UwbCxLrpDeviceGlue.h>
 
@@ -19,6 +21,7 @@ namespace windows::devices
  * holds as its flexible array member.
  */
 template <typename PropertyT>
+requires std::is_standard_layout_v<PropertyT>
 class UwbAppConfigurationParameter
 {
 public:

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbAppConfiguration.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbAppConfiguration.hxx
@@ -25,7 +25,14 @@ requires std::is_standard_layout_v<PropertyT>
 class UwbAppConfigurationParameter
 {
 public:
-    explicit UwbAppConfigurationParameter(const PropertyT& value, UWB_APP_CONFIG_PARAM_TYPE parameterType, size_t parameterSize = sizeof(PropertyT)) :
+    /**
+     * @brief Construct a new UwbAppConfigurationParameter object.
+     * 
+     * @param value The value to pack into the UWB_APP_CONFIG_PARAM paramValue flex-array member.
+     * @param parameterType The corresponding UwbCx parameter type value.
+     * @param parameterSize The size of the value to pack, in bytes.
+     */
+    explicit UwbAppConfigurationParameter(const PropertyT& value, UWB_APP_CONFIG_PARAM_TYPE parameterType, std::size_t parameterSize = sizeof(PropertyT)) :
         m_size(offsetof(UWB_APP_CONFIG_PARAM, paramValue[parameterSize])),
         m_buffer(std::make_unique<uint8_t[]>(m_size)),
         m_parameter(*reinterpret_cast<UWB_APP_CONFIG_PARAM*>(m_buffer.get())),


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Ensure that `UwbAppConfigurationParameter` can't be used incorrectly.

### Technical Details

The `PropertyT` input type that is converted to the UwbCx DDI equivalent must have a standard layout, since it is encoded into (or re-interpreted as) a raw byte array. As such, it must have a sequential object representation to make sense. 

* Add constraint to enforce standard layout requirement of `PropertyT`.
* Update constructor documentation.
* `size_t` -> `std::size_t`.

### Test Results

* All unit tests pass on Windows.

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
