### PR TITLE
Add debug configurations for launching nocli.exe

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,55 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "cli start ranging probe",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/windows/tools/nocli/${input:buildFlavor}/nocli.exe",
+            "args": [
+                "uwb",
+                "range",
+                "start",
+                "--probe",
+            ],
+            "stopAtEntry": false,
+            "cwd": "${fileDirname}",
+            "environment": [],
+            "console": "externalTerminal"
+        },
+        {
+            "name": "cli start ranging",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/windows/tools/nocli/${input:buildFlavor}/nocli.exe",
+            "args": [
+                "uwb",
+                "range",
+                "start",
+                "--deviceName",
+                "${input:deviceName}"
+            ],
+            "stopAtEntry": false,
+            "cwd": "${fileDirname}",
+            "environment": [],
+            "console": "externalTerminal"
+        }
+    ],
+    "inputs": [
+        {
+            "id": "buildFlavor",
+            "type": "pickString",
+            "description": "The build flavor to use",
+            "default": "Debug",
+            "options": [
+                "Debug",
+                "Release"
+            ]
+        },
+        {
+            "id": "deviceName",
+            "type": "promptString",
+            "description": "The uwb device name (GUID) to use for ranging"
+        }
+    ]
+}


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [X] Non-functional change
- [ ] Documentation
- [X] Infrastructure

### Goals

Allow common `nocli.exe` scenarios to be debugged from VSCode debugging menu.

### Technical Details

* Add Windows debug launch configurations for `nocli.exe` to:
    - Start ranging with a probe to determine the device.
    - Start ranging with a user prompt for the device name.
* The configuration prompts the user to select the desired build flavor, either `Debug` (default) or `Release`.

### Test Results

Ran the configurations and verified the debugger was started and broke on entrypoint.

### Reviewer Focus

None

### Future Work

Possible add more configurations with useful sets of configurations. For example, a configuration could be added which explicitly specifies all session arguments on the command line.

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
