### PR TITLE
Publicly export UwbAppConfiguration class

### DIFF
--- a/windows/devices/uwb/CMakeLists.txt
+++ b/windows/devices/uwb/CMakeLists.txt
@@ -1,20 +1,20 @@
 add_library(uwbcxadapter STATIC "")
 
-set(uwbcxadapter_DIR_PUBLIC_INCLUDE ${CMAKE_CURRENT_LIST_DIR}/include)
-set(uwbcxadapter_DIR_PUBLIC_INCLUDE_PREFIX ${uwbcxadapter_DIR_PUBLIC_INCLUDE}/windows/devices/uwb)
+set(UWBCXADAPTER_DIR_PUBLIC_INCLUDE ${CMAKE_CURRENT_LIST_DIR}/include)
+set(UWBCXADAPTER_DIR_PUBLIC_INCLUDE_PREFIX ${UWBCXADAPTER_DIR_PUBLIC_INCLUDE}/windows/devices/uwb)
 
 target_sources(uwbcxadapter
     PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/UwbCxAdapter.cxx
         ${CMAKE_CURRENT_LIST_DIR}/UwbAppConfiguration.cxx
     PUBLIC
-        ${uwbcxadapter_DIR_PUBLIC_INCLUDE_PREFIX}/UwbCxAdapter.hxx
-        ${uwbcxadapter_DIR_PUBLIC_INCLUDE_PREFIX}/UwbAppConfiguration.hxx
+        ${UWBCXADAPTER_DIR_PUBLIC_INCLUDE_PREFIX}/UwbCxAdapter.hxx
+        ${UWBCXADAPTER_DIR_PUBLIC_INCLUDE_PREFIX}/UwbAppConfiguration.hxx
 )
 
 target_include_directories(uwbcxadapter
     PUBLIC
-        ${uwbcxadapter_DIR_PUBLIC_INCLUDE}
+        ${UWBCXADAPTER_DIR_PUBLIC_INCLUDE}
 )
 
 target_link_libraries(uwbcxadapter
@@ -29,7 +29,8 @@ target_link_libraries(uwbcxadapter
 )
 
 list(APPEND uwbcxadapter_PUBLIC_HEADERS
-    ${uwbcxadapter_DIR_PUBLIC_INCLUDE_PREFIX}/UwbCxAdapter.hxx
+    ${UWBCXADAPTER_DIR_PUBLIC_INCLUDE_PREFIX}/UwbCxAdapter.hxx
+    ${UWBCXADAPTER_DIR_PUBLIC_INCLUDE_PREFIX}/UwbAppConfiguration.hxx
 )
 
 set_target_properties(uwbcxadapter PROPERTIES FOLDER windows/devices)


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [X] Non-functional change
- [ ] Documentation
- [X] Infrastructure

### Goals

Ensure the `IUwbAppConfigurationParameter`, `UwbAppConfigurationParameter`, and `UwbSetAppConfigurationParameters` classes are exported such that they're available for use in the simulator driver.

### Technical Details

* Add `UwbAppConfiguration.hxx` to the public header list.
* Update casing of variables in `CMakeLists.txt` to be consistent with other CMake variable naming.

### Test Results

Performed a `cmake install` and verified that `UwbAppConfiguration.hxx` showed up in the `include` tree.

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
