### PR TITLE
Remove vcpkg submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vcpkg"]
-	path = vcpkg
-	url = https://github.com/microsoft/vcpkg.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,8 @@
 cmake_minimum_required(VERSION 3.16)
 
-# Option to enable statically linking against the VC++ runtime library.
+# Project configuration options.
 option(NOF_USE_MSVC_STATIC_RUNTIME, "Statically link against the VC++ runtime library" OFF)
-
-# Configuration option for using vcpkg to satisfy source package dependencies.
-# This must be set to ON for official Windows builds.
 option(NOF_USE_VCPKG "Use vcpkg for obtaining source dependencies" OFF)
-
-# Option to specify the project is being built as part of Windows.
 option(NOF_WINDOWS_BUILD "Configure the project for an official Windows build" OFF)
 
 # Ensure vcpkg is enabled for the Windows build.
@@ -15,22 +10,7 @@ if (NOF_WINDOWS_BUILD AND NOT NOF_USE_VCPKG)
   set(NOF_USE_VCPKG CACHE BOOL ON "Enable vcpkg for Windows build")
 endif()
 
-# Select source package dependency manager based on selected option.
-# This must occur prior to the first project() statement.
 if (NOF_USE_VCPKG)
-  # if (NOT NOF_WINDOWS_BUILD)
-  #   find_package(Git REQUIRED)
-  #   set(VCPKG_SUBMODULE_ROOT ${CMAKE_CURRENT_LIST_DIR}/vcpkg)
-
-  #   # Initialize vcpkg sub-module if not already done.
-  #   if (NOT EXISTS ${VCPKG_SUBMODULE_ROOT}/.git)
-  #     execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive -- ${VCPKG_SUBMODULE_ROOT}
-  #       WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR} 
-  #       COMMAND_ERROR_IS_FATAL ANY)
-  #   endif()
-
-  #   set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake" CACHE STRING "vcpkg toolchain file")
-  # endif()
   MESSAGE(STATUS "using vcpkg for source dependencies")
 else()
   MESSAGE(STATUS "using FetchContent for source dependencies")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,19 +18,19 @@ endif()
 # Select source package dependency manager based on selected option.
 # This must occur prior to the first project() statement.
 if (NOF_USE_VCPKG)
-  if (NOT NOF_WINDOWS_BUILD)
-    find_package(Git REQUIRED)
-    set(VCPKG_SUBMODULE_ROOT ${CMAKE_CURRENT_LIST_DIR}/vcpkg)
+  # if (NOT NOF_WINDOWS_BUILD)
+  #   find_package(Git REQUIRED)
+  #   set(VCPKG_SUBMODULE_ROOT ${CMAKE_CURRENT_LIST_DIR}/vcpkg)
 
-    # Initialize vcpkg sub-module if not already done.
-    if (NOT EXISTS ${VCPKG_SUBMODULE_ROOT}/.git)
-      execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive -- ${VCPKG_SUBMODULE_ROOT}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR} 
-        COMMAND_ERROR_IS_FATAL ANY)
-    endif()
+  #   # Initialize vcpkg sub-module if not already done.
+  #   if (NOT EXISTS ${VCPKG_SUBMODULE_ROOT}/.git)
+  #     execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive -- ${VCPKG_SUBMODULE_ROOT}
+  #       WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR} 
+  #       COMMAND_ERROR_IS_FATAL ANY)
+  #   endif()
 
-    set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake" CACHE STRING "vcpkg toolchain file")
-  endif()
+  #   set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake" CACHE STRING "vcpkg toolchain file")
+  # endif()
   MESSAGE(STATUS "using vcpkg for source dependencies")
 else()
   MESSAGE(STATUS "using FetchContent for source dependencies")

--- a/ports/nearobject-framework/portfile.cmake
+++ b/ports/nearobject-framework/portfile.cmake
@@ -6,12 +6,14 @@ vcpkg_from_github(
     SHA512 34013159a09cfd52e297529cff115b4392dec536c02b2260548b25bb1abf4702a0641e61b3c83401c4002df7bb456175b7e5277cd862d6e7972fc12312c03ae4
     HEAD_REF develop
 )
+
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         msvc-link-static-runtime NOF_USE_MSVC_STATIC_RUNTIME
         windows-build NOF_WINDOWS_BUILD
 )
+
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
@@ -20,7 +22,9 @@ vcpkg_cmake_configure(
         -DNOF_DISABLE_TESTS=TRUE
         ${FEATURE_OPTIONS}
 )
+
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/nearobject-framework/portfile.cmake
+++ b/ports/nearobject-framework/portfile.cmake
@@ -15,6 +15,8 @@ vcpkg_check_features(
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
+        -DVCPKG_MANIFEST_DIR=${SOURCE_PATH}/ports/nearobject-framework
+        -DNOF_USE_VCPKG=TRUE
         -DNOF_DISABLE_TESTS=TRUE
         ${FEATURE_OPTIONS}
 )


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [X] Non-functional change
- [ ] Documentation
- [X] Infrastructure

### Goals

Avoid use of sub-modules where possible.

### Technical Details

* Removed use of `vcpkg` submodule in the repository. There is no longer any need for it, as the two uses (Windows build, simulator drvier) are guaranteed to have `vcpkg` installed.

### Test Results

* Successfully built the simulator driver locally.
* Successfully built the nearobject tree in Windows.

### Reviewer Focus

None

### Future Work

Eventually submit the complete port for inclusion in the public `vcpkg` registry.

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
