### PR TITLE
Add underlying types to FiRa OOB UwbConfiguration data types

### DIFF
--- a/lib/uwb/include/uwb/UwbMacAddress.hxx
+++ b/lib/uwb/include/uwb/UwbMacAddress.hxx
@@ -18,17 +18,27 @@
 
 namespace uwb
 {
-enum class UwbMacAddressFcsType {
-    Crc16,
-    Crc32,
+/**
+ * @brief See FiRa Consortium UWB MAC Technical Requirements v1.3.0, Section
+ * 7.5.3.3, Table 53.
+ */
+enum class UwbMacAddressFcsType : uint8_t {
+    Crc16 = 0,
+    Crc32 = 1,
 };
 
 /**
  * @brief The type of uwb device object address.
+ *
+ * See FiRa Consortium UWB MAC Technical Requirements v1.3.0, Section 7.5.3.3,
+ * Table 53.
+ *
+ * Skipping the value '1' below is intentional, as that value corresponds to an
+ * unsupported uwb mac address type.
  */
-enum class UwbMacAddressType {
-    Short,
-    Extended,
+enum class UwbMacAddressType : uint8_t {
+    Short = 0,
+    Extended = 2,
 };
 
 /**
@@ -43,7 +53,7 @@ struct UwbMacAddressLength final
 
 /**
  * @brief Concept to encode valid address lengths.
- * 
+ *
  * @tparam UwbMacAddessLength
  */
 template <size_t UwbMacAddessLength>
@@ -55,7 +65,7 @@ namespace detail
 {
 /**
  * @brief Compile-time address length lookup, given type.
- * 
+ *
  * @tparam AddressType
  */
 template <UwbMacAddressType AddressType>
@@ -64,7 +74,7 @@ struct UwbMacAddressSizeImpl
 
 /**
  * @brief Address length lookup full specialization for short addresses.
- * 
+ *
  * @tparam
  */
 template <>
@@ -75,7 +85,7 @@ struct UwbMacAddressSizeImpl<UwbMacAddressType::Short>
 
 /**
  * @brief Address length lookup full specialization for extended addresses.
- * 
+ *
  * @tparam
  */
 template <>
@@ -86,7 +96,7 @@ struct UwbMacAddressSizeImpl<UwbMacAddressType::Extended>
 
 /**
  * @brief Compile-time address type lookup helper, given length.
- * 
+ *
  * @tparam Length
  */
 template <size_t Length>
@@ -95,7 +105,7 @@ struct UwbMacAddressTypeImpl
 
 /**
  * @brief Address type lookup full specialization for short addresses.
- * 
+ *
  * @tparam
  */
 template <>
@@ -106,7 +116,7 @@ struct UwbMacAddressTypeImpl<UwbMacAddressLength::Short>
 
 /**
  * @brief Address type lookup full specialization for extended addresses.
- * 
+ *
  * @tparam
  */
 template <>
@@ -118,7 +128,7 @@ struct UwbMacAddressTypeImpl<UwbMacAddressLength::Extended>
 /**
  * @brief Helper providing compile-time lookup of UwbMacAddressType for the
  * supported address lengths.
- * 
+ *
  * @tparam Length The compile-time address length, typically from an array extent.
  */
 template <size_t Length>
@@ -127,7 +137,7 @@ inline constexpr UwbMacAddressType UwbMacAddressTypeV = UwbMacAddressTypeImpl<Le
 /**
  * @brief Helper providing compile-time lookup of UwbMacAddress size for the
  * supported address types.
- * 
+ *
  * @tparam AddressType The compile-time address type to get the size for.
  */
 template <UwbMacAddressType AddressType>
@@ -135,12 +145,12 @@ inline constexpr std::size_t UwbMacAddressSizeV = UwbMacAddressSizeImpl<AddressT
 
 /**
  * @brief Type traits for uwb mac addresses.
- * 
+ *
  * This collects traits of uwb mac addresses for compile-time usage, based
  * on the address length. This maps from address length to mac address type,
  * value type (eg. std::array<> with correct extent), and their
  * corresponding types.
- * 
+ *
  * @tparam Length
  */
 template <std::size_t Length>
@@ -155,9 +165,9 @@ struct UwbMacAddressTraits
 
 /**
  * @brief Helper which generically wraps a uwb mac address value.
- * 
+ *
  * This is used later in a templated constructor to allow a single declaration.
- * 
+ *
  * @tparam Length The length of the address.
  */
 template <std::size_t Length>
@@ -196,37 +206,37 @@ public:
 
     /**
      * @brief Get the address type.
-     * 
-     * @return UwbMacAddressType 
+     *
+     * @return UwbMacAddressType
      */
     UwbMacAddressType
     GetType() const noexcept;
 
     /**
      * @brief Get the length of the address, in bytes.
-     * 
-     * @return std::size_t 
+     *
+     * @return std::size_t
      */
     std::size_t
     GetLength() const noexcept;
 
     /**
      * @brief Get a view of the underlying value.
-     * 
-     * @return std::span<const uint8_t> 
+     *
+     * @return std::span<const uint8_t>
      */
     std::span<const uint8_t>
     GetValue() const noexcept;
 
     /**
      * @brief Return a string representation of the address.
-     * 
+     *
      * The address is output as hexadecimal values, separated by colons, eg.
-     *  
+     *
      *     ab (short address)
      *     1a:2f:3e:4d (extended address)
-     * 
-     * @return std::string 
+     *
+     * @return std::string
      */
     std::string
     ToString() const;
@@ -235,10 +245,10 @@ private:
     /**
      * @brief Compile-time helper to retrieve a reference to the active value of
      * the variant holding the mac address.
-     * 
-     * @tparam Length 
-     * @param uwbMacAddress 
-     * @return std::array<uint8_t, Length>& 
+     *
+     * @tparam Length
+     * @param uwbMacAddress
+     * @return std::array<uint8_t, Length>&
      */
     template <size_t Length>
     std::array<uint8_t, Length>&
@@ -250,10 +260,10 @@ private:
     /**
      * @brief Compile-time helper to generate a view of the address based on the
      * selected type.
-     * 
-     * @tparam Length 
-     * @param uwbMacAddress 
-     * @return std::span<const uint8_t> 
+     *
+     * @tparam Length
+     * @param uwbMacAddress
+     * @return std::span<const uint8_t>
      */
     template <size_t Length>
     std::span<const uint8_t>
@@ -266,7 +276,7 @@ private:
     /**
      * @brief Construct a new UwbMacAddress object based on compile-time deduced
      * arguments from a value wrapper.
-     * 
+     *
      * @tparam Length The length of the address.
      * @param value The address value.
      */
@@ -282,9 +292,9 @@ public:
     /**
      * @brief Construct a new UwbMacAddress object based on compile-time deduced
      * arguments.
-     * 
+     *
      * This constructor should be preferred when possible.
-     * 
+     *
      * @tparam Length The length of the address.
      * @param address The address value.
      */
@@ -295,8 +305,8 @@ public:
 
     /**
      * @brief Construct a new, randomly generated UwbMacAddress object based on
-     * compile-time deduced arguments. 
-     * 
+     * compile-time deduced arguments.
+     *
      * @tparam AddressType The type of address to generate.
      * @return UwbMacAddress The randomly generated address value.
      */
@@ -327,29 +337,30 @@ public:
 
     /**
      * @brief Copy constructor.
-     * 
-     * @param other 
+     *
+     * @param other
      */
     UwbMacAddress(const UwbMacAddress& other);
 
     /**
      * @brief Copy assignment operator.
-     * 
+     *
      * @param other
-     * @return UwbMacAddress& 
-      */
+     * @return UwbMacAddress&
+     */
     UwbMacAddress&
     operator=(UwbMacAddress other);
 
     /**
      * @brief Three-way comparison operator.
      */
-    auto operator<=>(const UwbMacAddress& other) const noexcept;
+    auto
+    operator<=>(const UwbMacAddress& other) const noexcept;
 
 private:
     /**
      * @brief Swap the data members of this instance with another one.
-     * 
+     *
      * @param other The other instance to swap with.
      */
     void
@@ -357,11 +368,11 @@ private:
 
     /**
      * @brief Initialize the address view.
-     * 
+     *
      * This is the runtime version that must be used for the copy-constructor,
      * since the other object being copied does not have compile-time address
      * length information available.
-     * 
+     *
      * Note that the assigned view will reflect whatever is in the m_value
      * variant at the time of the call. Thus, m_value must be appropriately
      * initialized prior to invoking this function for the view to be assigned
@@ -372,9 +383,9 @@ private:
 
     /**
      * @brief Allow global equality function to access private members.
-     * 
-     * @return true 
-     * @return false 
+     *
+     * @return true
+     * @return false
      */
     friend bool
     operator==(const UwbMacAddress&, const UwbMacAddress&) noexcept;
@@ -383,14 +394,14 @@ private:
     /**
      * @brief Note: the order of variable declarations here is critical. The
      * m_view member must be declared after m_value since it is a read-only view
-     * of its contents. 
+     * of its contents.
      */
     std::size_t m_length{ UwbMacAddressLength::Short };
     UwbMacAddressType m_type{ UwbMacAddressType::Short };
 
     /**
      * @brief The address value, which depends on the 'm_type' field.
-     * 
+     *
      * Despite the 'm_type' field driving this value, the std::variant is the
      * ultimate ground-truth for the value, and the appropriate methods from
      * that class should be used to obtain it.
@@ -398,7 +409,7 @@ private:
     std::variant<ShortType, ExtendedType> m_value{ ShortType{ 0xBE, 0xEF } };
 
     /**
-     * @brief Read-only view of the address data. 
+     * @brief Read-only view of the address data.
      */
     std::span<const uint8_t> m_view;
 };

--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -11,7 +11,8 @@
 namespace uwb::protocol::fira
 {
 /**
- * @brief Converts the binary representation of the Fira PHY and Mac version to a string.
+ * @brief Converts the binary representation of the Fira PHY and Mac version to
+ * a string.
  *
  * @param input
  * @return std::string
@@ -20,7 +21,8 @@ std::string
 VersionToString(uint32_t input) noexcept;
 
 /**
- * @brief Converts the string representation of the Fira PHY and Mac version to the binary
+ * @brief Converts the string representation of the Fira PHY and Mac version to
+ * the binary.
  *
  * @param input
  * @return std::optional<uint32_t>
@@ -32,9 +34,9 @@ StringToVersion(const std::string& input) noexcept;
  * @brief See FiRa Consortium UWB MAC Technical Requirements v1.3.0, Section
  * 5.1.
  */
-enum class DeviceRole {
-    Initiator,
-    Responder,
+enum class DeviceRole : uint8_t {
+    Responder = 0,
+    Initiator = 1,
 };
 
 /**
@@ -49,41 +51,41 @@ enum class DeviceType {
 /**
  * @brief TODO Add spec reference.
  */
-enum class StsConfiguration {
-    Static,
-    Dynamic,
-    DynamicWithResponderSubSessionKey,
+enum class StsConfiguration : uint8_t {
+    Static = 0,
+    Dynamic = 1,
+    DynamicWithResponderSubSessionKey = 2,
 };
 
 /**
  * @brief See FiRa Consortium UWB MAC Technical Requirements v1.3.0, Section
  * 5.3.
  */
-enum class StsPacketConfiguration {
-    SP0,
-    SP1,
-    SP2,
-    SP3,
+enum class StsPacketConfiguration : uint8_t {
+    SP0 = 0,
+    SP1 = 1,
+    SP2 = 2,
+    SP3 = 3,
 };
 
 /**
  * @brief See FiRa Consortium UWB MAC Technical Requirements v1.3.0, Section
  * 5.4.
  */
-enum class RangingDirection {
-    OneWay,
-    SingleSidedTwoWay,
-    DoubleSidedTwoWay,
+enum class RangingDirection : uint8_t {
+    OneWay = 0,
+    SingleSidedTwoWay = 1,
+    DoubleSidedTwoWay = 2,
 };
 
 /**
  * @brief See FiRa Consortium UWB MAC Technical Requirements v1.3.0, Section
  * 5.5.
  */
-enum class MultiNodeMode {
-    Unicast,
-    OneToMany,
-    ManyToMany,
+enum class MultiNodeMode : uint8_t {
+    Unicast = 0,
+    OneToMany = 1,
+    ManyToMany = 2,
 };
 
 /**
@@ -91,16 +93,17 @@ enum class MultiNodeMode {
  * 5.6.
  */
 enum class SchedulingMode {
-    Contention,
-    Time,
+    Contention = 0,
+    Time = 1,
 };
 
 /**
- * @brief TODO Add spec reference.
+ * @brief See FiRa Consortium UWB MAC Technical Requirements v1.3.0, Section
+ * 7.5.3.3, Table 53.
  */
-enum class RangingMode {
-    Interval,
-    Block,
+enum class RangingMode : uint8_t {
+    Interval = 0,
+    Block = 1,
 };
 
 /**
@@ -123,35 +126,39 @@ enum class AngleOfArrival {
 };
 
 /**
- * @brief TODO Add spec reference.
+ * @brief See FiRa Consortium UWB MAC Technical Requirements v1.3.0, Section
+ * 7.5.3.3, Table 53.
  */
 enum class ConvolutionalCodeConstraintLength {
-    K3,
-    K7,
+    K3 = 0,
+    K7 = 1,
 };
 
 /**
- * @brief TODO Add spec reference.
+ * @brief See FiRa Consortium UWB MAC Technical Requirements v1.3.0, Section
+ * 7.5.3.3, Table 53.
  *
- * Note: The spec does not define channel 7 or 11 which is why it's missing here.
+ * Note: The spec does not define channels 7 nor 11 which is why they're missing
+ * here.
  */
 enum class Channel {
-    C5,
-    C6,
-    C8,
-    C9,
-    C10,
-    C12,
-    C13,
-    C14,
+    C5 = 5,
+    C6 = 6,
+    C8 = 8,
+    C9 = 9,
+    C10 = 10,
+    C12 = 12,
+    C13 = 13,
+    C14 = 14,
 };
 
 /**
- * @brief TODO Add spec reference.
+ * @brief See FiRa Consortium UWB MAC Technical Requirements v1.3.0, Section
+ * 7.5.3.3, Table 53.
  */
 enum class PrfMode {
-    Bprf,
-    Hprf,
+    Bprf = 0,
+    Hprf = 1,
 };
 
 /**
@@ -208,13 +215,14 @@ enum class HprfParameter {
 };
 
 /**
- * @brief TODO: Add spec reference.
+ * @brief See FiRa Consortium UWB MAC Technical Requirements v1.3.0, Section
+ * 7.5.3.3, Table 53.
  */
-enum class ResultReportConfiguration {
-    TofReport,
-    AoAAzimuthReport,
-    AoAElevationReport,
-    AoAFoMReport,
+enum class ResultReportConfiguration : uint8_t {
+    TofReport = 0b00000001,
+    AoAAzimuthReport = 0b00000010,
+    AoAElevationReport = 0b00000100,
+    AoAFoMReport = 0b00001000,
 };
 
 /**
@@ -227,9 +235,9 @@ ResultReportConfigurationToString(const std::unordered_set<ResultReportConfigura
 
 /**
  * @brief Converts a string to vector of ResultReportConfiguration.
- * 
+ *
  * @param input The string input to convert.
- * @return std::optional<std::unordered_set<ResultReportConfiguration>> 
+ * @return std::optional<std::unordered_set<ResultReportConfiguration>>
  */
 std::optional<std::unordered_set<ResultReportConfiguration>>
 StringToResultReportConfiguration(const std::string& input);


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

* Allow underlying values of FiRa enumeration types to be used directly with OOB and session configuration. This PR specifically limits the enumerations to those that are used in the `UwbConfiguration` object.
* Aid cli conversions in #22 

### Technical Details

* Set the underlying type of FIRa enumeration types involved in the `UwbConfiguration` object.
* Apply formatting to changed files.

### Test Results

All unit tests pass on both Linux and Windows.

### Reviewer Focus

None

### Future Work

Apply same logic to other FiRa enumeration types used in various other OOB data structures.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
