### PR TITLE
Define simulator driver DDI handler interface

### DIFF
--- a/windows/drivers/uwb/simulator/UwbSimulator.vcxproj
+++ b/windows/drivers/uwb/simulator/UwbSimulator.vcxproj
@@ -101,6 +101,7 @@
       <AdditionalIncludeDirectories>$(MSBuildProjectDirectory)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ExceptionHandling>Sync</ExceptionHandling>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <PreprocessorDefinitions>NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
@@ -110,6 +111,7 @@
     <ClCompile>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
+      <PreprocessorDefinitions>NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>

--- a/windows/drivers/uwb/simulator/UwbSimulator.vcxproj
+++ b/windows/drivers/uwb/simulator/UwbSimulator.vcxproj
@@ -9,14 +9,6 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
-    <ProjectConfiguration Include="Debug|ARM64">
-      <Configuration>Debug</Configuration>
-      <Platform>ARM64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|ARM64">
-      <Configuration>Release</Configuration>
-      <Platform>ARM64</Platform>
-    </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="UwbSimulatorDdiHandlerLrp.cxx" />

--- a/windows/drivers/uwb/simulator/UwbSimulator.vcxproj
+++ b/windows/drivers/uwb/simulator/UwbSimulator.vcxproj
@@ -19,6 +19,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="UwbSimulatorDdiHandlerLrp.cxx" />
     <ClCompile Include="UwbSimulatorDriver.cxx" />
     <ClCompile Include="UwbSimulatorDdiCallbacksLrpNoop.cxx" />
     <ClCompile Include="UwbSimulatorIoQueue.cxx" />
@@ -27,6 +28,8 @@
     <ClCompile Include="UwbSimulatorTracelogging.cxx" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="UwbSimulatorDdiHandler.hxx" />
+    <ClInclude Include="UwbSimulatorDdiHandlerLrp.hxx" />
     <ClInclude Include="UwbSimulatorDriver.hxx" />
     <ClInclude Include="include\UwbSimulatorDdi.h" />
     <ClInclude Include="UwbCxLrpDevice.h" />

--- a/windows/drivers/uwb/simulator/UwbSimulator.vcxproj
+++ b/windows/drivers/uwb/simulator/UwbSimulator.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -63,16 +63,6 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <DriverTargetPlatform>Universal</DriverTargetPlatform>
   </PropertyGroup>
-  <PropertyGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <PlatformToolset>WindowsUserModeDriver10.0</PlatformToolset>
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <DriverTargetPlatform>Universal</DriverTargetPlatform>
-  </PropertyGroup>
-  <PropertyGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-    <PlatformToolset>WindowsUserModeDriver10.0</PlatformToolset>
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <DriverTargetPlatform>Universal</DriverTargetPlatform>
-  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
@@ -81,16 +71,6 @@
     <Driver_SpectreMitigation>Spectre</Driver_SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <TargetVersion>Windows10</TargetVersion>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <UMDF_VERSION_MAJOR>2</UMDF_VERSION_MAJOR>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
-    <TargetVersion>Windows10</TargetVersion>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <UMDF_VERSION_MAJOR>2</UMDF_VERSION_MAJOR>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>false</UseDebugLibraries>
     <UMDF_VERSION_MAJOR>2</UMDF_VERSION_MAJOR>
@@ -107,12 +87,6 @@
     <PublicIncludeDirectories>$(MSBuildProjectDirectory)\include;$(PublicIncludeDirectories)</PublicIncludeDirectories>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <DebuggerFlavor>DbgengRemoteDebugger</DebuggerFlavor>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <DebuggerFlavor>DbgengRemoteDebugger</DebuggerFlavor>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <DebuggerFlavor>DbgengRemoteDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
@@ -137,16 +111,6 @@
       <LanguageStandard>stdcpp20</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
     </ClCompile>
-    <DriverSign>
-      <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
-    </DriverSign>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <DriverSign>
-      <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
-    </DriverSign>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
     </DriverSign>

--- a/windows/drivers/uwb/simulator/UwbSimulator.vcxproj
+++ b/windows/drivers/uwb/simulator/UwbSimulator.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -12,6 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="UwbSimulatorDdiHandlerLrp.cxx" />
+    <ClCompile Include="UwbSimulatorDispatchEntry.cxx" />
     <ClCompile Include="UwbSimulatorDriver.cxx" />
     <ClCompile Include="UwbSimulatorDdiCallbacksLrpNoop.cxx" />
     <ClCompile Include="UwbSimulatorIoQueue.cxx" />
@@ -22,6 +23,7 @@
   <ItemGroup>
     <ClInclude Include="UwbSimulatorDdiHandler.hxx" />
     <ClInclude Include="UwbSimulatorDdiHandlerLrp.hxx" />
+    <ClInclude Include="UwbSimulatorDispatchEntry.hxx" />
     <ClInclude Include="UwbSimulatorDriver.hxx" />
     <ClInclude Include="include\UwbSimulatorDdi.h" />
     <ClInclude Include="UwbCxLrpDevice.h" />

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacksLrp.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacksLrp.hxx
@@ -21,6 +21,8 @@ namespace windows::devices::uwb::simulator
  */
 struct UwbSimulatorDdiCallbacksLrp
 {
+    virtual ~UwbSimulatorDdiCallbacksLrp() = default;
+
     /**
      * @brief
      *

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.hxx
@@ -1,0 +1,46 @@
+
+#ifndef UWB_SIMULATOR_DDI_HANDLER_HXX 
+#define UWB_SIMULATOR_DDI_HANDLER_HXX
+
+#include <cstddef>
+
+#include <windows.h>
+
+#include <wdf.h>
+
+namespace windows::devices::uwb::simulator
+{
+/**
+ * @brief Base class which is responsible for handling DDI i/o control
+ * requests.
+ */
+struct UwbSimulatorDdiHandler
+{
+    virtual ~UwbSimulatorDdiHandler() = default;
+
+    /**
+     * @brief Indicates whether the specified i/o control code is handled by
+     * this handler. 
+     * 
+     * @param ioControlCode The i/o control code to check.
+     * @return true 
+     * @return false 
+     */
+    virtual bool
+    HandlesIoControlCode(ULONG ioControlCode) const noexcept = 0;
+
+    /**
+     * @brief 
+     * 
+     * @param request 
+     * @param outputBufferLength 
+     * @param inputBufferLength 
+     * @param ioControlCode 
+     * @return NTSTATUS 
+     */
+    virtual NTSTATUS
+    HandleRequest(WDFREQUEST request, std::size_t outputBufferLength, std::size_t inputBufferLength, ULONG ioControlCode) = 0;
+};
+} // namespace windows::devices::uwb::simulator
+
+#endif // UWB_SIMULATOR_DDI_HANDLER_HXX

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.hxx
@@ -45,7 +45,7 @@ struct UwbSimulatorDdiHandler
     ValidateRequest(WDFREQUEST request, ULONG ioControlCode, std::size_t inputBufferLength, std::size_t outputBufferLength) = 0;
 
     /**
-     * @brief
+     * @brief Handles the request.
      *
      * @param request
      * @param ioControlCode

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.hxx
@@ -1,5 +1,5 @@
 
-#ifndef UWB_SIMULATOR_DDI_HANDLER_HXX 
+#ifndef UWB_SIMULATOR_DDI_HANDLER_HXX
 #define UWB_SIMULATOR_DDI_HANDLER_HXX
 
 #include <cstddef>
@@ -12,8 +12,7 @@
 namespace windows::devices::uwb::simulator
 {
 /**
- * @brief Base class which is responsible for handling DDI i/o control
- * requests.
+ * @brief Base class which responsible for handling DDI i/o control requests.
  */
 struct UwbSimulatorDdiHandler
 {
@@ -21,29 +20,41 @@ struct UwbSimulatorDdiHandler
 
     /**
      * @brief Indicates whether the specified i/o control code is handled by
-     * this handler. 
-     * 
+     * this handler.
+     *
      * @param ioControlCode The i/o control code to check.
-     * @return true 
-     * @return false 
+     * @return true
+     * @return false
      */
     virtual bool
-    HandlesIoControlCode(ULONG ioControlCode) const noexcept = 0;
-
-    // virtual NTSTATUS
-    // ValidateRequest(WDFREQUEST request, std::size_t outputBufferLength, )
+    HandlesIoControlCode(ULONG ioControlCode) = 0;
 
     /**
-     * @brief 
-     * 
-     * @param request 
-     * @param outputBuffer 
-     * @param inputBuffer 
-     * @param ioControlCode 
-     * @return NTSTATUS 
+     * @brief Validates that a given request is valid.
+     *
+     * This is responsible for validating that the input and output buffers are
+     * of sufficient length.
+     *
+     * @param request
+     * @param ioControlCode
+     * @param inputBufferLength
+     * @param outputBufferLength
+     * @return NTSTATUS
      */
     virtual NTSTATUS
-    HandleRequest(WDFREQUEST request, std::span<uint8_t> outputBuffer, std::span<uint8_t> inputBuffer, ULONG ioControlCode) = 0;
+    ValidateRequest(WDFREQUEST request, ULONG ioControlCode, std::size_t inputBufferLength, std::size_t outputBufferLength) = 0;
+
+    /**
+     * @brief
+     *
+     * @param request
+     * @param ioControlCode
+     * @param inputBuffer
+     * @param outputBuffer
+     * @return NTSTATUS
+     */
+    virtual NTSTATUS
+    HandleRequest(WDFREQUEST request, ULONG ioControlCode, std::span<uint8_t> inputBuffer, std::span<uint8_t> outputBuffer) = 0;
 };
 } // namespace windows::devices::uwb::simulator
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.hxx
@@ -3,6 +3,7 @@
 #define UWB_SIMULATOR_DDI_HANDLER_HXX
 
 #include <cstddef>
+#include <span>
 
 #include <windows.h>
 
@@ -29,17 +30,20 @@ struct UwbSimulatorDdiHandler
     virtual bool
     HandlesIoControlCode(ULONG ioControlCode) const noexcept = 0;
 
+    // virtual NTSTATUS
+    // ValidateRequest(WDFREQUEST request, std::size_t outputBufferLength, )
+
     /**
      * @brief 
      * 
      * @param request 
-     * @param outputBufferLength 
-     * @param inputBufferLength 
+     * @param outputBuffer 
+     * @param inputBuffer 
      * @param ioControlCode 
      * @return NTSTATUS 
      */
     virtual NTSTATUS
-    HandleRequest(WDFREQUEST request, std::size_t outputBufferLength, std::size_t inputBufferLength, ULONG ioControlCode) = 0;
+    HandleRequest(WDFREQUEST request, std::span<uint8_t> outputBuffer, std::span<uint8_t> inputBuffer, ULONG ioControlCode) = 0;
 };
 } // namespace windows::devices::uwb::simulator
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.cxx
@@ -1,16 +1,44 @@
 
+#include "UwbCxLrpDeviceGlue.h"
+
 #include "UwbSimulatorDdiHandlerLrp.hxx"
+#include "UwbSimulatorDdiCallbacksLrpNoop.hxx"
 
 using namespace windows::devices::uwb::simulator;
 
-bool
-UwbSimulatorDdiHandlerLrp::HandlesIoControlCode(ULONG /* ioControlCode */) const noexcept
+UwbSimulatorDdiHandlerLrp::UwbSimulatorDdiHandlerLrp() :
+    m_callbacks(std::make_unique<UwbSimulatorDdiCallbacksLrpNoop>())
 {
-    return false; 
+}
+
+bool
+UwbSimulatorDdiHandlerLrp::HandlesIoControlCode(ULONG ioControlCode) const noexcept
+{
+    switch (ioControlCode) {
+    case IOCTL_UWB_DEVICE_RESET:
+    case IOCTL_UWB_GET_APP_CONFIG_PARAMS:
+    case IOCTL_UWB_GET_DEVICE_CAPABILITIES:
+    case IOCTL_UWB_GET_DEVICE_CONFIG_PARAMS:
+    case IOCTL_UWB_GET_DEVICE_INFO:
+    case IOCTL_UWB_GET_RANGING_COUNT:
+    case IOCTL_UWB_GET_SESSION_COUNT:
+    case IOCTL_UWB_GET_SESSION_STATE:
+    case IOCTL_UWB_NOTIFICATION:
+    case IOCTL_UWB_SESSION_DEINIT:
+    case IOCTL_UWB_SESSION_INIT:
+    case IOCTL_UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST:
+    case IOCTL_UWB_SET_APP_CONFIG_PARAMS:
+    case IOCTL_UWB_SET_DEVICE_CONFIG_PARAMS:
+    case IOCTL_UWB_START_RANGING_SESSION:
+    case IOCTL_UWB_STOP_RANGING_SESSION:
+        return true;
+    }
+
+    return false;
 }
 
 NTSTATUS
-UwbSimulatorDdiHandlerLrp::HandleRequest(WDFREQUEST /* request */, std::size_t /* outputBufferLength */, std::size_t /* inputBufferLength */, ULONG /* ioControlCode */)
+UwbSimulatorDdiHandlerLrp::HandleRequest(WDFREQUEST /* request */, std::span<uint8_t> /* outputBuffer */, std::span<uint8_t> /* inputBuffer */, ULONG /* ioControlCode */)
 {
-    return STATUS_NOT_IMPLEMENTED; 
+    return STATUS_NOT_IMPLEMENTED;
 }

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.cxx
@@ -1,0 +1,16 @@
+
+#include "UwbSimulatorDdiHandlerLrp.hxx"
+
+using namespace windows::devices::uwb::simulator;
+
+bool
+UwbSimulatorDdiHandlerLrp::HandlesIoControlCode(ULONG /* ioControlCode */) const noexcept
+{
+    return false; 
+}
+
+NTSTATUS
+UwbSimulatorDdiHandlerLrp::HandleRequest(WDFREQUEST /* request */, std::size_t /* outputBufferLength */, std::size_t /* inputBufferLength */, ULONG /* ioControlCode */)
+{
+    return STATUS_NOT_IMPLEMENTED; 
+}

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.cxx
@@ -1,8 +1,8 @@
 
 #include "UwbCxLrpDeviceGlue.h"
 
-#include "UwbSimulatorDdiHandlerLrp.hxx"
 #include "UwbSimulatorDdiCallbacksLrpNoop.hxx"
+#include "UwbSimulatorDdiHandlerLrp.hxx"
 
 using namespace windows::devices::uwb::simulator;
 
@@ -12,7 +12,7 @@ UwbSimulatorDdiHandlerLrp::UwbSimulatorDdiHandlerLrp() :
 }
 
 bool
-UwbSimulatorDdiHandlerLrp::HandlesIoControlCode(ULONG ioControlCode) const noexcept
+UwbSimulatorDdiHandlerLrp::HandlesIoControlCode(ULONG ioControlCode)
 {
     switch (ioControlCode) {
     case IOCTL_UWB_DEVICE_RESET:
@@ -38,7 +38,13 @@ UwbSimulatorDdiHandlerLrp::HandlesIoControlCode(ULONG ioControlCode) const noexc
 }
 
 NTSTATUS
-UwbSimulatorDdiHandlerLrp::HandleRequest(WDFREQUEST /* request */, std::span<uint8_t> /* outputBuffer */, std::span<uint8_t> /* inputBuffer */, ULONG /* ioControlCode */)
+UwbSimulatorDdiHandlerLrp::ValidateRequest(WDFREQUEST /*request*/, ULONG /*ioControlCode*/, std::size_t /*inputBufferLength*/, std::size_t /*outputBufferLength*/)
+{
+    return STATUS_NOT_SUPPORTED;
+}
+
+NTSTATUS
+UwbSimulatorDdiHandlerLrp::HandleRequest(WDFREQUEST /* request */, ULONG /* ioControlCode */, std::span<uint8_t> /* inputBuffer */, std::span<uint8_t> /* outputBuffer */)
 {
     return STATUS_NOT_IMPLEMENTED;
 }

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.hxx
@@ -7,12 +7,16 @@
 #include <wdf.h>
 
 #include "UwbSimulatorDdiHandler.hxx"
+#include "UwbSimulatorDdiCallbacksLrp.hxx"
 
 namespace windows::devices::uwb::simulator
 {
 class UwbSimulatorDdiHandlerLrp :
     public UwbSimulatorDdiHandler
 {
+public:
+    UwbSimulatorDdiHandlerLrp();
+
     /**
      * @brief Indicates whether the specified i/o control code is handled by
      * this handler. 
@@ -34,7 +38,10 @@ class UwbSimulatorDdiHandlerLrp :
      * @return NTSTATUS 
      */
     NTSTATUS
-    HandleRequest(WDFREQUEST request, std::size_t outputBufferLength, std::size_t inputBufferLength, ULONG ioControlCode) override;
+    HandleRequest(WDFREQUEST request, std::span<uint8_t> outputBuffer, std::span<uint8_t> inputBuffer, ULONG ioControlCode) override;
+
+private:
+    std::unique_ptr<windows::devices::uwb::simulator::UwbSimulatorDdiCallbacksLrp> m_callbacks;
 };
 } // namespace windows::devices::uwb::simulator
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.hxx
@@ -1,0 +1,41 @@
+
+#ifndef UWB_SIMULATOR_DDI_HANDLER_LRP_HXX
+#define UWB_SIMULATOR_DDI_HANDLER_LRP_HXX
+
+#include <windows.h>
+
+#include <wdf.h>
+
+#include "UwbSimulatorDdiHandler.hxx"
+
+namespace windows::devices::uwb::simulator
+{
+class UwbSimulatorDdiHandlerLrp :
+    public UwbSimulatorDdiHandler
+{
+    /**
+     * @brief Indicates whether the specified i/o control code is handled by
+     * this handler. 
+     * 
+     * @param ioControlCode The i/o control code to check.
+     * @return true 
+     * @return false 
+     */
+    bool
+    HandlesIoControlCode(ULONG ioControlCode) const noexcept override;
+
+    /**
+     * @brief 
+     * 
+     * @param request 
+     * @param outputBufferLength 
+     * @param inputBufferLength 
+     * @param ioControlCode 
+     * @return NTSTATUS 
+     */
+    NTSTATUS
+    HandleRequest(WDFREQUEST request, std::size_t outputBufferLength, std::size_t inputBufferLength, ULONG ioControlCode) override;
+};
+} // namespace windows::devices::uwb::simulator
+
+#endif // UWB_SIMULATOR_DDI_HANDLER_LRP_HXX

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.hxx
@@ -6,8 +6,8 @@
 
 #include <wdf.h>
 
-#include "UwbSimulatorDdiHandler.hxx"
 #include "UwbSimulatorDdiCallbacksLrp.hxx"
+#include "UwbSimulatorDdiHandler.hxx"
 
 namespace windows::devices::uwb::simulator
 {
@@ -19,26 +19,38 @@ public:
 
     /**
      * @brief Indicates whether the specified i/o control code is handled by
-     * this handler. 
-     * 
+     * this handler.
+     *
      * @param ioControlCode The i/o control code to check.
-     * @return true 
-     * @return false 
+     * @return true
+     * @return false
      */
     bool
-    HandlesIoControlCode(ULONG ioControlCode) const noexcept override;
+    HandlesIoControlCode(ULONG ioControlCode) override;
 
     /**
-     * @brief 
-     * 
-     * @param request 
-     * @param outputBufferLength 
-     * @param inputBufferLength 
-     * @param ioControlCode 
-     * @return NTSTATUS 
+     * @brief
+     *
+     * @param request
+     * @param ioControlCode
+     * @param inputBufferLength
+     * @param outputBufferLength
+     * @return NTSTATUS
      */
     NTSTATUS
-    HandleRequest(WDFREQUEST request, std::span<uint8_t> outputBuffer, std::span<uint8_t> inputBuffer, ULONG ioControlCode) override;
+    ValidateRequest(WDFREQUEST request, ULONG ioControlCode, std::size_t inputBufferLength, std::size_t outputBufferLength) override;
+
+    /**
+     * @brief
+     *
+     * @param request
+     * @param ioControlCode
+     * @param inputBuffer
+     * @param outputBuffer
+     * @return NTSTATUS
+     */
+    NTSTATUS
+    HandleRequest(WDFREQUEST request, ULONG ioControlCode, std::span<uint8_t> inputBuffer, std::span<uint8_t> outputBuffer) override;
 
 private:
     std::unique_ptr<windows::devices::uwb::simulator::UwbSimulatorDdiCallbacksLrp> m_callbacks;

--- a/windows/drivers/uwb/simulator/UwbSimulatorDevice.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDevice.cxx
@@ -169,7 +169,7 @@ UwbSimulatorDevice::OnFileCreate(WDFDEVICE device, WDFREQUEST request, WDFFILEOB
     auto uwbSimulatorFile [[maybe_unused]] = new (uwbSimulatorFileBuffer) UwbSimulatorDeviceFile(file);
 
     // TODO: Here, uwbSimulatorFile should be associated with the DDI it is responsible for handling.
-    // It could make sense for it to use the pimp idiom since the storage for the class is pre-allocated
+    // It could make sense for it to use the pimpl idiom since the storage for the class is pre-allocated
     // by the driver framework, polymorphism can't be used.
 
     WdfRequestComplete(request, STATUS_SUCCESS);

--- a/windows/drivers/uwb/simulator/UwbSimulatorDevice.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDevice.cxx
@@ -165,6 +165,9 @@ UwbSimulatorDevice::OnFileCreate(WDFDEVICE device, WDFREQUEST request, WDFFILEOB
         TraceLoggingPointer(request, "Request"),
         TraceLoggingPointer(file, "File"));
 
+    auto uwbSimulatorFileBuffer = GetUwbSimulatorFile(file);
+    auto uwbSimulatorFile [[maybe_unused]] = new (uwbSimulatorFileBuffer) UwbSimulatorDeviceFile(file);
+
     WdfRequestComplete(request, STATUS_SUCCESS);
 }
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDevice.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDevice.cxx
@@ -168,6 +168,10 @@ UwbSimulatorDevice::OnFileCreate(WDFDEVICE device, WDFREQUEST request, WDFFILEOB
     auto uwbSimulatorFileBuffer = GetUwbSimulatorFile(file);
     auto uwbSimulatorFile [[maybe_unused]] = new (uwbSimulatorFileBuffer) UwbSimulatorDeviceFile(file);
 
+    // TODO: Here, uwbSimulatorFile should be associated with the DDI it is responsible for handling.
+    // It could make sense for it to use the pimp idiom since the storage for the class is pre-allocated
+    // by the driver framework, polymorphism can't be used.
+
     WdfRequestComplete(request, STATUS_SUCCESS);
 }
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.cxx
@@ -1,4 +1,7 @@
 
+#include <algorithm>
+#include <iterator>
+
 #include "UwbSimulatorDeviceFile.hxx"
 
 UwbSimulatorDeviceFile::UwbSimulatorDeviceFile(WDFFILEOBJECT wdfFile) :
@@ -40,4 +43,46 @@ UwbSimulatorDeviceFile::OnDestroy()
 void
 UwbSimulatorDeviceFile::OnRequestCancel(WDFREQUEST /* request */)
 {
+}
+
+NTSTATUS
+UwbSimulatorDeviceFile::OnRequest(WDFREQUEST request, ULONG ioControlCode, size_t inputBufferLength, size_t outputBufferLength)
+{
+    // Find a handler for this i/o control code.
+    auto ddiHandlerIt = std::find_if(std::begin(m_ddiHandlers), std::end(m_ddiHandlers), [&](const auto &ddiHandler) {
+        return (ddiHandler->HandlesIoControlCode(ioControlCode));
+    });
+    if (ddiHandlerIt == std::cend(m_ddiHandlers)) {
+        return STATUS_NOT_IMPLEMENTED;
+    }
+
+    // Use the handler to validate the request.
+    auto &ddiHandler = *ddiHandlerIt;
+    auto status = ddiHandler->ValidateRequest(request, ioControlCode, inputBufferLength, outputBufferLength);
+    if (status != STATUS_SUCCESS) {
+        return status;
+    }
+
+    // Obtain the input and output buffers.
+    void *inputBufferPtr = nullptr;
+    if (inputBufferLength != 0) {
+        status = WdfRequestRetrieveInputBuffer(request, 0, &inputBufferPtr, nullptr);
+        if (status != STATUS_SUCCESS) {
+            return status;
+        }
+    }
+    void *outputBufferPtr = nullptr;
+    if (outputBufferLength != 0) {
+        status = WdfRequestRetrieveOutputBuffer(request, 0, &outputBufferPtr, nullptr);
+        if (status != STATUS_SUCCESS) {
+            return status;
+        }
+    }
+
+    // Dispatch the request to the DDI handler.
+    std::span<uint8_t> inputBuffer{ reinterpret_cast<uint8_t *>(inputBufferPtr), inputBufferLength };
+    std::span<uint8_t> outputBuffer{ reinterpret_cast<uint8_t *>(outputBufferPtr), outputBufferLength };
+    status = ddiHandler->HandleRequest(request, ioControlCode, inputBuffer, outputBuffer);
+
+    return status;
 }

--- a/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.hxx
@@ -2,14 +2,37 @@
 #ifndef UWB_SIMULATOR_DEVICE_FILE_OBJECT
 #define UWB_SIMULATOR_DEVICE_FILE_OBJECT
 
+#include <memory>
+#include <vector>
+
 #include <windows.h>
 
 #include <wdf.h>
 
+#include "UwbSimulatorDdiHandler.hxx"
+
+/**
+ * @brief Device driver open file abstraction.
+ */
 class UwbSimulatorDeviceFile
 {
 public:
     explicit UwbSimulatorDeviceFile(WDFFILEOBJECT wdfFile);
+
+    /**
+     * @brief Device i/o control handler function.
+     * 
+     * This is invoked when the driver receives an i/o control request on the
+     * file handle associated with this instance.
+     * 
+     * @param request The WDF driver request.
+     * @param ioControlCode The i/o control code for the request.
+     * @param inputBufferLength The input buffer length.
+     * @param outputBufferLength The output buffer length.
+     * @return NTSTATUS The status of the request operation.
+     */
+    NTSTATUS
+    OnRequest(WDFREQUEST request, ULONG ioControlCode, size_t inputBufferLength, size_t outputBufferLength);
 
 public:
     static EVT_WDF_OBJECT_CONTEXT_DESTROY OnWdfDestroy;
@@ -32,6 +55,7 @@ private:
 
 private:
     WDFFILEOBJECT m_wdfFile;
+    std::vector<std::unique_ptr<windows::devices::uwb::simulator::UwbSimulatorDdiHandler>> m_ddiHandlers{};
 };
 
 WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(UwbSimulatorDeviceFile, GetUwbSimulatorFile);

--- a/windows/drivers/uwb/simulator/UwbSimulatorDispatchEntry.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDispatchEntry.cxx
@@ -1,0 +1,16 @@
+
+#include "UwbSimulatorDispatchEntry.hxx"
+
+using namespace windows::devices::uwb::simulator;
+
+NTSTATUS
+UwbSimulatorDispatchEntry::GetRequestValidityStatus(std::size_t inputBufferSize, std::size_t outputBufferSize) const noexcept
+{
+    if (inputBufferSize < InputSizeMinimum || outputBufferSize < OutputSizeMinimum) {
+        return STATUS_BUFFER_TOO_SMALL;
+    } else if (inputBufferSize > InputSizeMaximum || outputBufferSize > OutputSizeMaximum) {
+        return STATUS_INVALID_BUFFER_SIZE;
+    } else {
+        return STATUS_SUCCESS;
+    }
+}

--- a/windows/drivers/uwb/simulator/UwbSimulatorDispatchEntry.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDispatchEntry.hxx
@@ -1,0 +1,32 @@
+
+#ifndef UWB_SIMULATOR_DISPATCH_ENTRY_HXX
+#define UWB_SIMULATOR_DISPATCH_ENTRY_HXX
+
+#include <cstddef>
+#include <functional>
+#include <limits>
+#include <span>
+
+#include <windows.h>
+
+#include <wdf.h>
+
+namespace windows::devices::uwb::simulator
+{
+struct UwbSimulatorDispatchEntry
+{
+    ULONG IoControlCode;
+
+    std::size_t InputSizeMinimum{ 0 };
+    std::size_t InputSizeMaximum{ std::numeric_limits<std::size_t>::max() };
+    std::size_t OutputSizeMinimum{ 0 };
+    std::size_t OutputSizeMaximum{ std::numeric_limits<std::size_t>::max() };
+    
+    std::function<NTSTATUS(WDFREQUEST, ULONG, std::span<uint8_t>, std::span<uint8_t>)> Handler;
+
+    NTSTATUS
+    GetRequestValidityStatus(std::size_t inputBufferSize, std::size_t outputBufferSize) const noexcept;
+};
+} // namespace windows::devices::uwb::simulator
+
+#endif // UWB_SIMULATOR_DISPATCH_ENTRY_HXX

--- a/windows/drivers/uwb/simulator/UwbSimulatorDispatchEntry.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDispatchEntry.hxx
@@ -21,7 +21,7 @@ struct UwbSimulatorDispatchEntry
     std::size_t InputSizeMaximum{ std::numeric_limits<std::size_t>::max() };
     std::size_t OutputSizeMinimum{ 0 };
     std::size_t OutputSizeMaximum{ std::numeric_limits<std::size_t>::max() };
-    
+
     std::function<NTSTATUS(WDFREQUEST, ULONG, std::span<uint8_t>, std::span<uint8_t>)> Handler;
 
     NTSTATUS

--- a/windows/drivers/uwb/simulator/UwbSimulatorIoQueue.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorIoQueue.cxx
@@ -73,13 +73,18 @@ UwbSimulatorIoQueue::OnIoDeviceControl(WDFREQUEST request, size_t outputBufferLe
 
     // Get the file object this request came in on, and dispatch the request to it.
     UwbSimulatorDeviceFile *uwbSimulatorDeviceFile = GetUwbSimulatorFile(WdfRequestGetFileObject(request));
-    if (uwbSimulatorDeviceFile) {
+    if (uwbSimulatorDeviceFile != nullptr) {
         status = uwbSimulatorDeviceFile->OnRequest(request, ioControlCode, inputBufferLength, outputBufferLength);
     }
 
-    if (status != STATUS_PENDING) {
-        WdfRequestComplete(request, status);
-    }
+    TraceLoggingWrite(
+        UwbSimulatorTraceloggingProvider,
+        "Queue Request Complete",
+        TraceLoggingLevel(TRACE_LEVEL_VERBOSE),
+        TraceLoggingPointer(m_wdfQueue, "Queue"),
+        TraceLoggingPointer(request, "Request"),
+        TraceLoggingHexInt32(ioControlCode, "IoControlCode"),
+        TraceLoggingNTStatus(status));
 }
 
 void

--- a/windows/drivers/uwb/simulator/UwbSimulatorIoQueue.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorIoQueue.cxx
@@ -10,6 +10,7 @@
 #include <windows.h>
 
 #include "UwbSimulatorDdi.h"
+#include "UwbSimulatorDeviceFile.hxx"
 #include "UwbSimulatorIoQueue.hxx"
 #include "UwbSimulatorTracelogging.hxx"
 
@@ -70,16 +71,11 @@ UwbSimulatorIoQueue::OnIoDeviceControl(WDFREQUEST request, size_t outputBufferLe
 
     NTSTATUS status = STATUS_INVALID_DEVICE_STATE;
 
-    switch (ioControlCode) {
-    case IOCTL_UWB_DEVICE_SIM_GET_CAPABILITIES:
-    {
-        // TODO: handle this   
+    // Get the file object this request came in on, and dispatch the request to it.
+    UwbSimulatorDeviceFile *uwbSimulatorDeviceFile = GetUwbSimulatorFile(WdfRequestGetFileObject(request));
+    if (uwbSimulatorDeviceFile) {
+        status = uwbSimulatorDeviceFile->OnRequest(request, ioControlCode, inputBufferLength, outputBufferLength);
     }
-    default:
-    {
-        status = STATUS_NOT_SUPPORTED;
-    }
-    } // switch (ioControlCode)
 
     if (status != STATUS_PENDING) {
         WdfRequestComplete(request, status);


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Allow consistent handling of device driver interfaces within the simulator.

### Technical Details

* Introduce an interface `UwbSimulatorDdiHandler` for handling DDI i/o requests.
* Add basic DDI handler implementation for the UwbCx LRP DDI.
* Remove ARM64 targets.
* Fix missing virtual destructor for `UwbSimulatorDdiCallbacksLrp`.
* Construct `UwbSimulatorDeviceFile` instance on file creation.

### Test Results

Ad-hoc testing to make sure nothing crashes. Additional testing is needed.

### Reviewer Focus

None

### Future Work

* The current implementation needs to be expanded to actually validate and handle requests.
* Code is needed to bind `UwbSimulatorDeviceFile` to `UwbSimulatorDdiHandler` instance(s).
* Code is needed to convert from the UwbCx DDI types to neutral types.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
