### PR TITLE
Organize CMake functionality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,27 +7,21 @@ option(NOF_WINDOWS_BUILD "Configure the project for an official Windows build" O
 option(NOF_WINDOWS_BUILD_DRIVER "Configure the project for building for a Windows driver" OFF)
 option(NOF_ENABLE_CODE_COVERAGE "Enable instrumenting the build with code coverage" OFF)
 
+# Other fixed project variables.
+set(NOF_VCPKG_SUBMODULE_ROOT ${CMAKE_CURRENT_LIST_DIR}/packaging/vcpkg/vcpkg)
+
 # Ensure vcpkg is enabled for the Windows builds.
 if ((NOF_WINDOWS_BUILD OR NOF_WINDOWS_BUILD_DRIVER) AND NOT NOF_USE_VCPKG)
   set(NOF_USE_VCPKG CACHE BOOL ON "Enable vcpkg for Windows build")
 endif()
 
+include(CMakeParseArguments)
+
 # Select source package dependency manager based on selected option.
 # This must occur prior to the first project() statement.
 if (NOF_USE_VCPKG)
-  if ("${VCPKG_CHAINLOAD_TOOLCHAIN_FILE}" STREQUAL "")
-    find_package(Git REQUIRED)
-    set(VCPKG_SUBMODULE_ROOT ${CMAKE_CURRENT_LIST_DIR}/packaging/vcpkg/vcpkg)
-
-    # Initialize vcpkg sub-module if not already done.
-    if (NOT EXISTS ${VCPKG_SUBMODULE_ROOT}/.git)
-      execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive -- ${VCPKG_SUBMODULE_ROOT}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR} 
-        COMMAND_ERROR_IS_FATAL ANY)
-    endif()
-
-    set(CMAKE_TOOLCHAIN_FILE "${VCPKG_SUBMODULE_ROOT}/scripts/buildsystems/vcpkg.cmake" CACHE STRING "vcpkg toolchain file")
-  endif()
+  include(cmake/vcpkg.cmake)
+  vcpkg_configure(SUBMODULE_ROOT ${NOF_VCPKG_SUBMODULE_ROOT}) 
   MESSAGE(STATUS "using vcpkg for source dependencies")
 else()
   MESSAGE(STATUS "using FetchContent for source dependencies")
@@ -185,46 +179,6 @@ set(NOF_DIR_WINDOWS ${CMAKE_CURRENT_LIST_DIR}/windows)
 if (BUILD_FOR_LINUX)
   add_subdirectory(linux)
 elseif (BUILD_FOR_WINDOWS)
-  # Make public version of wil available.
-  set(WIL_BUILD_TESTS OFF CACHE INTERNAL "Turn off wil tests")
-  set(WIL_BUILD_PACKAGING OFF CACHE INTERNAL "Turn off wil packaging")
-
-  if (NOF_USE_VCPKG)
-    find_package(wil CONFIG REQUIRED)
-  else()
-    FetchContent_Declare(WIL
-        GIT_REPOSITORY "https://github.com/microsoft/wil"
-        GIT_TAG "5eb59d60e167482639cc47ffb40442158da7fd04"
-        GIT_SHALLOW OFF
-    )
-    FetchContent_MakeAvailable(WIL)
-  endif()
-
-  # Add Windows-specific global compile definitions.
-  add_compile_definitions(
-      _UNICODE
-      UNICODE
-      NOMINMAX
-      WIN32_LEAN_AND_MEAN
-  )
-
-  if (NOF_WINDOWS_BUILD_DRIVER)
-    if (NOF_USE_MSVC_STATIC_RUNTIME)
-      # Enable explicit selection of MSVC runtime library.
-      if (POLICY CMP0091)
-        cmake_policy(SET CMP0091 NEW)
-        # Statically link to the VC++ runtime library. This is required because
-        # when an MSBuild project targets the 'WindowsUserModeDriver10.0' toolset,
-        # the runtime library settings are completely ignored and instead links
-        # staticaly to the VC++ runtime and dynamically to the UCRT. See the
-        # following page for aditional details: more details:
-        # https://learn.microsoft.com/en-us/windows-hardware/drivers/develop/using-the-microsoft-c-runtime-with-user-mode-drivers-and-apps
-        MESSAGE(STATUS "Enabled static linking to VC++ runtime")
-        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-      endif()
-    endif()
-  endif()
-
   add_subdirectory(windows)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
 # Project configuration options.
-option(NOF_USE_MSVC_STATIC_RUNTIME, "Statically link against the VC++ runtime library" OFF)
 option(NOF_USE_VCPKG "Use vcpkg for obtaining source dependencies" OFF)
 option(NOF_WINDOWS_BUILD "Configure the project for an official Windows build" OFF)
 option(NOF_WINDOWS_BUILD_DRIVER "Configure the project for building for a Windows driver" OFF)

--- a/cmake/vcpkg.cmake
+++ b/cmake/vcpkg.cmake
@@ -1,0 +1,30 @@
+
+function(vcpkg_configure)
+  cmake_parse_arguments(
+    VCPKG 
+    "" 
+    "SUBMODULE_ROOT"
+    ""
+    ${ARGN}
+  )
+
+  get_filename_component(VCPKG_SUBMODULE_NAME ${VCPKG_SUBMODULE_ROOT} NAME)
+
+  if ("${VCPKG_CHAINLOAD_TOOLCHAIN_FILE}" STREQUAL "")
+    find_package(Git REQUIRED)
+
+    # Initialize vcpkg sub-module if not already done.
+    if (NOT EXISTS ${VCPKG_SUBMODULE_ROOT}/.git)
+      execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive -- ${VCPKG_SUBMODULE_ROOT}
+        WORKING_DIRECTORY ${VCPKG_SUBMODULE_ROOT}../
+        COMMAND_ERROR_IS_FATAL ANY)
+    endif()
+    set(CMAKE_TOOLCHAIN_FILE "${VCPKG_SUBMODULE_ROOT}/scripts/buildsystems/vcpkg.cmake" CACHE STRING "vcpkg toolchain file")
+  endif()
+
+  # Ignore all changes to the submodule tree.
+  execute_process(COMMAND ${GIT_EXECUTABLE} "config submodule.${VCPKG_SUBMODULE_NAME}.ignore all"
+    WORKING_DIRECTORY ${VCPKG_SUBMODULE_ROOT}../
+  )
+
+endfunction()

--- a/packaging/vcpkg/CMakeLists.txt
+++ b/packaging/vcpkg/CMakeLists.txt
@@ -32,10 +32,10 @@ set(NOF_VCPKG_RELEASE_GIT_REF ${NOF_VCPKG_RELEASE_TAG})
 set(NOF_VCPKG_RELEASE_GIT_REF_FETCH ${NOF_GIT_BRANCH_CURRENT})
 
 # Determine the vcpkg target the codebase is being built for.
-if (NOF_WINDOWS_BUILD_DRIVER)
-    set(NOF_VCPKG_TARGET DRIVER)
+if (NOF_WINDOWS_BUILD)
+  set(NOF_VCPKG_TARGET RELEASE)
 else()
-    set(NOF_VCPKG_TARGET RELEASE)
+  set(NOF_VCPKG_TARGET DRIVER)
 endif()
 
 # Select configuration based on build target.

--- a/packaging/vcpkg/ports/nearobject-framework/portfile.cmake.in
+++ b/packaging/vcpkg/ports/nearobject-framework/portfile.cmake.in
@@ -9,7 +9,6 @@ vcpkg_from_git(
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        msvc-link-static-runtime NOF_USE_MSVC_STATIC_RUNTIME
         windows-build NOF_WINDOWS_BUILD
         windows-build-driver NOF_WINDOWS_BUILD_DRIVER
 )

--- a/packaging/vcpkg/ports/nearobject-framework/vcpkg.json
+++ b/packaging/vcpkg/ports/nearobject-framework/vcpkg.json
@@ -19,23 +19,10 @@
     }
   ],
   "features": {
-    "msvc-link-static-runtime": {
-      "description": "Enables statically linking against the VC++ runtime, required for UMDF drivers",
-      "dependencies": [
-        "nearobject-framework"
-      ],
-      "supports": "windows"
-    },
     "windows-build-driver": {
       "description": "Enables specific functionality for Windows driver development",
-      "dependencies": [
-        {
-          "name": "nearobject-framework",
-          "default-features": false,
-          "features": [
-            "msvc-link-static-runtime"
-          ]
-        }
+      "dependencies": [ 
+        "nearobject-framework" 
       ],
       "supports": "windows"
     },

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -23,19 +23,17 @@ add_compile_definitions(
 )
 
 if (NOF_WINDOWS_BUILD_DRIVER)
-  if (NOF_USE_MSVC_STATIC_RUNTIME)
-    # Enable explicit selection of MSVC runtime library.
-    if (POLICY CMP0091)
-      cmake_policy(SET CMP0091 NEW)
-      # Statically link to the VC++ runtime library. This is required because
-      # when an MSBuild project targets the 'WindowsUserModeDriver10.0' toolset,
-      # the runtime library settings are completely ignored and instead links
-      # staticaly to the VC++ runtime and dynamically to the UCRT. See the
-      # following page for aditional details: more details:
-      # https://learn.microsoft.com/en-us/windows-hardware/drivers/develop/using-the-microsoft-c-runtime-with-user-mode-drivers-and-apps
-      MESSAGE(STATUS "Enabled static linking to VC++ runtime")
-      set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-    endif()
+  # Enable explicit selection of MSVC runtime library.
+  if (POLICY CMP0091)
+    cmake_policy(SET CMP0091 NEW)
+    # Statically link to the VC++ runtime library. This is required because
+    # when an MSBuild project targets the 'WindowsUserModeDriver10.0' toolset,
+    # the runtime library settings are completely ignored and instead links
+    # staticaly to the VC++ runtime and dynamically to the UCRT. See the
+    # following page for aditional details: more details:
+    # https://learn.microsoft.com/en-us/windows-hardware/drivers/develop/using-the-microsoft-c-runtime-with-user-mode-drivers-and-apps
+    MESSAGE(STATUS "Enabled static linking to VC++ runtime")
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
   endif()
 endif()
 

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -1,3 +1,44 @@
+
+# Make public version of wil available.
+set(WIL_BUILD_TESTS OFF CACHE INTERNAL "Turn off wil tests")
+set(WIL_BUILD_PACKAGING OFF CACHE INTERNAL "Turn off wil packaging")
+
+if (NOF_USE_VCPKG)
+  find_package(wil CONFIG REQUIRED)
+else()
+  FetchContent_Declare(WIL
+    GIT_REPOSITORY "https://github.com/microsoft/wil"
+    GIT_TAG "5eb59d60e167482639cc47ffb40442158da7fd04"
+    GIT_SHALLOW OFF
+  )
+  FetchContent_MakeAvailable(WIL)
+endif()
+
+# Add Windows-specific global compile definitions.
+add_compile_definitions(
+  _UNICODE
+  UNICODE
+  NOMINMAX
+  WIN32_LEAN_AND_MEAN
+)
+
+if (NOF_WINDOWS_BUILD_DRIVER)
+  if (NOF_USE_MSVC_STATIC_RUNTIME)
+    # Enable explicit selection of MSVC runtime library.
+    if (POLICY CMP0091)
+      cmake_policy(SET CMP0091 NEW)
+      # Statically link to the VC++ runtime library. This is required because
+      # when an MSBuild project targets the 'WindowsUserModeDriver10.0' toolset,
+      # the runtime library settings are completely ignored and instead links
+      # staticaly to the VC++ runtime and dynamically to the UCRT. See the
+      # following page for aditional details: more details:
+      # https://learn.microsoft.com/en-us/windows-hardware/drivers/develop/using-the-microsoft-c-runtime-with-user-mode-drivers-and-apps
+      MESSAGE(STATUS "Enabled static linking to VC++ runtime")
+      set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+    endif()
+  endif()
+endif()
+
 add_subdirectory(devices)
 add_subdirectory(drivers)
 add_subdirectory(nearobject)


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [X] Non-functional change
- [ ] Documentation
- [X] Infrastructure

### Goals

Reduce complexity of top-level CMake file.

### Technical Details

* Move vcpkg related functionality into its own script file and introduce function to configure it.
* Move windows related functionality into existing `windows/CMakeLists.txt` file.
* Ensure vcpkg driver target is set even when vcpkg is not being used to resolve dependencies.

### Test Results

Built with `dev` and `vcpkg-dev` presets, with clear caches, and verified everything worked, including the simulator driver build.

### Reviewer Focus

None

### Future Work

* Security hardening needs to move to its own script file.
    - Options need to be categorized and applied appropriately: all configs, debug, release.\

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
