### PR TITLE
Move adaptor code from windows::devices to windows::devices::uwb

### DIFF
--- a/tests/unit/windows/TestUwbAppConfiguration.cxx
+++ b/tests/unit/windows/TestUwbAppConfiguration.cxx
@@ -12,7 +12,7 @@
 
 TEST_CASE("UwbAppConfiguration performs allocation for contained value correctly", "[basic]")
 {
-    using windows::devices::UwbAppConfigurationParameter;
+    using windows::devices::uwb::UwbAppConfigurationParameter;
     using namespace uwb::protocol::fira;
 
     SECTION("DDI type is correctly reflected")
@@ -143,12 +143,12 @@ TEST_CASE("UwbAppConfiguration performs allocation for contained value correctly
 
 TEST_CASE("UwbSetAppConfigurationParameters performs allocation for contained values correctly", "[basic]")
 {
-    using windows::devices::UwbAppConfigurationParameter;
+    using windows::devices::uwb::UwbAppConfigurationParameter;
     using namespace uwb::protocol::fira;
 
     SECTION("One parameter case")
     {
-        using namespace windows::devices;
+        using namespace windows::devices::uwb;
         std::vector<std::unique_ptr<IUwbAppConfigurationParameter>> parameters;
         uint32_t expectedSessionId = 1;
 
@@ -167,7 +167,7 @@ TEST_CASE("UwbSetAppConfigurationParameters performs allocation for contained va
 
     SECTION("One enum parameter and one mac address parameter case")
     {
-        using namespace windows::devices;
+        using namespace windows::devices::uwb;
         std::vector<std::unique_ptr<IUwbAppConfigurationParameter>> parameters;
         uint32_t expectedSessionId = 1;
 
@@ -204,11 +204,11 @@ TEST_CASE("GenerateUwbSetAppConfigParameterDdi works", "[basic]")
 
     SECTION("enum works")
     {
-        using namespace windows::devices;
+        using namespace windows::devices::uwb;
 
         constexpr DeviceRole roleExpected{ DeviceRole::Initiator };
         const auto parameterTag = UwbConfiguration::ParameterTag::DeviceRole;
-        const auto ddiType = windows::devices::detail::AppConfigUwbConfigurationTagMap.at(parameterTag);
+        const auto ddiType = windows::devices::uwb::detail::AppConfigUwbConfigurationTagMap.at(parameterTag);
 
         // construct the sessionData and push it thru the GenerateUwbSetAppConfigParameterDdi function
         UwbSessionData sessionData;
@@ -233,11 +233,11 @@ TEST_CASE("GenerateUwbSetAppConfigParameterDdi works", "[basic]")
 
     SECTION("short mac address works")
     {
-        using namespace windows::devices;
+        using namespace windows::devices::uwb;
 
         constexpr std::array<uint8_t, 2> dstMacAddressExpected{ 0xAAU, 0xBBU };
         const auto parameterTag = UwbConfiguration::ParameterTag::ControleeShortMacAddress;
-        const auto ddiType = windows::devices::detail::AppConfigUwbConfigurationTagMap.at(parameterTag);
+        const auto ddiType = windows::devices::uwb::detail::AppConfigUwbConfigurationTagMap.at(parameterTag);
 
         // construct the sessionData and push it thru the GenerateUwbSetAppConfigParameterDdi function
         UwbSessionData sessionData;
@@ -262,11 +262,11 @@ TEST_CASE("GenerateUwbSetAppConfigParameterDdi works", "[basic]")
 
     SECTION("long mac address works")
     {
-        using namespace windows::devices;
+        using namespace windows::devices::uwb;
 
         constexpr std::array<uint8_t, 8> macAddressExpected{ 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77 };
         const auto parameterTag = UwbConfiguration::ParameterTag::ControllerMacAddress;
-        const auto ddiType = windows::devices::detail::AppConfigUwbConfigurationTagMap.at(parameterTag);
+        const auto ddiType = windows::devices::uwb::detail::AppConfigUwbConfigurationTagMap.at(parameterTag);
 
         // construct the sessionData and push it thru the GenerateUwbSetAppConfigParameterDdi function
         UwbSessionData sessionData;
@@ -291,11 +291,11 @@ TEST_CASE("GenerateUwbSetAppConfigParameterDdi works", "[basic]")
 
     SECTION("uint16_t works")
     {
-        using namespace windows::devices;
+        using namespace windows::devices::uwb;
 
         constexpr uint16_t slotDurationExpected = 0xFF20;
         const auto parameterTag = UwbConfiguration::ParameterTag::SlotDuration;
-        const auto ddiType = windows::devices::detail::AppConfigUwbConfigurationTagMap.at(parameterTag);
+        const auto ddiType = windows::devices::uwb::detail::AppConfigUwbConfigurationTagMap.at(parameterTag);
 
         // construct the sessionData and push it thru the GenerateUwbSetAppConfigParameterDdi function
         UwbSessionData sessionData;
@@ -320,11 +320,11 @@ TEST_CASE("GenerateUwbSetAppConfigParameterDdi works", "[basic]")
 
     SECTION("uint32_t works")
     {
-        using namespace windows::devices;
+        using namespace windows::devices::uwb;
 
         constexpr uint32_t uwbInitiationTimeExpected = 0x2000;
         constexpr auto parameterTag = UwbConfiguration::ParameterTag::UwbInitiationTime;
-        const auto ddiType = windows::devices::detail::AppConfigUwbConfigurationTagMap.at(parameterTag);
+        const auto ddiType = windows::devices::uwb::detail::AppConfigUwbConfigurationTagMap.at(parameterTag);
 
         // construct the sessionData and push it thru the GenerateUwbSetAppConfigParameterDdi function
         UwbSessionData sessionData;
@@ -349,11 +349,11 @@ TEST_CASE("GenerateUwbSetAppConfigParameterDdi works", "[basic]")
 
     SECTION("RangingMethod works")
     {
-        using namespace windows::devices;
+        using namespace windows::devices::uwb;
 
         constexpr RangingMethod RangingMethodValue{ RangingDirection::SingleSidedTwoWay, MeasurementReportMode::Deferred };
         const auto parameterTag = UwbConfiguration::ParameterTag::RangingMethod;
-        const auto ddiType = windows::devices::detail::AppConfigUwbConfigurationTagMap.at(parameterTag);
+        const auto ddiType = windows::devices::uwb::detail::AppConfigUwbConfigurationTagMap.at(parameterTag);
 
         // construct the sessionData and push it thru the GenerateUwbSetAppConfigParameterDdi function
         UwbSessionData sessionData;
@@ -378,7 +378,7 @@ TEST_CASE("GenerateUwbSetAppConfigParameterDdi works", "[basic]")
 
     SECTION("ResultReportConfig works")
     {
-        using namespace windows::devices;
+        using namespace windows::devices::uwb;
 
         constexpr ResultReportConfiguration ResultReportConfigurationValue1{ ResultReportConfiguration::AoAAzimuthReport };
         constexpr ResultReportConfiguration ResultReportConfigurationValue2{ ResultReportConfiguration::AoAElevationReport };
@@ -386,7 +386,7 @@ TEST_CASE("GenerateUwbSetAppConfigParameterDdi works", "[basic]")
         constexpr ResultReportConfiguration ResultReportConfigurationValue4{ ResultReportConfiguration::TofReport };
 
         const auto parameterTag = UwbConfiguration::ParameterTag::ResultReportConfig;
-        const auto ddiType = windows::devices::detail::AppConfigUwbConfigurationTagMap.at(parameterTag);
+        const auto ddiType = windows::devices::uwb::detail::AppConfigUwbConfigurationTagMap.at(parameterTag);
 
         // construct the sessionData and push it thru the GenerateUwbSetAppConfigParameterDdi function
         UwbSessionData sessionData;

--- a/windows/devices/uwb/UwbAppConfiguration.cxx
+++ b/windows/devices/uwb/UwbAppConfiguration.cxx
@@ -13,7 +13,7 @@ operator==(const UWB_APP_CONFIG_PARAM& lhs, const UWB_APP_CONFIG_PARAM& rhs) noe
     return (lhs.size == rhs.size) && (std::memcmp(&lhs, &rhs, lhs.size) == 0);
 }
 
-using namespace windows::devices;
+using namespace windows::devices::uwb;
 
 IUwbAppConfigurationParameter::IUwbAppConfigurationParameter(UWB_APP_CONFIG_PARAM_TYPE parameterType, std::span<const uint8_t> parameterValue) :
     m_buffer(offsetof(UWB_APP_CONFIG_PARAM, paramValue[parameterValue.size()])),

--- a/windows/devices/uwb/UwbCxAdapter.cxx
+++ b/windows/devices/uwb/UwbCxAdapter.cxx
@@ -5,7 +5,7 @@
 
 #include <windows/devices/uwb/UwbAppConfiguration.hxx>
 
-using namespace windows::devices;
+using namespace windows::devices::uwb;
 
 UwbSetAppConfigurationParameters
 windows::devices::uwb::GenerateUwbSetAppConfigParameterDdi(const ::uwb::protocol::fira::UwbSessionData& uwbSessionData)

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbAppConfiguration.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbAppConfiguration.hxx
@@ -17,7 +17,7 @@
 
 #include <UwbCxLrpDeviceGlue.h>
 
-namespace windows::devices
+namespace windows::devices::uwb
 {
 /**
  * @brief Interface for UWB_APP_CONFIG_PARAM UwbCx DDI structure adaptor.
@@ -172,7 +172,7 @@ private:
     std::vector<uint8_t> m_buffer;
     UWB_SET_APP_CONFIG_PARAMS& m_parameters;
 };
-} // namespace windows::devices
+} // namespace windows::devices::uwb
 
 bool
 operator==(const UWB_APP_CONFIG_PARAM& lhs, const UWB_APP_CONFIG_PARAM& rhs) noexcept;


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [X] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Ensure code lives in logical namespaces.


### Technical Details

* Move uwb related code from `windows::devices` to `windows::devices::uwb`.

### Test Results

All unit tests pass on Windows.

### Reviewer Focus

None

### Future Work

Determine if additional code needs to similarly move. 

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
