### PR TITLE
Add CMake presets for development and vcpkg-integration based builds

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,27 @@
+{
+    "version": 6,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 16
+    },
+    "configurePresets": [
+        {
+            "name": "dev-build",
+            "displayName": "Development",
+            "description": "Enables development build for inner-loop",
+            "cacheVariables": {
+                "NOF_USE_VCPKG": false,
+                "NOF_OFFICIAL_BUILD": false
+            }
+        },
+        {
+            "name": "vcpkg-build",
+            "displayName": "Vcpkg Integration",
+            "description": "Enables development build for integration with vcpkg-based environments",
+            "cacheVariables": {
+                "NOF_USE_VCPKG": true,
+                "NOF_OFFICIAL_BUILD": true
+            }
+        }
+    ]
+}


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [X] Infrastructure

### Goals

Allow common build environments to be easily configured without manual intervention.

### Technical Details

* Add CMake presents for the following build configurations:
    - Development: configures the build for inner loop development
    - vcpkg integration: configures the build for integration with vcpkg-based environments (eg. Windows builds).

### Test Results

* Loaded the project anew VS Code and verified it prompted to select a configure preset. 
* Built with each preset and verified they completed successfully.

### Reviewer Focus

None

### Future Work

* Possibly add build and test presets, if useful.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
