### PR TITLE
Simplify adding enumeration values to nocli

### DIFF
--- a/lib/uwb/protocols/fira/StaticRangingInfo.cxx
+++ b/lib/uwb/protocols/fira/StaticRangingInfo.cxx
@@ -7,7 +7,7 @@ std::string
 uwb::protocol::fira::StaticRangingInfo::ToString() const
 {
     std::ostringstream staticRangingInfoString{};
-    staticRangingInfoString 
+    staticRangingInfoString
         << "VendorId " << VendorId
         << ", InitializationVector 0x";
     for (const auto& i : InitializationVector) {

--- a/lib/uwb/protocols/fira/StaticRangingInfo.cxx
+++ b/lib/uwb/protocols/fira/StaticRangingInfo.cxx
@@ -6,12 +6,13 @@
 std::string
 uwb::protocol::fira::StaticRangingInfo::ToString() const
 {
-    std::ostringstream ss;
-    ss << "VendorId: " << VendorId << std::endl;
-    ss << "InitializationVector: " << std::hex << std::setw(2) << std::setfill('0') << std::showbase << std::internal;
-    for (const auto i : InitializationVector) {
-        ss << +i << " ";
+    std::ostringstream staticRangingInfoString{};
+    staticRangingInfoString 
+        << "VendorId " << VendorId
+        << ", InitializationVector 0x";
+    for (const auto& i : InitializationVector) {
+        staticRangingInfoString << std::hex << std::setw(2) << std::setfill('0') << std::showbase << std::internal << +i;
     }
-    ss << std::endl;
-    return ss.str();
+
+    return staticRangingInfoString.str();
 }

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -246,7 +246,7 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App* parent)
                 parameterValue);
         }
 
-        std::cout << "StaticRangingInfo: {" << m_cliData->SessionData.staticRangingInfo << "}" << std::endl;
+        std::cout << "StaticRangingInfo: { " << m_cliData->SessionData.staticRangingInfo << " }" << std::endl;
     });
 
     rangeStartApp->final_callback([this] {

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -109,9 +109,11 @@ namespace detail
  * @return std::map<std::string, EnumType>
  */
 template <typename EnumType>
+// clang-format off
 requires std::is_enum_v<EnumType>
 const std::unordered_map<std::string, EnumType>
 CreateEnumerationStringMap() noexcept
+// clang-format on
 {
     const auto& reverseMap = magic_enum::enum_entries<EnumType>();
     std::unordered_map<std::string, EnumType> map;
@@ -136,9 +138,11 @@ CreateEnumerationStringMap() noexcept
  * @return The added option, which additional configuration can be applied to.
  */
 template <typename EnumType>
+// clang-format off
 requires std::is_enum_v<EnumType>
 CLI::Option*
 AddEnumOption(CLI::App* app, std::optional<EnumType>& assignTo)
+// clang-format on
 {
     std::string optionName{ std::string("--").append(magic_enum::enum_type_name<EnumType>()) };
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Simplify adding enumerations as nocli options.

### Technical Details

* Flatten `StaticRangingInfo::ToString()` output to a single line + ensure hex output of each byte.
* Optimize `populateMap` to create the map directly, since a copy was being made from an intermediate vector anyway.
* Introduce template function to add enum options which derives the option name from the enum type name.
* Remove unused lambda capture argument.

### Test Results

* All unit tests pass on Windows.
* Validated the following execution produced the expected values:

```
nocli.exe uwb range start --DeviceRole Initiator --RangingDirection DoubleSidedTwoWay --MeasurementReportMode None --StsConfiguration Static  --MultiNodeMode Unicast --RangingMode Interval  --SchedulingMode Contention --Channel C5  --StsPacketConfiguration SP0  --ConvolutionalCodeConstraintLength K3 --PrfMode Bprf --UwbMacAddressFcsType Crc16  --controller --HoppingMode --BlockStriding --UwbInitiationTime 500  --FiraPhyVersion 1.2 --FiraMacVersion 0.1  --ResultReportConfiguration TofReport,AoAAzimuthReport
Selected parameters:
ResultReportConfigurations: TofReport,AoAAzimuthReport
DeviceRole::Initiator
StsConfiguration::Static
MultiNodeMode::Unicast
RangingMode::Interval
SchedulingMode::Contention
Channel::C5
StsPacketConfiguration::SP0
ConvolutionalCodeConstraintLength::K3
PrfMode::Bprf
UwbMacAddressFcsType::Crc16
StaticRangingInfo: { VendorId 0, InitializationVector 0x000000000000 }
```

### Reviewer Focus

None

### Future Work

Consider whether non-enum options can be simplified as well.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
