### PR TITLE
Expose static libraries for use by simulator project

### DIFF
--- a/lib/shared/notstd/CMakeLists.txt
+++ b/lib/shared/notstd/CMakeLists.txt
@@ -23,7 +23,28 @@ target_include_directories(notstd
         ${NOTSTD_DIR_PUBLIC_INCLUDE}
 )
 
+list(APPEND NOTSTD_PUBLIC_HEADERS
+    ${NOTSTD_DIR_PUBLIC_INCLUDE_PREFIX}/hash.hxx
+    ${NOTSTD_DIR_PUBLIC_INCLUDE_PREFIX}/memory.hxx
+    ${NOTSTD_DIR_PUBLIC_INCLUDE_PREFIX}/range.hxx
+    ${NOTSTD_DIR_PUBLIC_INCLUDE_PREFIX}/tostring.hxx
+    ${NOTSTD_DIR_PUBLIC_INCLUDE_PREFIX}/task_queue.hxx
+    ${NOTSTD_DIR_PUBLIC_INCLUDE_PREFIX}/type_traits.hxx
+    ${NOTSTD_DIR_PUBLIC_INCLUDE_PREFIX}/unique_ptr_out.hxx
+    ${NOTSTD_DIR_PUBLIC_INCLUDE_PREFIX}/utility.hxx
+)
+
 target_link_libraries(notstd
     PUBLIC
         Threads::Threads
+)
+
+set_target_properties(notstd PROPERTIES FOLDER shared/notstd)
+set_target_properties(notstd PROPERTIES PUBLIC_HEADER "${NOTSTD_PUBLIC_HEADERS}")
+
+install(
+    TARGETS notstd
+    EXPORT notstd
+    ARCHIVE
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/notstd
 )

--- a/lib/shared/tlv/CMakeLists.txt
+++ b/lib/shared/tlv/CMakeLists.txt
@@ -18,4 +18,18 @@ target_include_directories(tlv
         ${TLV_DIR_PUBLIC_INCLUDE}
 )
 
+list(APPEND TLV_PUBLIC_HEADERS
+    ${TLV_DIR_PUBLIC_INCLUDE}/Tlv.hxx
+    ${TLV_DIR_PUBLIC_INCLUDE}/TlvBer.hxx
+    ${TLV_DIR_PUBLIC_INCLUDE}/TlvSimple.hxx
+)
+
 set_target_properties(tlv PROPERTIES FOLDER lib/shared/tlv)
+set_target_properties(tlv PROPERTIES PUBLIC_HEADER "${TLV_PUBLIC_HEADERS}")
+
+install(
+    TARGETS tlv
+    EXPORT tlv
+    ARCHIVE
+    PUBLIC_HEADER
+)

--- a/lib/smartcard/CMakeLists.txt
+++ b/lib/smartcard/CMakeLists.txt
@@ -23,4 +23,17 @@ target_link_libraries(smartcard
         tlv
 )
 
+list(APPEND SMARTCARD_PUBLIC_HEADERS
+    ${SMARTCARD_DIR_PUBLIC_INCLUDE_PREFIX}/Apdu.hxx
+    ${SMARTCARD_DIR_PUBLIC_INCLUDE_PREFIX}/Smartcard.hxx
+)
+
 set_target_properties(smartcard PROPERTIES FOLDER lib/smartcard)
+set_target_properties(smartcard PROPERTIES PUBLIC_HEADER "${SMARTCARD_PUBLIC_HEADERS}")
+
+install(
+    TARGETS smartcard
+    EXPORT smartcard
+    ARCHIVE
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/smartcard
+)

--- a/lib/uwb/CMakeLists.txt
+++ b/lib/uwb/CMakeLists.txt
@@ -32,6 +32,22 @@ target_link_libraries(uwb
         uwb-proto-fira
 )
 
+list(APPEND UWB_PUBLIC_HEADERS
+    ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbDevice.hxx
+    ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbMacAddress.hxx
+    ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbPeer.hxx
+    ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbSession.hxx
+    ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbSessionEventCallbacks.hxx
+)
+
 set_target_properties(uwb PROPERTIES FOLDER lib/uwb)
+set_target_properties(uwb PROPERTIES PUBLIC_HEADER "${UWB_PUBLIC_HEADERS}")
+
+install(
+    TARGETS uwb
+    EXPORT uwb
+    ARCHIVE
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/uwb
+)
 
 add_subdirectory(protocols)

--- a/lib/uwb/protocols/fira/CMakeLists.txt
+++ b/lib/uwb/protocols/fira/CMakeLists.txt
@@ -42,6 +42,27 @@ target_link_libraries(uwb-proto-fira
         uwb
 )
 
+list(APPEND UWBPROTOFIRA_PUBLIC_HEADERS
+    ${UWB_PROTO_FIRA_DIR_PUBLIC_INCLUDE_PREFIX}/ControleePreference.hxx
+    ${UWB_PROTO_FIRA_DIR_PUBLIC_INCLUDE_PREFIX}/FiraDevice.hxx
+    ${UWB_PROTO_FIRA_DIR_PUBLIC_INCLUDE_PREFIX}/RangingMethod.hxx
+    ${UWB_PROTO_FIRA_DIR_PUBLIC_INCLUDE_PREFIX}/SecureRangingInfo.hxx
+    ${UWB_PROTO_FIRA_DIR_PUBLIC_INCLUDE_PREFIX}/StaticRangingInfo.hxx
+    ${UWB_PROTO_FIRA_DIR_PUBLIC_INCLUDE_PREFIX}/UwbCapability.hxx
+    ${UWB_PROTO_FIRA_DIR_PUBLIC_INCLUDE_PREFIX}/UwbConfiguration.hxx
+    ${UWB_PROTO_FIRA_DIR_PUBLIC_INCLUDE_PREFIX}/UwbConfigurationBuilder.hxx
+    ${UWB_PROTO_FIRA_DIR_PUBLIC_INCLUDE_PREFIX}/UwbRegulatoryInformation.hxx
+    ${UWB_PROTO_FIRA_DIR_PUBLIC_INCLUDE_PREFIX}/UwbSessionData.hxx
+)
+
 set_target_properties(uwb-proto-fira PROPERTIES FOLDER lib/uwb/protocol/fira)
+set_target_properties(uwb-proto-fira PROPERTIES PUBLIC_HEADER "${UWBPROTOFIRA_PUBLIC_HEADERS}")
+
+install(
+    TARGETS uwb-proto-fira
+    EXPORT uwb-proto-fira
+    ARCHIVE
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/uwb/protocol/fira
+)
 
 add_subdirectory(uci)

--- a/lib/uwb/protocols/fira/uci/CMakeLists.txt
+++ b/lib/uwb/protocols/fira/uci/CMakeLists.txt
@@ -20,4 +20,20 @@ target_include_directories(uwb-proto-fira-uci
         ${UWB_PROTO_FIRA_UCI_DIR_PUBLIC_INCLUDE}
 )
 
+list(APPEND UWBPROTOFIRAUCI_PUBLIC_HEADERS
+    ${UWB_PROTO_FIRA_UCI_DIR_PUBLIC_INCLUDE_PREFIX}/ControlMessage.hxx
+    ${UWB_PROTO_FIRA_UCI_DIR_PUBLIC_INCLUDE_PREFIX}/ControlPacket.hxx
+    ${UWB_PROTO_FIRA_UCI_DIR_PUBLIC_INCLUDE_PREFIX}/DeviceState.hxx
+    ${UWB_PROTO_FIRA_UCI_DIR_PUBLIC_INCLUDE_PREFIX}/SessionState.hxx
+    ${UWB_PROTO_FIRA_UCI_DIR_PUBLIC_INCLUDE_PREFIX}/StatusCodes.hxx
+)
+
 set_target_properties(uwb-proto-fira-uci PROPERTIES FOLDER lib/uwb/protocol/fira)
+set_target_properties(uwb-proto-fira-uci PROPERTIES PUBLIC_HEADER "${UWBPROTOFIRAUCI_PUBLIC_HEADERS}")
+
+install(
+    TARGETS uwb-proto-fira-uci
+    EXPORT uwb-proto-fira-uci
+    ARCHIVE
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/uwb/protocol/fira
+)

--- a/ports/nearobject-framework/portfile.cmake
+++ b/ports/nearobject-framework/portfile.cmake
@@ -1,10 +1,11 @@
 
-vcpkg_from_git(
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    URL "https://github.com/aep-microsoft/nearobject-framework.git"
-    REF 6235d1afc5e31b0a63c5591d5548f7cc17850971
+    REPO microsoft/nearobject-framework
+    REF v0.2.0
+    SHA512 8e18b09c9f8b0594d299d70bfbbe29c44de5959dd4b10bbc07dccbcfbe6a1629d5db1d18200442735da4d4a399b4ffa4ee13e4bf96ecf5117b485a3f679f502e
+    HEAD_REF develop
 )
-
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
@@ -12,9 +13,7 @@ vcpkg_cmake_configure(
         -DNOF_USE_VCPKG=TRUE
         -DNOF_OFFICIAL_BUILD=TRUE
 )
-
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
-
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/windows/nearobjectsvc/CMakeLists.txt
+++ b/windows/nearobjectsvc/CMakeLists.txt
@@ -12,7 +12,7 @@ target_link_libraries(nearobjectsvc
         notstd
 )
 
-set_target_properties(nearobjectsvc PROPERTIES FOLDER linux/service/nearobjectd)
+set_target_properties(nearobjectsvc PROPERTIES FOLDER windows/service)
 
 install(
     TARGETS nearobjectsvc

--- a/windows/shared/CMakeLists.txt
+++ b/windows/shared/CMakeLists.txt
@@ -17,4 +17,16 @@ target_link_libraries(notstd-windows
         WIL::WIL
 )
 
+list(APPEND NOTSTDWINDOWS_PUBLIC_HEADERS
+    ${CMAKE_CURRENT_LIST_DIR}/notstd/guid.hxx
+)
+
 set_target_properties(notstd-windows PROPERTIES FOLDER windows/shared/notstd)
+set_target_properties(notstd-windows PROPERTIES PUBLIC_HEADER "${NOTSTDWINDOWS_PUBLIC_HEADERS}")
+
+install(
+    TARGETS notstd-windows
+    EXPORT notstd-windows
+    ARCHIVE
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/notstd
+)


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [X] Infrastructure

### Goals

Allow the simulator project to ingest the static libraries for use.

### Technical Details

* Define public headers for all utility projects to be exported.
* Define CMake install rules for above projects.
* Update vcpkg port file to use public repo and `v0.2.0` tag.

### Test Results

* CMake install test to a local dir appeared to show all desired files and libs exported.

### Reviewer Focus

Consider whether all dependencies of the exported libs are met.

### Future Work

* Link public libs into simulator driver.
* Release a new tag for the simulator to pull in.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
