### PR TITLE
Explicitly set plog version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ set(VERSION_NLOHMANN_JSON 3.11.2)
 set(VERSION_MAGIC_ENUM 0.8.1)
 set(VERSION_CLI11 2.2.0)
 set(VERSION_CATCH2 3.1.0)
-set(VERSION PLOG 1.1.9)
+set(VERSION_PLOG 1.1.9)
 
 # Pull in external dependencies.
 if (NOF_USE_VCPKG)


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Ensure plog is sourced at a specific version to ensure build stability.

### Technical Details

* Fix typo introduced in #49 which missed an underscore in the CMake variable name for the version.

### Test Results

Built the project with the `vcpkg-dev` preset and manually inspected the vcpkg build tree to ensure that version 1.1.9 was present.

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
