### PR TITLE
Integrate Uwb Simulator driver with static libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,14 @@ elseif (BUILD_FOR_WINDOWS)
       WIN32_LEAN_AND_MEAN
   )
 
+  if (NOF_BUILD_FOR_UMDF)
+    # Enable explicit selection of MSVC runtime library.
+    if (POLICY CMP0091)
+      cmake_policy(SET CMP0091 NEW)
+      set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+    endif()
+  endif()
+
   add_subdirectory(windows)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,12 @@ elseif (BUILD_FOR_WINDOWS)
     # Enable explicit selection of MSVC runtime library.
     if (POLICY CMP0091)
       cmake_policy(SET CMP0091 NEW)
+      # Statically link to the VC++ runtime library. This is required because
+      # when an MSBuild project targets the 'WindowsUserModeDriver10.0' toolset,
+      # the runtime library settings are completely ignored and instead links
+      # staticaly to the VC++ runtime and dynamically to the UCRT. See the
+      # following page for aditional details: more details:
+      # https://learn.microsoft.com/en-us/windows-hardware/drivers/develop/using-the-microsoft-c-runtime-with-user-mode-drivers-and-apps
       set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
     endif()
   endif()

--- a/ports/nearobject-framework-umdf/portfile.cmake
+++ b/ports/nearobject-framework-umdf/portfile.cmake
@@ -2,13 +2,14 @@
 vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL https://github.com/microsoft/nearobject-framework.git
-    REF c7dddb18316c37fc89659e63bc18271ac2609250
+    REF c084972e4643a075feaf7c93f75295e2f1b13fea
 )
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
         -DNOF_DISABLE_TESTS=TRUE
         -DNOF_USE_VCPKG=TRUE
+        -DNOF_OFFICIAL_BUILD=TRUE
         -DNOF_BUILD_FOR_UMDF=TRUE
 )
 vcpkg_cmake_install()

--- a/ports/nearobject-framework-umdf/portfile.cmake
+++ b/ports/nearobject-framework-umdf/portfile.cmake
@@ -1,0 +1,17 @@
+
+vcpkg_from_git(
+    OUT_SOURCE_PATH SOURCE_PATH
+    URL https://github.com/microsoft/nearobject-framework.git
+    REF c7dddb18316c37fc89659e63bc18271ac2609250
+)
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        -DNOF_DISABLE_TESTS=TRUE
+        -DNOF_USE_VCPKG=TRUE
+        -DNOF_BUILD_FOR_UMDF=TRUE
+)
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/windows/drivers/uwb/simulator/UwbSimulator.vcxproj
+++ b/windows/drivers/uwb/simulator/UwbSimulator.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -77,6 +77,7 @@
     <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>true</UseDebugLibraries>
     <UMDF_VERSION_MAJOR>2</UMDF_VERSION_MAJOR>
+    <Driver_SpectreMitigation>Spectre</Driver_SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
@@ -115,6 +116,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnableManifest>true</VcpkgEnableManifest>
+    <VcpkgEnabled>true</VcpkgEnabled>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>

--- a/windows/drivers/uwb/simulator/UwbSimulator.vcxproj
+++ b/windows/drivers/uwb/simulator/UwbSimulator.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -122,6 +122,8 @@
       <LanguageStandard_C>stdc17</LanguageStandard_C>
       <ConformanceMode>false</ConformanceMode>
       <AdditionalIncludeDirectories>$(MSBuildProjectDirectory)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>

--- a/windows/drivers/uwb/simulator/vcpkg.json
+++ b/windows/drivers/uwb/simulator/vcpkg.json
@@ -3,6 +3,6 @@
   "name": "uwbsimulator",
   "version": "1.0",
   "dependencies": [
-    "nearobject-framework"
+    "nearobject-framework-umdf"
   ]
 }


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [X] Infrastructure

### Goals

Allow the Uwb Simulator driver project link against exported static libraries from the main project tree.

### Technical Details

Prior to this change, when linking against a static library in the NOF tree, the VS compiler complained of a mismatch between the runtime library of the driver project itself, and the static library, despite both projects targeting the same one. Through some painstaking debugging, we found that projects which use the `WindowsUserModeDriver10.0` (the driver) will actually ignore the runtime library settings and instead statically link to the VC++ runtime, and does not notify about this, so happens silently.

Consequently, the build configuration was modified to allow requesting that the static VC++ runtime library be linked instead, based on a newly introduced CMake cache variable, `NOF_BUILD_FOR_UMDF`.

* Statically link against VC++ runtime library when requested using ``NOF_BUILD_FOR_UMDF`.
* Add new `vcpkg` port for local umdf driver development.
* Enable static exception handling in the driver.
* Enable spectre mitigations in the driver.
* Enable use of debug runtime for the debug configuration in the driver.
* Enable use of `vcpkg` in the driver.

### Test Results

* Instantiated objects of `libuwb.lib` and built the driver, confirming no linking issues occurred.

### Reviewer Focus

None

### Future Work

* There are some include order issues with some of the windows-specific exported libraries that will need to be corrected before they can be used. If they're not directly involved with the driver, we'll skip this.
* Investigate whether the port file can accept options to dynamically configure the project for use with UMDF, so we can eliminate the UMDF specific port file.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
