### PR TITLE
Fix CMake presets and extend with explicit build configuration settings

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -46,7 +46,7 @@
             "cacheVariables": {
                 "NOF_WINDOWS_BUILD": true
             }
-        },
+        }
     ],
     "buildPresets": [
         {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -51,11 +51,13 @@
     "buildPresets": [
         {
             "name": "dev",
-            "configurePreset": "dev"
+            "configurePreset": "dev",
+            "configuration": "Debug"
         },
         {
             "name": "vcpkg",
-            "configurePreset": "vcpkg-dev"
+            "configurePreset": "vcpkg-dev",
+            "configuration": "Debug"
         },
         {
             "name": "release",


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

* Allow CMake presets to be selected.
* Allow intellisense to work with selected CMake presets.

### Technical Details

* Remove extraneous `,` in preset json.
* Add explicit build configuration for each build preset.

### Test Results

* Verified VSCode allows selection of configure, build, and test presets.
* Verified intellisense works when a preset is selected.

### Reviewer Focus

None

### Future Work

None

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
