### PR TITLE
Implement Uwb Simulator driver IOCTL buffer size checks

### DIFF
--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.cxx
@@ -13,28 +13,53 @@
 
 using namespace windows::devices::uwb::simulator;
 
+/**
+ * @brief Namespace alias to reduce typing but preserve clarity regarding DDI
+ * conversion.
+ */
 namespace UwbCxDdi = windows::devices::uwb::ddi::lrp;
 
 /**
- * TODO: min+max sizes need filling in. Get these numbers from the UwbCx driver.
+ * @brief Template function alias which partially specializes the
+ * UwbSimulatorDispatchEntry template with ClassT = UwbSimulatorDdiHandlerLrp.
+ * This reduces some typing.
+ *
+ * It's not possible to create an alias to a templated function, however, it is
+ * posssible to create an alias of a function pointer variable. Hence, this
+ * template alias is defined with a pointer (`*MakeLrpDispatchEntry') and
+ * assigned the address of MakeDispatchEntry.
+ *
+ * @tparam The type of the IOCTL input that's accepted.
+ * @tparam The type of the IOCTL ouput that's accepted.
+ */
+template <
+    typename InputT = void *,
+    typename OutputT = void *>
+UwbSimulatorDispatchEntry<UwbSimulatorDdiHandlerLrp> (*MakeLrpDispatchEntry)(ULONG, typename UwbSimulatorDispatchEntry<UwbSimulatorDdiHandlerLrp>::HandlerFuncT) = &MakeDispatchEntry<UwbSimulatorDdiHandlerLrp, InputT, OutputT>;
+
+/**
+ * @brief Dispatch table for the LRP DDI driver IOCTLs.
+ *
+ * This defines the expected input and output buffer sizes and the corresponding
+ * member function that will handle the IOCTL.
  */
 const std::initializer_list<UwbSimulatorDispatchEntry<UwbSimulatorDdiHandlerLrp>> UwbSimulatorDdiHandlerLrp::Dispatch{
-    UwbSimulatorDispatchEntry<UwbSimulatorDdiHandlerLrp>{ IOCTL_UWB_DEVICE_RESET, 0, 0, 0, 0, &UwbSimulatorDdiHandlerLrp::OnUwbDeviceReset },
-    UwbSimulatorDispatchEntry<UwbSimulatorDdiHandlerLrp>{ IOCTL_UWB_GET_DEVICE_INFO, 0, 0, 0, 0, &UwbSimulatorDdiHandlerLrp::OnUwbGetDeviceInformation },
-    UwbSimulatorDispatchEntry<UwbSimulatorDdiHandlerLrp>{ IOCTL_UWB_GET_DEVICE_CAPABILITIES, 0, 0, 0, 0, &UwbSimulatorDdiHandlerLrp::OnUwbGetDeviceCapabilities },
-    UwbSimulatorDispatchEntry<UwbSimulatorDdiHandlerLrp>{ IOCTL_UWB_GET_DEVICE_CONFIG_PARAMS, 0, 0, 0, 0, &UwbSimulatorDdiHandlerLrp::OnUwbGetDeviceConfigurationParameters },
-    UwbSimulatorDispatchEntry<UwbSimulatorDdiHandlerLrp>{ IOCTL_UWB_SET_DEVICE_CONFIG_PARAMS, 0, 0, 0, 0, &UwbSimulatorDdiHandlerLrp::OnUwbSetDeviceConfigurationParameters },
-    UwbSimulatorDispatchEntry<UwbSimulatorDdiHandlerLrp>{ IOCTL_UWB_GET_APP_CONFIG_PARAMS, 0, 0, 0, 0, &UwbSimulatorDdiHandlerLrp::OnUwbGetApplicationConfigurationParameters },
-    UwbSimulatorDispatchEntry<UwbSimulatorDdiHandlerLrp>{ IOCTL_UWB_SET_APP_CONFIG_PARAMS, 0, 0, 0, 0, &UwbSimulatorDdiHandlerLrp::OnUwbSetApplicationConfigurationParameters },
-    UwbSimulatorDispatchEntry<UwbSimulatorDdiHandlerLrp>{ IOCTL_UWB_GET_SESSION_COUNT, 0, 0, 0, 0, &UwbSimulatorDdiHandlerLrp::OnUwbGetSessionCount },
-    UwbSimulatorDispatchEntry<UwbSimulatorDdiHandlerLrp>{ IOCTL_UWB_SESSION_INIT, 0, 0, 0, 0, &UwbSimulatorDdiHandlerLrp::OnUwbSessionInitialize },
-    UwbSimulatorDispatchEntry<UwbSimulatorDdiHandlerLrp>{ IOCTL_UWB_SESSION_DEINIT, 0, 0, 0, 0, &UwbSimulatorDdiHandlerLrp::OnUwbSessionDeinitialize },
-    UwbSimulatorDispatchEntry<UwbSimulatorDdiHandlerLrp>{ IOCTL_UWB_GET_SESSION_STATE, 0, 0, 0, 0, &UwbSimulatorDdiHandlerLrp::OnUwbGetSessionState },
-    UwbSimulatorDispatchEntry<UwbSimulatorDdiHandlerLrp>{ IOCTL_UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST, 0, 0, 0, 0, &UwbSimulatorDdiHandlerLrp::OnUwbSessionUpdateControllerMulticastList },
-    UwbSimulatorDispatchEntry<UwbSimulatorDdiHandlerLrp>{ IOCTL_UWB_START_RANGING_SESSION, 0, 0, 0, 0, &UwbSimulatorDdiHandlerLrp::OnUwbSessionStartRanging },
-    UwbSimulatorDispatchEntry<UwbSimulatorDdiHandlerLrp>{ IOCTL_UWB_STOP_RANGING_SESSION, 0, 0, 0, 0, &UwbSimulatorDdiHandlerLrp::OnUwbSessionStopRanging },
-    UwbSimulatorDispatchEntry<UwbSimulatorDdiHandlerLrp>{ IOCTL_UWB_GET_RANGING_COUNT, 0, 0, 0, 0, &UwbSimulatorDdiHandlerLrp::OnUwbSessionGetRangingCount },
-    UwbSimulatorDispatchEntry<UwbSimulatorDdiHandlerLrp>{ IOCTL_UWB_NOTIFICATION, 0, 0, 0, 0, &UwbSimulatorDdiHandlerLrp::OnUwbNotification },
+    MakeLrpDispatchEntry<UWB_DEVICE_RESET, UWB_STATUS>(IOCTL_UWB_DEVICE_RESET, &UwbSimulatorDdiHandlerLrp::OnUwbDeviceReset),
+    MakeLrpDispatchEntry<Unrestricted, UWB_DEVICE_INFO>(IOCTL_UWB_GET_DEVICE_INFO, &UwbSimulatorDdiHandlerLrp::OnUwbGetDeviceInformation),
+    MakeLrpDispatchEntry<Unrestricted, UWB_DEVICE_CAPABILITIES>(IOCTL_UWB_GET_DEVICE_CAPABILITIES, &UwbSimulatorDdiHandlerLrp::OnUwbGetDeviceCapabilities),
+    MakeLrpDispatchEntry<UWB_SET_DEVICE_CONFIG_PARAMS, UWB_SET_DEVICE_CONFIG_PARAMS_STATUS>(IOCTL_UWB_GET_DEVICE_CONFIG_PARAMS, &UwbSimulatorDdiHandlerLrp::OnUwbGetDeviceConfigurationParameters),
+    MakeLrpDispatchEntry<UWB_GET_DEVICE_CONFIG_PARAMS, UWB_DEVICE_CONFIG_PARAMS>(IOCTL_UWB_SET_DEVICE_CONFIG_PARAMS, &UwbSimulatorDdiHandlerLrp::OnUwbSetDeviceConfigurationParameters),
+    MakeLrpDispatchEntry<UWB_GET_APP_CONFIG_PARAMS, UWB_APP_CONFIG_PARAMS>(IOCTL_UWB_GET_APP_CONFIG_PARAMS, &UwbSimulatorDdiHandlerLrp::OnUwbGetApplicationConfigurationParameters),
+    MakeLrpDispatchEntry<UWB_SET_APP_CONFIG_PARAMS, UWB_SET_APP_CONFIG_PARAMS_STATUS>(IOCTL_UWB_SET_APP_CONFIG_PARAMS, &UwbSimulatorDdiHandlerLrp::OnUwbSetApplicationConfigurationParameters),
+    MakeLrpDispatchEntry<Unrestricted, UWB_GET_SESSION_COUNT>(IOCTL_UWB_GET_SESSION_COUNT, &UwbSimulatorDdiHandlerLrp::OnUwbGetSessionCount),
+    MakeLrpDispatchEntry<UWB_SESSION_INIT, UWB_STATUS>(IOCTL_UWB_SESSION_INIT, &UwbSimulatorDdiHandlerLrp::OnUwbSessionInitialize),
+    MakeLrpDispatchEntry<UWB_SESSION_DEINIT, UWB_STATUS>(IOCTL_UWB_SESSION_DEINIT, &UwbSimulatorDdiHandlerLrp::OnUwbSessionDeinitialize),
+    MakeLrpDispatchEntry<UWB_GET_SESSION_STATE, UWB_SESSION_STATE_STATUS>(IOCTL_UWB_GET_SESSION_STATE, &UwbSimulatorDdiHandlerLrp::OnUwbGetSessionState),
+    MakeLrpDispatchEntry<UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST, UWB_STATUS>(IOCTL_UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST, &UwbSimulatorDdiHandlerLrp::OnUwbSessionUpdateControllerMulticastList),
+    MakeLrpDispatchEntry<UWB_START_RANGING_SESSION, UWB_STATUS>(IOCTL_UWB_START_RANGING_SESSION, &UwbSimulatorDdiHandlerLrp::OnUwbSessionStartRanging),
+    MakeLrpDispatchEntry<UWB_STOP_RANGING_SESSION, UWB_STATUS>(IOCTL_UWB_STOP_RANGING_SESSION, &UwbSimulatorDdiHandlerLrp::OnUwbSessionStopRanging),
+    MakeLrpDispatchEntry<UWB_GET_RANGING_COUNT, UWB_RANGING_COUNT>(IOCTL_UWB_GET_RANGING_COUNT, &UwbSimulatorDdiHandlerLrp::OnUwbSessionGetRangingCount),
+    MakeLrpDispatchEntry<Unrestricted, UWB_NOTIFICATION_DATA>(IOCTL_UWB_NOTIFICATION, &UwbSimulatorDdiHandlerLrp::OnUwbNotification),
 };
 
 // IOCTL_UWB_DEVICE_RESET
@@ -96,48 +121,56 @@ UwbSimulatorDdiHandlerLrp::OnUwbGetDeviceCapabilities(WDFREQUEST request, std::s
     return status;
 }
 
+// IOCTL_UWB_GET_DEVICE_CONFIG_PARAMS
 NTSTATUS
 UwbSimulatorDdiHandlerLrp::OnUwbGetDeviceConfigurationParameters(WDFREQUEST /*request*/, std::span<uint8_t> /*inputBuffer*/, std::span<uint8_t> /*outputBuffer*/)
 {
     return STATUS_NOT_IMPLEMENTED;
 }
 
+// IOCTL_UWB_SET_DEVICE_CONFIG_PARAMS
 NTSTATUS
 UwbSimulatorDdiHandlerLrp::OnUwbSetDeviceConfigurationParameters(WDFREQUEST /*request*/, std::span<uint8_t> /*inputBuffer*/, std::span<uint8_t> /*outputBuffer*/)
 {
     return STATUS_NOT_IMPLEMENTED;
 }
 
+// IOCTL_UWB_GET_APP_CONFIG_PARAMS
 NTSTATUS
 UwbSimulatorDdiHandlerLrp::OnUwbGetApplicationConfigurationParameters(WDFREQUEST /*request*/, std::span<uint8_t> /*inputBuffer*/, std::span<uint8_t> /*outputBuffer*/)
 {
     return STATUS_NOT_IMPLEMENTED;
 }
 
+// IOCTL_UWB_SET_APP_CONFIG_PARAMS
 NTSTATUS
 UwbSimulatorDdiHandlerLrp::OnUwbSetApplicationConfigurationParameters(WDFREQUEST /*request*/, std::span<uint8_t> /*inputBuffer*/, std::span<uint8_t> /*outputBuffer*/)
 {
     return STATUS_NOT_IMPLEMENTED;
 }
 
+// IOCTL_UWB_GET_SESSION_COUNT
 NTSTATUS
 UwbSimulatorDdiHandlerLrp::OnUwbGetSessionCount(WDFREQUEST /*request*/, std::span<uint8_t> /*inputBuffer*/, std::span<uint8_t> /*outputBuffer*/)
 {
     return STATUS_NOT_IMPLEMENTED;
 }
 
+// IOCTL_UWB_SESSION_INIT
 NTSTATUS
 UwbSimulatorDdiHandlerLrp::OnUwbSessionInitialize(WDFREQUEST /*request*/, std::span<uint8_t> /*inputBuffer*/, std::span<uint8_t> /*outputBuffer*/)
 {
     return STATUS_NOT_IMPLEMENTED;
 }
 
+// IOCTL_UWB_SESSION_DEINIT
 NTSTATUS
 UwbSimulatorDdiHandlerLrp::OnUwbSessionDeinitialize(WDFREQUEST /*request*/, std::span<uint8_t> /*inputBuffer*/, std::span<uint8_t> /*outputBuffer*/)
 {
     return STATUS_NOT_IMPLEMENTED;
 }
 
+// IOCTL_UWB_GET_SESSION_STATE
 NTSTATUS
 UwbSimulatorDdiHandlerLrp::OnUwbGetSessionState(WDFREQUEST request, std::span<uint8_t> inputBuffer, std::span<uint8_t> outputBuffer)
 {
@@ -160,30 +193,35 @@ UwbSimulatorDdiHandlerLrp::OnUwbGetSessionState(WDFREQUEST request, std::span<ui
     return status;
 }
 
+// IOCTL_UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST
 NTSTATUS
 UwbSimulatorDdiHandlerLrp::OnUwbSessionUpdateControllerMulticastList(WDFREQUEST /*request*/, std::span<uint8_t> /*inputBuffer*/, std::span<uint8_t> /*outputBuffer*/)
 {
     return STATUS_NOT_IMPLEMENTED;
 }
 
+// IOCTL_UWB_START_RANGING_SESSION
 NTSTATUS
 UwbSimulatorDdiHandlerLrp::OnUwbSessionStartRanging(WDFREQUEST /*request*/, std::span<uint8_t> /*inputBuffer*/, std::span<uint8_t> /*outputBuffer*/)
 {
     return STATUS_NOT_IMPLEMENTED;
 }
 
+// IOCTL_UWB_STOP_RANGING_SESSION
 NTSTATUS
 UwbSimulatorDdiHandlerLrp::OnUwbSessionStopRanging(WDFREQUEST /*request*/, std::span<uint8_t> /*inputBuffer*/, std::span<uint8_t> /*outputBuffer*/)
 {
     return STATUS_NOT_IMPLEMENTED;
 }
 
+// IOCTL_UWB_GET_RANGING_COUNT
 NTSTATUS
 UwbSimulatorDdiHandlerLrp::OnUwbSessionGetRangingCount(WDFREQUEST /*request*/, std::span<uint8_t> /*inputBuffer*/, std::span<uint8_t> /*outputBuffer*/)
 {
     return STATUS_NOT_IMPLEMENTED;
 }
 
+// IOCTL_UWB_NOTIFICATION
 NTSTATUS
 UwbSimulatorDdiHandlerLrp::OnUwbNotification(WDFREQUEST /*request*/, std::span<uint8_t> /*inputBuffer*/, std::span<uint8_t> /*outputBuffer*/)
 {

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.cxx
@@ -33,8 +33,8 @@ namespace UwbCxDdi = windows::devices::uwb::ddi::lrp;
  * @tparam The type of the IOCTL ouput that's accepted.
  */
 template <
-    typename InputT = void *,
-    typename OutputT = void *>
+    typename InputT = Unrestricted,
+    typename OutputT = Unrestricted>
 UwbSimulatorDispatchEntry<UwbSimulatorDdiHandlerLrp> (*MakeLrpDispatchEntry)(ULONG, typename UwbSimulatorDispatchEntry<UwbSimulatorDdiHandlerLrp>::HandlerFuncT) = &MakeDispatchEntry<UwbSimulatorDdiHandlerLrp, InputT, OutputT>;
 
 /**

--- a/windows/drivers/uwb/simulator/UwbSimulatorDispatchEntry.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDispatchEntry.hxx
@@ -2,10 +2,12 @@
 #ifndef UWB_SIMULATOR_DISPATCH_ENTRY_HXX
 #define UWB_SIMULATOR_DISPATCH_ENTRY_HXX
 
+#include <concepts>
 #include <cstddef>
 #include <functional>
 #include <limits>
 #include <span>
+#include <type_traits>
 
 #include <windows.h>
 
@@ -26,33 +28,150 @@ struct UwbSimulatorDispatchEntry
 {
     using HandlerFuncT = NTSTATUS (ClassT::*)(WDFREQUEST, std::span<uint8_t>, std::span<uint8_t>);
 
+    HandlerFuncT Handler;
     ULONG IoControlCode;
     std::size_t InputSizeMinimum{ 0 };
-    std::size_t InputSizeMaximum{ std::numeric_limits<std::size_t>::max() };
     std::size_t OutputSizeMinimum{ 0 };
-    std::size_t OutputSizeMaximum{ std::numeric_limits<std::size_t>::max() };
-    HandlerFuncT Handler;
 
     /**
      * @brief Determines whether the specified request parameters are valid for
      * this dispatch entry.
      *
+     * The last two parameters, [input|output]BufferVariableSize are intended to
+     * be used for IOCTLs which expect types that vary in size. In particular,
+     * this includes types that have a flex-array member (member[1]) at the end
+     * of the structure that references trailing data beyond its compile-time
+     * size. The value of these arguments will be added to the entry's minimum
+     * size to account for the variable portion.
+     *
+     * Eg.
+     * <in app>
+     * std::size_t paramLength = 20;
+     * std::size_t paramLengthTotal = sizeof (UWB_CAPABILITY_PARAM) + paramLength - 1;
+     * auto paramsBuffer = std::make_unique<uint8_t[]>(paramLenghtTotal);
+     * UWB_CAPABILITY_PARAM *params = reinterpret_cast<UWB_CAPABILITY_PARAM *>(paramsBuffer.get());
+     * auto hr = DeviceIoControl(handle, ..., paramsBuffer, paramLengthTotal, ...);
+     *
+     * <in driver>
+     * std::size_t paramLengthExpected = 10;
+     * auto status = <dispatchEntry>.GetRequestValidityStatus(inputBufferSize, 0, paramLengthExpected, 0);
+     *
      * @param inputBufferSize The size of the request input buffer, in bytes.
      * @param outputBufferSize The size of the request output buffer, in bytes.
+     * @param inputBufferVariableSize The variable portion of the input buffer.
+     * @param outputBufferVariableSize The variable portion of the output buffer.
      * @return NTSTATUS
      */
     NTSTATUS
-    GetRequestValidityStatus(std::size_t inputBufferSize, std::size_t outputBufferSize) const noexcept
+    GetRequestValidityStatus(std::size_t inputBufferSize, std::size_t outputBufferSize, std::size_t inputBufferVariableSize = 0, std::size_t outputBufferVariableSize = 0) const noexcept
     {
-        if (inputBufferSize < InputSizeMinimum || outputBufferSize < OutputSizeMinimum) {
-            return STATUS_BUFFER_TOO_SMALL;
-        } else if (inputBufferSize > InputSizeMaximum || outputBufferSize > OutputSizeMaximum) {
-            return STATUS_INVALID_BUFFER_SIZE;
-        } else {
-            return STATUS_SUCCESS;
-        }
+        return (inputBufferSize >= (InputSizeMinimum + inputBufferVariableSize)) &&
+            (outputBufferSize >= (OutputSizeMinimum + outputBufferVariableSize));
     }
 };
+
+/**
+ * @brief Helper function to create a UwbSimulatorDispatchEntry.
+ *
+ * This isn't strictly needed since the same effect can be achieved by
+ * performing aggregrate-initialization directly. However, this exists to enable
+ * consistency in the UwbSimulatorDispatchEntry creational pattern.
+ *
+ * @tparam ClassT The type of class that defines the handler function.
+ * @param ioControlCode The control code for the entry.
+ * @param handler The handler for the IOCTL.
+ * @param inputSizeMinimum The minimum input buffer size.
+ * @param outputSizeMinimum The minimum output buffer size.
+ * @return UwbSimulatorDispatchEntry<ClassT>
+ */
+template <typename ClassT>
+UwbSimulatorDispatchEntry<ClassT>
+MakeDispatchEntry(ULONG ioControlCode, typename UwbSimulatorDispatchEntry<ClassT>::HandlerFuncT handler, std::size_t inputSizeMinimum, std::size_t outputSizeMinimum)
+{
+    return UwbSimulatorDispatchEntry<ClassT>{
+        .Handler = handler,
+        .IoControlCode = ioControlCode,
+        .InputSizeMinimum = inputSizeMinimum,
+        .OutputSizeMinimum = outputSizeMinimum,
+    };
+}
+
+namespace detail
+{
+/**
+ * @brief Type trait to define the minimum size for a dispatch entry.
+ *
+ * By default, this returns the size of the type specified.
+ *
+ * @tparam T The expected type contained in the buffer.
+ */
+template <typename BufferT>
+struct DispatchEntryMinimumSizeImpl
+{
+    static constexpr std::size_t value = sizeof(BufferT);
+};
+
+/**
+ * @brief Sentinel type to denote that the buffer size should be unrestricted.
+ */
+struct Unrestricted
+{};
+
+/**
+ * @brief Specialization to enforce no minimum buffer size (0).
+ *
+ * @tparam Sentinel Unrestricted type.
+ */
+template <>
+struct DispatchEntryMinimumSizeImpl<Unrestricted>
+{
+    static constexpr std::size_t value = 0;
+};
+
+/**
+ * @brief Helper alias to resolve the type value of the
+ * DispatchEntryMinimumSizeImpl trait, which denotes the size of the buffer.
+ *
+ * @tparam T The expected type contained in the buffer.
+ */
+template <typename BufferT>
+inline constexpr std::size_t DispatchEntryMinimumSizeImpl_v = DispatchEntryMinimumSizeImpl<BufferT>::value;
+
+} // namespace detail
+
+/**
+ * @brief Helper type to denote that the buffer size should not be restricted.
+ */
+using Unrestricted = detail::DispatchEntryMinimumSizeImpl<detail::Unrestricted>;
+
+/**
+ * @brief Helper function to create a UwbSimulatorDispatchEntry that uses the
+ * size of a structure to determine the minimum size of the expected input
+ * and/or output buffers for an IOCTL.
+ *
+ * When either of the InputT or OutputT types are not directly specified, the
+ * associated buffer size shall be unrestricted (no minimum required).
+ *
+ * @tparam ClassT The type of class that defines the handler function.
+ * @tparam InputT The expected type that is contained in the input buffer.
+ * @tparam OutputT The expected type that is contained in the output buffer.
+ * @param ioControlCode The control code for the entry.
+ * @param handler The handler for the IOCTL.
+ * @return UwbSimulatorDispatchEntry<ClassT>
+ */
+template <
+    typename ClassT,
+    typename InputT = Unrestricted,
+    typename OutputT = Unrestricted>
+UwbSimulatorDispatchEntry<ClassT>
+MakeDispatchEntry(ULONG ioControlCode, typename UwbSimulatorDispatchEntry<ClassT>::HandlerFuncT handler)
+{
+    return MakeDispatchEntry<ClassT>(
+        ioControlCode,
+        handler,
+        detail::DispatchEntryMinimumSizeImpl_v<InputT>,
+        detail::DispatchEntryMinimumSizeImpl_v<OutputT>);
+}
 } // namespace windows::devices::uwb::simulator
 
 #endif // UWB_SIMULATOR_DISPATCH_ENTRY_HXX


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Ensure that IOCTLs buffer minimum sizes are enforced and accurate.

### Technical Details

* Add real input and output buffer sizes to the existing dispatch entry map.
* Extend `UwbSimulatorDispatchEntry::GetRequestValidityStatus` to support buffers containing variably-sized types.
* Enable inferring minimum buffer size from type instead of requiring explicit size.


### Test Results

Ad-hoc testing only.

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
