### PR TITLE
Move cmake vcpkg logic to separate script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,12 @@ option(NOF_WINDOWS_BUILD "Configure the project for an official Windows build" O
 option(NOF_WINDOWS_BUILD_DRIVER "Configure the project for building for a Windows driver" OFF)
 option(NOF_ENABLE_CODE_COVERAGE "Enable instrumenting the build with code coverage" OFF)
 
+# Other fixed project variables.
+set(NOF_VCPKG_SUBMODULE_ROOT ${CMAKE_CURRENT_LIST_DIR}/packaging/vcpkg/vcpkg)
+
+include(CMakeParseArguments)
+include(cmake/vcpkg.cmake)
+
 # Ensure vcpkg is enabled for the Windows builds.
 if ((NOF_WINDOWS_BUILD OR NOF_WINDOWS_BUILD_DRIVER) AND NOT NOF_USE_VCPKG)
   set(NOF_USE_VCPKG CACHE BOOL ON "Enable vcpkg for Windows build")
@@ -15,19 +21,7 @@ endif()
 # Select source package dependency manager based on selected option.
 # This must occur prior to the first project() statement.
 if (NOF_USE_VCPKG)
-  if ("${VCPKG_CHAINLOAD_TOOLCHAIN_FILE}" STREQUAL "")
-    find_package(Git REQUIRED)
-    set(VCPKG_SUBMODULE_ROOT ${CMAKE_CURRENT_LIST_DIR}/packaging/vcpkg/vcpkg)
-
-    # Initialize vcpkg sub-module if not already done.
-    if (NOT EXISTS ${VCPKG_SUBMODULE_ROOT}/.git)
-      execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive -- ${VCPKG_SUBMODULE_ROOT}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR} 
-        COMMAND_ERROR_IS_FATAL ANY)
-    endif()
-
-    set(CMAKE_TOOLCHAIN_FILE "${VCPKG_SUBMODULE_ROOT}/scripts/buildsystems/vcpkg.cmake" CACHE STRING "vcpkg toolchain file")
-  endif()
+  vcpkg_configure(SUBMODULE_ROOT ${NOF_VCPKG_SUBMODULE_ROOT})
   MESSAGE(STATUS "using vcpkg for source dependencies")
 else()
   MESSAGE(STATUS "using FetchContent for source dependencies")

--- a/cmake/vcpkg.cmake
+++ b/cmake/vcpkg.cmake
@@ -1,0 +1,29 @@
+function(vcpkg_configure)
+  cmake_parse_arguments(
+    VCPKG 
+    "" 
+    "SUBMODULE_ROOT"
+    ""
+    ${ARGN}
+  )
+
+  get_filename_component(VCPKG_SUBMODULE_NAME ${VCPKG_SUBMODULE_ROOT} NAME)
+
+  if ("${VCPKG_CHAINLOAD_TOOLCHAIN_FILE}" STREQUAL "")
+    find_package(Git REQUIRED)
+
+    # Initialize vcpkg sub-module if not already done.
+    if (NOT EXISTS ${VCPKG_SUBMODULE_ROOT}/.git)
+      execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive -- ${VCPKG_SUBMODULE_ROOT}
+        WORKING_DIRECTORY ${VCPKG_SUBMODULE_ROOT}../
+        COMMAND_ERROR_IS_FATAL ANY)
+    endif()
+    set(CMAKE_TOOLCHAIN_FILE "${VCPKG_SUBMODULE_ROOT}/scripts/buildsystems/vcpkg.cmake" CACHE STRING "vcpkg toolchain file")
+  endif()
+
+  # Ignore all changes to the submodule tree.
+  execute_process(COMMAND ${GIT_EXECUTABLE} "config submodule.${VCPKG_SUBMODULE_NAME}.ignore all"
+    WORKING_DIRECTORY ${VCPKG_SUBMODULE_ROOT}../
+  )
+
+endfunction()

--- a/cmake/vcpkg.cmake
+++ b/cmake/vcpkg.cmake
@@ -23,7 +23,7 @@ function(vcpkg_configure)
     # Initialize vcpkg sub-module if not already done.
     if (NOT EXISTS ${VCPKG_SUBMODULE_ROOT}/.git)
       execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive -- ${VCPKG_SUBMODULE_ROOT}
-        WORKING_DIRECTORY ${VCPKG_SUBMODULE_ROOT}../
+        WORKING_DIRECTORY ${VCPKG_SUBMODULE_ROOT}/../
         COMMAND_ERROR_IS_FATAL ANY)
     endif()
     set(CMAKE_TOOLCHAIN_FILE "${VCPKG_SUBMODULE_ROOT}/scripts/buildsystems/vcpkg.cmake" CACHE STRING "vcpkg toolchain file")

--- a/cmake/vcpkg.cmake
+++ b/cmake/vcpkg.cmake
@@ -1,3 +1,11 @@
+
+# Configures vcpkg for use locally.
+# 
+# This will determine if vcpkg is available. If not, it will clone the vcpkg
+# Github repository as a submodule into the directory specified by
+# SUBMODULE_ROOT, and instruct cmake to use its toolchain file to help satisfy
+# dependencies. It also adds a local git configuration rule to ignore all
+# changes in the submodule.
 function(vcpkg_configure)
   cmake_parse_arguments(
     VCPKG 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [X] Non-functional change
- [ ] Documentation
- [X] Infrastructure

### Goals

Better organize CMake logic in the project so it's simpler to modify and understand.

### Technical Details

* Moved vcpkg-specific CMake logic to separate script in `cmake/vcpkg.cmake`.
* Refactored the logic into a function to increase clarity and re-usability.

### Test Results

Built the project and simulator driver successfully.

### Reviewer Focus

None

### Future Work

Additional refactoring and simplification of the vcpkg logic is necessary.

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
