### PR TITLE
Add code coverage build option

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,2 @@
+- name: Codecov
+  uses: codecov/codecov-action@v3.1.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(VERSION 3.16)
 option(NOF_USE_MSVC_STATIC_RUNTIME, "Statically link against the VC++ runtime library" OFF)
 option(NOF_USE_VCPKG "Use vcpkg for obtaining source dependencies" OFF)
 option(NOF_WINDOWS_BUILD "Configure the project for an official Windows build" OFF)
+option(NOF_ENABLE_CODE_COVERAGE "Enable instrumenting the build with code coverage" OFF)
 
 # Ensure vcpkg is enabled for the Windows build.
 if (NOF_WINDOWS_BUILD AND NOT NOF_USE_VCPKG)
@@ -131,8 +132,20 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GN
       -Wl,-z,relro
       -z noexecstack
     )
+    if (NOF_ENABLE_CODE_COVERAGE)
+      add_compile_options(
+        -fprofile-arcs
+        -ftest-coverage
+      )
+    endif()
+  # clang specific options
   elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    # clang specific options, presently none
+    if (NOF_ENABLE_CODE_COVERAGE)
+      add_compile_options(
+        -fprofile-instr-generate
+        -fcoverage-mapping
+      )
+    endif()
   endif()
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   # TODO


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [X] Non-functional change
- [ ] Documentation
- [X] Infrastructure

### Goals

Allow the project to be measured for testing coverage.

### Technical Details

* Add build flags for gcc and clang to enable profiling code coverage.
* Add CMake option to opt-in to code coverage instrumentation.
* Add placeholder `codecov` github workflow file.

### Test Results

Successfully compiled on Windows using the MSVC toolchain with LLVM/clang as the compiler and verified the raw `.profraw` coverage files were present for binary targets.

### Reviewer Focus

None

### Future Work

Figure out how to get coverage with basic MSVC toolchain with VC++ compiler.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
