### PR TITLE
Move Windows smartcard lib code to windows::devices::smartcards

### DIFF
--- a/windows/devices/smartcard/CMakeLists.txt
+++ b/windows/devices/smartcard/CMakeLists.txt
@@ -25,12 +25,12 @@ list(APPEND SMARTCARD_PUBLIC_HEADERS
     ${SMARTCARD_DIR_PUBLIC_INCLUDE_PREFIX}/Smartcard.hxx
 )
 
-set_target_properties(windevsmartcard PROPERTIES FOLDER windows/devices)
+set_target_properties(windevsmartcard PROPERTIES FOLDER windows/devices/smartcard)
 
 set_target_properties(windevsmartcard PROPERTIES PUBLIC_HEADER "${SMARTCARD_PUBLIC_HEADERS}")
 
 install(
     TARGETS windevsmartcard
     EXPORT smartcard
-    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/windows/smartcard
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/windows/devices/smartcard
 )

--- a/windows/devices/smartcard/Smartcard.cxx
+++ b/windows/devices/smartcard/Smartcard.cxx
@@ -3,7 +3,7 @@
 
 #include <stdexcept>
 
-using namespace windows::devices;
+using namespace windows::devices::smartcards;
 
 void
 Smartcard::TransmitImpl(const smartcard::ApduCommand& command, smartcard::ApduResponse& response, std::chrono::milliseconds timeout)

--- a/windows/devices/smartcard/include/windows/smartcard/Smartcard.hxx
+++ b/windows/devices/smartcard/include/windows/smartcard/Smartcard.hxx
@@ -10,9 +10,7 @@
 
 #include <smartcard/Smartcard.hxx>
 
-namespace windows
-{
-namespace devices
+namespace windows::devices::smartcards
 {
 /**
  * @brief Helper class to interact with Windows SmartCards using the Windows SmartCard DDI:
@@ -60,7 +58,6 @@ private:
     std::optional<std::promise<smartcard::ApduResponse>> m_pendingTxResponsePromise;
 };
 
-} // namespace devices
-} // namespace windows
+} // namespace windows::devices::smartcards
 
 #endif // WINDOWS_DEVICE_SMARTCARD_HXX


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [X] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Ensure code lives in predictable, consistently named namespaces.

### Technical Details

* Move Windows smartcard code from `windows:;devices` to `windows::devices::smartcard`.

### Test Results

* All unit tests pass on both Linux and Windows.

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
