### PR TITLE
Add Uwb Simulator driver cli tool

### DIFF
--- a/windows/devices/uwbsimulator/UwbDeviceSimulator.cxx
+++ b/windows/devices/uwbsimulator/UwbDeviceSimulator.cxx
@@ -15,7 +15,7 @@ UwbDeviceSimulator::DeviceName() const noexcept
     return m_deviceName;
 }
 
-void
+bool
 UwbDeviceSimulator::Initialize()
 {
     wil::unique_hfile handleDriver(CreateFileA(
@@ -26,6 +26,10 @@ UwbDeviceSimulator::Initialize()
         OPEN_EXISTING,
         FILE_FLAG_OVERLAPPED,
         nullptr));
+    if (!handleDriver.is_valid()) {
+        return false;
+    }
 
     m_handleDriver = std::move(handleDriver);
+    return true;
 }

--- a/windows/devices/uwbsimulator/UwbDeviceSimulator.cxx
+++ b/windows/devices/uwbsimulator/UwbDeviceSimulator.cxx
@@ -1,2 +1,31 @@
 
 #include <windows/devices/uwb/simulator/UwbDeviceSimulator.hxx>
+
+#include <UwbSimulatorDdiGlue.h>
+
+using namespace windows::devices::uwb::simulator;
+
+UwbDeviceSimulator::UwbDeviceSimulator(std::string deviceName) :
+    m_deviceName(std::move(deviceName))
+{}
+
+const std::string&
+UwbDeviceSimulator::DeviceName() const noexcept
+{
+    return m_deviceName;
+}
+
+void
+UwbDeviceSimulator::Initialize()
+{
+    wil::unique_hfile handleDriver(CreateFileA(
+        m_deviceName.c_str(),
+        GENERIC_READ | GENERIC_WRITE,
+        FILE_SHARE_READ | FILE_SHARE_WRITE,
+        nullptr,
+        OPEN_EXISTING,
+        FILE_FLAG_OVERLAPPED,
+        nullptr));
+
+    m_handleDriver = std::move(handleDriver);
+}

--- a/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbDeviceSimulator.hxx
+++ b/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbDeviceSimulator.hxx
@@ -34,9 +34,8 @@ public:
 
     /**
      * @brief Initialize the device.
-     * TODO: return type needs to convey whether this worked.
      */
-    void
+    bool
     Initialize();
 
 private:

--- a/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbDeviceSimulator.hxx
+++ b/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbDeviceSimulator.hxx
@@ -2,8 +2,50 @@
 #ifndef UWB_DEVICE_SIMULATOR_HXX
 #define UWB_DEVICE_SIMULATOR_HXX
 
-struct UwbDeviceSimulator
+#include <cstdint>
+#include <string>
+
+// NB: This must come before any other Windows include
+#include <windows.h>
+
+#include <cfgmgr32.h>
+#include <windows/devices/DeviceResource.hxx>
+#include <wil/resource.h>
+
+namespace windows::devices::uwb::simulator
 {
+class UwbDeviceSimulator
+{
+public:
+    /**
+     * @brief Construct a new UwbDeviceSimulator object.
+     * 
+     * @param deviceName The device name (path).
+     */
+    explicit UwbDeviceSimulator(std::string deviceName);
+
+    /**
+     * @brief Get the name of this device.
+     *
+     * @return const std::string&
+     */
+    const std::string&
+    DeviceName() const noexcept;
+
+    /**
+     * @brief Initialize the device.
+     * TODO: return type needs to convey whether this worked.
+     */
+    void
+    Initialize();
+
+private:
+    const std::string m_deviceName;
+
+    unique_hcmnotification m_hcmNotificationHandle;
+    wil::unique_hfile m_handleDriver;
 };
+
+} // namespace windows::devices::uwb::simulator
 
 #endif // UWB_DEVICE_SIMULATOR_HXX

--- a/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbDeviceSimulator.hxx
+++ b/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbDeviceSimulator.hxx
@@ -9,8 +9,8 @@
 #include <windows.h>
 
 #include <cfgmgr32.h>
-#include <windows/devices/DeviceResource.hxx>
 #include <wil/resource.h>
+#include <windows/devices/DeviceResource.hxx>
 
 namespace windows::devices::uwb::simulator
 {
@@ -19,7 +19,7 @@ class UwbDeviceSimulator
 public:
     /**
      * @brief Construct a new UwbDeviceSimulator object.
-     * 
+     *
      * @param deviceName The device name (path).
      */
     explicit UwbDeviceSimulator(std::string deviceName);

--- a/windows/tools/CMakeLists.txt
+++ b/windows/tools/CMakeLists.txt
@@ -1,3 +1,4 @@
 
 add_subdirectory(devicemon)
 add_subdirectory(nocli)
+add_subdirectory(uwb)

--- a/windows/tools/uwb/CMakeLists.txt
+++ b/windows/tools/uwb/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(simulator)

--- a/windows/tools/uwb/simulator/CMakeLists.txt
+++ b/windows/tools/uwb/simulator/CMakeLists.txt
@@ -1,0 +1,18 @@
+
+add_executable(uwbsim-win "")
+
+target_sources(uwbsim-win
+    PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR}/Main.cxx
+)
+
+target_link_libraries(uwbsim-win
+    PRIVATE
+        CLI11::CLI11
+        windevutil
+        windev-uwb-simulator
+)
+
+set_target_properties(uwbsim-win PROPERTIES OUTPUT_NAME uwbsim)
+set_target_properties(uwbsim-win PROPERTIES FOLDER windows/tools)
+

--- a/windows/tools/uwb/simulator/Main.cxx
+++ b/windows/tools/uwb/simulator/Main.cxx
@@ -43,7 +43,7 @@ main(int argc, char* argv[])
     }
 
     std::cout << "creating uwb simulator device " << deviceName << std::endl;
-    
+
     auto uwbDeviceSimulator = std::make_unique<uwb::simulator::UwbDeviceSimulator>(deviceName);
     if (!uwbDeviceSimulator) {
         std::cerr << "failed to create uwb simulator device instance" << std::endl;

--- a/windows/tools/uwb/simulator/Main.cxx
+++ b/windows/tools/uwb/simulator/Main.cxx
@@ -1,0 +1,61 @@
+
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include <CLI/CLI.hpp>
+#include <notstd/guid.hxx>
+
+#include <UwbSimulatorDdiGlue.h>
+#include <windows/devices/DeviceEnumerator.hxx>
+#include <windows/devices/uwb/simulator/UwbDeviceSimulator.hxx>
+
+using namespace windows::devices;
+
+int
+main(int argc, char* argv[])
+{
+    CLI::App app{};
+    app.name("uwbsim");
+    app.description("control and interact uwb simulator devices");
+
+    std::string deviceName{};
+    app.add_option("--deviceName, -d", deviceName, "The uwb simulator device name (path)");
+
+    try {
+        app.parse(argc, argv);
+    } catch (const CLI::ParseError& e) {
+        std::cerr << "failed to parse command line arguments" << std::endl;
+        return app.exit(e);
+    }
+
+    if (deviceName.empty()) {
+        const auto deviceNames = DeviceEnumerator::GetDeviceInterfaceClassInstanceNames(GUID_DEVINTERFACE_UWB_SIMULATOR);
+        if (!deviceNames.empty()) {
+            deviceName = deviceNames.front();
+        }
+    }
+
+    if (deviceName.empty()) {
+        std::cerr << "no uwb simulator device found or no device specified" << std::endl;
+        return -1;
+    }
+
+    std::cout << "creating uwb simulator device " << deviceName << std::endl;
+    
+    auto uwbDeviceSimulator = std::make_unique<uwb::simulator::UwbDeviceSimulator>(deviceName);
+    if (!uwbDeviceSimulator) {
+        std::cerr << "failed to create uwb simulator device instance" << std::endl;
+        return -2;
+    }
+
+    if (!uwbDeviceSimulator->Initialize()) {
+        std::cerr << "failed to initialize uwb simulator device" << std::endl;
+        return -2;
+    }
+
+    std::cout << "initialization succeeded" << std::endl;
+
+    return 0;
+}


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Allow uwb simulator drivers to be controlled via the command-line.

### Technical Details

* Add basic uwb simulator driver tool `uwbsim.exe` allowing control via command-line interface.

### Test Results

Ran the tool on a VM with the simulator driver installed and validated success:
```
C:\data\test\bin>uwbsim.exe
creating uwb simulator device \\?\ROOT#PROXIMITY#0000#{21663d8d-2dd6-45c7-a54a-d902202124d7}
initialization succeeded
```

### Reviewer Focus

None

### Future Work

* Actual simulator driver ddi wrapper functionality needs to be implemented.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
