### PR TITLE
Fix crash on displaying nocli selected parameters output 

### DIFF
--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -226,12 +226,13 @@ std::string
 ResultReportConfigurationToString(const std::unordered_set<ResultReportConfiguration>& resultReportConfiguration);
 
 /**
- * @brief Converts a string to vector of ResultReportConfiguration, using the given map
- *
- * @return std::unordered_set<ResultReportConfiguration>
+ * @brief Converts a string to vector of ResultReportConfiguration.
+ * 
+ * @param input The string input to convert.
+ * @return std::optional<std::unordered_set<ResultReportConfiguration>> 
  */
 std::optional<std::unordered_set<ResultReportConfiguration>>
-StringToResultReportConfiguration(const std::string& input, std::unordered_map<std::string, ResultReportConfiguration> map);
+StringToResultReportConfiguration(const std::string& input);
 
 } // namespace uwb::protocol::fira
 

--- a/lib/uwb/protocols/fira/FiraDevice.cxx
+++ b/lib/uwb/protocols/fira/FiraDevice.cxx
@@ -81,16 +81,15 @@ uwb::protocol::fira::ResultReportConfigurationToString(const std::unordered_set<
 }
 
 std::optional<std::unordered_set<ResultReportConfiguration>>
-uwb::protocol::fira::StringToResultReportConfiguration(const std::string& input, std::unordered_map<std::string, ResultReportConfiguration> map)
+uwb::protocol::fira::StringToResultReportConfiguration(const std::string& input)
 {
-    auto tokens = tokenize(input, ',');
     std::unordered_set<ResultReportConfiguration> output{};
 
-    for (const auto& s : tokens) {
-        if (not map.contains(s)) {
-            return std::nullopt;
+    for (const auto& token : tokenize(input, ',')) {
+        auto resultReportConfiguration = magic_enum::enum_cast<ResultReportConfiguration>(token);
+        if (resultReportConfiguration.has_value()) {
+            output.insert(resultReportConfiguration.value());
         }
-        output.insert(map.at(s));
     }
 
     return output;

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -222,8 +222,8 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App* parent)
                 using ParameterValueT = std::decay_t<decltype(arg)>;
                 if constexpr (std::is_enum_v<ParameterValueT>) {
                     std::cout << magic_enum::enum_type_name<ParameterValueT>() << "::" <<  magic_enum::enum_name(arg) << std::endl;
-                } else if constexpr (std::is_same_v<ParameterValueT, uwb::protocol::fira::ResultReportConfiguration>) {
-                    std::cout << "ResultReportConfigurations: " << uwb::protocol::fira::ResultReportConfigurationToString(arg);
+                } else if constexpr (std::is_same_v<ParameterValueT, std::unordered_set<uwb::protocol::fira::ResultReportConfiguration>>) {
+                    std::cout << "ResultReportConfigurations: " << uwb::protocol::fira::ResultReportConfigurationToString(arg) << std::endl;
                 }
             }, parameterValue);
         }

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -2,8 +2,10 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <tuple>
 #include <vector>
+#include <variant>
 
 #include <magic_enum.hpp>
 #include <nearobject/cli/NearObjectCli.hxx>
@@ -117,21 +119,6 @@ populateMap() noexcept
     return { std::cbegin(destVector), std::cend(destVector) };
 }
 
-/**
- * @brief Helper function to return a tuple containing the string
- * representations of an enum type and the value.
- *
- * @tparam EnumT The type of the enumeration.
- * @param value The enumeration value.
- * @return std::tuple<std::string_view, std::string_view>
- */
-template <typename EnumT>
-std::tuple<std::string_view, std::string_view>
-GetEnumTypeAndValue(const std::optional<EnumT>& value)
-{
-    return std::make_tuple(magic_enum::enum_type_name<EnumT>(), magic_enum::enum_name(*value));
-}
-
 const std::unordered_map<std::string, uwb::protocol::fira::DeviceRole> DeviceRoleMap = populateMap<uwb::protocol::fira::DeviceRole>();
 const std::unordered_map<std::string, uwb::protocol::fira::RangingDirection> RangingMethodMap = populateMap<uwb::protocol::fira::RangingDirection>();
 const std::unordered_map<std::string, uwb::protocol::fira::MeasurementReportMode> MeasurementReportModeMap = populateMap<uwb::protocol::fira::MeasurementReportMode>();
@@ -144,7 +131,6 @@ const std::unordered_map<std::string, uwb::protocol::fira::StsPacketConfiguratio
 const std::unordered_map<std::string, uwb::protocol::fira::ConvolutionalCodeConstraintLength> ConvolutionalCodeConstraintLengthMap = populateMap<uwb::protocol::fira::ConvolutionalCodeConstraintLength>();
 const std::unordered_map<std::string, uwb::protocol::fira::PrfMode> PrfModeMap = populateMap<uwb::protocol::fira::PrfMode>();
 const std::unordered_map<std::string, uwb::UwbMacAddressFcsType> UwbMacAddressFcsTypeMap = populateMap<uwb::UwbMacAddressFcsType>();
-const std::unordered_map<std::string, uwb::protocol::fira::ResultReportConfiguration> ResultReportConfigurationMap = populateMap<uwb::protocol::fira::ResultReportConfiguration>();
 } // namespace detail
 
 CLI::App*
@@ -226,53 +212,23 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App* parent)
     rangeStartApp->add_option("--ResultReportConfiguration", uwbConfig.resultReportConfigurationString)->capture_default_str();
 
     rangeStartApp->parse_complete_callback([this, &uwbConfig] {
+        m_cliData->SessionData.uwbConfiguration = m_cliData->uwbConfiguration;
+        m_cliData->SessionData.staticRangingInfo = m_cliData->StaticRanging;
+
         std::cout << "Selected parameters:" << std::endl;
 
-        for (const auto& [optionName, optionSelected] :
-            std::initializer_list<std::tuple<std::string_view, std::string_view>>{
-                detail::GetEnumTypeAndValue(uwbConfig.deviceRole),
-                detail::GetEnumTypeAndValue(uwbConfig.rangingDirection),
-                detail::GetEnumTypeAndValue(uwbConfig.rangingMeasurementReportMode),
-                detail::GetEnumTypeAndValue(uwbConfig.stsConfiguration),
-                detail::GetEnumTypeAndValue(uwbConfig.multiNodeMode),
-                detail::GetEnumTypeAndValue(uwbConfig.rangingTimeStruct),
-                detail::GetEnumTypeAndValue(uwbConfig.channel),
-                detail::GetEnumTypeAndValue(uwbConfig.rframeConfig),
-                detail::GetEnumTypeAndValue(uwbConfig.convolutionalCodeConstraintLength),
-                detail::GetEnumTypeAndValue(uwbConfig.prfMode),
-                detail::GetEnumTypeAndValue(uwbConfig.macAddressFcsType) }) {
-            std::cout << optionName << "::" << optionSelected << std::endl;
-        }
-        if (!uwbConfig.firaMacVersionString.empty()) {
-            auto result = uwb::protocol::fira::StringToVersion(uwbConfig.firaMacVersionString);
-            if (not result) {
-                std::cout << "could not parse MacVersionString" << std::endl;
-            } else {
-                uwbConfig.firaMacVersion = result.value();
-            }
-        }
-        if (!uwbConfig.firaPhyVersionString.empty()) {
-            auto result = uwb::protocol::fira::StringToVersion(uwbConfig.firaPhyVersionString);
-            if (not result) {
-                std::cout << "could not parse PhyVersionString" << std::endl;
-            } else {
-                uwbConfig.firaPhyVersion = result.value();
-            }
+        for (const auto& [parameterTag, parameterValue]: m_cliData->SessionData.uwbConfiguration.GetValueMap()) {
+            std::visit([](auto&& arg) {
+                using ParameterValueT = std::decay_t<decltype(arg)>;
+                if constexpr (std::is_enum_v<ParameterValueT>) {
+                    std::cout << magic_enum::enum_type_name<ParameterValueT>() << "::" <<  magic_enum::enum_name(arg) << std::endl;
+                } else if constexpr (std::is_same_v<ParameterValueT, uwb::protocol::fira::ResultReportConfiguration>) {
+                    std::cout << "ResultReportConfigurations: " << uwb::protocol::fira::ResultReportConfigurationToString(arg);
+                }
+            }, parameterValue);
         }
 
-        if (!uwbConfig.resultReportConfigurationString.empty()) {
-            auto result = uwb::protocol::fira::StringToResultReportConfiguration(uwbConfig.resultReportConfigurationString, detail::ResultReportConfigurationMap);
-            if (not result) {
-                std::cout << "could not parse ResultReportConfiguration" << std::endl;
-            } else {
-                uwbConfig.resultReportConfigurations = result.value();
-            }
-        }
-
-        m_cliData->SessionData.staticRangingInfo = m_cliData->StaticRanging;
-        m_cliData->SessionData.uwbConfiguration = m_cliData->uwbConfiguration;
         std::cout << "StaticRangingInfo: {" << m_cliData->SessionData.staticRangingInfo << "}" << std::endl;
-        std::cout << "ResultReportConfigurations: " << uwb::protocol::fira::ResultReportConfigurationToString(uwbConfig.resultReportConfigurations) << std::endl;
     });
 
     rangeStartApp->final_callback([this] {

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -2,10 +2,10 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
-#include <type_traits>
 #include <tuple>
-#include <vector>
+#include <type_traits>
 #include <variant>
+#include <vector>
 
 #include <magic_enum.hpp>
 #include <nearobject/cli/NearObjectCli.hxx>
@@ -217,15 +217,16 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App* parent)
 
         std::cout << "Selected parameters:" << std::endl;
 
-        for (const auto& [parameterTag, parameterValue]: m_cliData->SessionData.uwbConfiguration.GetValueMap()) {
+        for (const auto& [parameterTag, parameterValue] : m_cliData->SessionData.uwbConfiguration.GetValueMap()) {
             std::visit([](auto&& arg) {
                 using ParameterValueT = std::decay_t<decltype(arg)>;
                 if constexpr (std::is_enum_v<ParameterValueT>) {
-                    std::cout << magic_enum::enum_type_name<ParameterValueT>() << "::" <<  magic_enum::enum_name(arg) << std::endl;
+                    std::cout << magic_enum::enum_type_name<ParameterValueT>() << "::" << magic_enum::enum_name(arg) << std::endl;
                 } else if constexpr (std::is_same_v<ParameterValueT, std::unordered_set<uwb::protocol::fira::ResultReportConfiguration>>) {
                     std::cout << "ResultReportConfigurations: " << uwb::protocol::fira::ResultReportConfigurationToString(arg) << std::endl;
                 }
-            }, parameterValue);
+            },
+                parameterValue);
         }
 
         std::cout << "StaticRangingInfo: {" << m_cliData->SessionData.staticRangingInfo << "}" << std::endl;

--- a/tools/cli/NearObjectCliData.cxx
+++ b/tools/cli/NearObjectCliData.cxx
@@ -9,12 +9,27 @@ UwbConfigurationData::operator UwbConfiguration() const noexcept
 {
     UwbConfiguration::Builder builder{};
 
-    if (firaPhyVersion.has_value()) {
-        builder.SetFiraVersionPhy(firaMacVersion.value());
+    // Handle inputs that require parsing from string type.
+    if (!firaPhyVersionString.empty()) {
+        auto firaPhyVersion = uwb::protocol::fira::StringToVersion(firaPhyVersionString);
+        if (firaPhyVersion.has_value()) {
+            builder.SetFiraVersionPhy(firaPhyVersion.value());
+        }
     }
-    if (firaMacVersion.has_value()) {
-        builder.SetFiraVersionMac(firaMacVersion.value());
+    if (!firaMacVersionString.empty()) {
+        auto firaMacVersion = uwb::protocol::fira::StringToVersion(firaMacVersionString);
+        if (firaMacVersion.has_value()) {
+            builder.SetFiraVersionMac(firaMacVersion.value());
+        }
     }
+    if (!resultReportConfigurationString.empty()) {
+        auto resultReportConfigurations = uwb::protocol::fira::StringToResultReportConfiguration(resultReportConfigurationString);
+        for (const auto& resultReportConfiguration : resultReportConfigurations.value_or(std::unordered_set<uwb::protocol::fira::ResultReportConfiguration>{})) {
+            builder.AddResultReportConfiguration(resultReportConfiguration);
+        }
+    }
+
+    // Handle other inputs which have already been parsed.
     if (deviceRole.has_value()) {
         builder.SetDeviceRole(deviceRole.value());
     }
@@ -65,9 +80,6 @@ UwbConfigurationData::operator UwbConfiguration() const noexcept
     }
     if (preableCodeIndex.has_value()) {
         builder.SetPreableCodeIndex(preableCodeIndex.value());
-    }
-    for (const auto& resultReportConfiguration : resultReportConfigurations) {
-        builder.AddResultReportConfiguration(resultReportConfiguration);
     }
     if (macAddressMode.has_value()) {
         builder.SetMacAddressType(macAddressMode.value());

--- a/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
@@ -5,8 +5,6 @@
 #include <cstdint>
 #include <optional>
 #include <string>
-#include <unordered_map>
-#include <unordered_set>
 
 #include <uwb/UwbMacAddress.hxx>
 #include <uwb/protocols/fira/FiraDevice.hxx>
@@ -25,8 +23,6 @@ struct UwbConfigurationData
     // Mirrored properties from UwbConfiguration data. Any newly added fields
     // that should be supported from the command-line must also be added here,
     // along with parsing support in a NearObjectCli instance.
-    std::optional<uint32_t> firaPhyVersion;
-    std::optional<uint32_t> firaMacVersion;
     std::optional<uwb::protocol::fira::DeviceRole> deviceRole;
     std::optional<uwb::protocol::fira::RangingDirection> rangingDirection;
     std::optional<uwb::protocol::fira::MeasurementReportMode> rangingMeasurementReportMode;
@@ -45,7 +41,6 @@ struct UwbConfigurationData
     std::optional<uint8_t> sp1PhySetNumber;
     std::optional<uint8_t> sp3PhySetNumber;
     std::optional<uint8_t> preableCodeIndex;
-    std::unordered_set<uwb::protocol::fira::ResultReportConfiguration> resultReportConfigurations;
     std::optional<uwb::UwbMacAddressType> macAddressMode;
     std::optional<uwb::UwbMacAddress> controleeShortMacAddress;
     std::optional<uwb::UwbMacAddress> controllerMacAddress;


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Prevent `nocli` from crashing when outputting selected parameters.

### Technical Details

Existing code crashed when `GetEnumTypeAndValue` received a `std::optional` with no value set (`std::nullopt`).
 
* Replace use of `GetEnumTypeAndValue` on input variables with use of `std::visit` on parsed values.
* Eliminate use of map in `StringToResultReportConfiguration`.
* Parse string values automatically on conversion from `UwbConfigurationData` to `UwbConfiguration`.

### Test Results

* All unit tests pass on Windows.
* The following execution was verified to produce the expected output:
```
nocli.exe uwb range start --DeviceRole Initiator --RangingMethod DoubleSidedTwoWay --MeasurementReportMode None --StsConfiguration Static  --MultiNodeMode Unicast --RangingMode Interval  --SchedulingMode Contention --Channel C5  --StsPacketConfiguration SP0  --ConvolutionalCodeConstraintLength K3 --PrfMode Bprf --UwbMacAddressFcsType Crc16  --controller --HoppingMode --BlockStriding --UwbInitiationTime 500  --FiraPhyVersion 1.2 --FiraMacVersion 0.1  --ResultReportConfiguration TofReport,AoAAzimuthReport
Selected parameters:
ResultReportConfigurations: TofReport, AoAAzimuthReport
DeviceRole::Initiator
StsConfiguration::Static
MultiNodeMode::Unicast
RangingMode::Interval
SchedulingMode::Contention
Channel::C5
StsPacketConfiguration::SP0
ConvolutionalCodeConstraintLength::K3
PrfMode::Bprf
UwbMacAddressFcsType::Crc16
StaticRangingInfo: {VendorId: 0
InitializationVector: 00 0 0 0 0 0
}
```

### Reviewer Focus

None

### Future Work

* The maps used with CLI11 `transform()` can probably be eliminated with a templated transform function that uses `magic_enum::enum_cast()`.
* The code to output selected parameters is not complete and should be updated (it was previously incomplete and has been kept as such for this PR).
 
### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
