### PR TITLE
Add configure preset for driver development

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -86,7 +86,8 @@
             "displayName": "Development (driver)",
             "description": "Development for the simulator driver",
             "inherits": [
-                "os-windows"
+                "os-windows",
+                "dev"
             ],
             "generator": "Visual Studio 17 2022",
             "architecture":{

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -6,6 +6,24 @@
     },
     "configurePresets": [
         {
+            "name": "os-windows",
+            "hidden": true,
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "os-linux",
+            "hidden": true,
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
             "name": "resolve-deps-fetchcontent",
             "hidden": true,
             "displayName": "Resolve dependencies with FetchContent",
@@ -64,6 +82,26 @@
             ]
         },
         {
+            "name": "dev-driver",
+            "displayName": "Development (driver)",
+            "description": "Development for the simulator driver",
+            "inherits": [
+                "os-windows"
+            ],
+            "generator": "Visual Studio 17 2022",
+            "architecture":{
+                "strategy": "set",
+                "value": "x64"
+            },
+            "toolset":{
+                "strategy": "set",
+                "value": "host=x64"
+            },
+            "cacheVariables": {
+                "CMAKE_CXX_COMPILER": "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.34.31933/bin/Hostx64/x64/cl.exe"
+            }
+        },
+        {
             "name": "vcpkg-dev",
             "displayName": "vcpkg (development)",
             "description": "vcpkg-based build with development (latest) sources",
@@ -101,6 +139,10 @@
             "name": "release",
             "configurePreset": "vcpkg-release",
             "configuration": "Release"
+        },
+        {
+            "name": "driver",
+            "configurePreset": "dev-driver"
         }
     ],
     "testPresets": [


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [X] Non-functional change
- [ ] Documentation
- [X] Infrastructure

### Goals

Enable easy configuration of build environment for building the simulator driver.

### Technical Details

* Add a CMake configuration preset `dev-driver` that captures and applies all necessary configuration for simulator driver development setup.

### Test Results

Built the project and driver with the new preset.

### Reviewer Focus

None

### Future Work

* Eventually try to remove specifying the `CXX_COMPILER` directly.
* A target for the MSbuild driver project should be added using the CMake helper `include_external_msproject`. Attempts so far have failed since CMake continues to select the VS build tools compilers instead of those shipping with Visual Studio, so additional work needs to be done here to workaround this problem.

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
