### PR TITLE
Add documentation for building the driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Both a compiler and standard C++ library supporting C++20 are required. The C++ 
 
 #### Windows
 
-[Visual Studio 2022](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Enterprise&channel=Release&version=VS2022&source=VSLandingPage&cid=2030&passive=false) generally satisfies the requirements, however, the full integrated development environment (IDE) is not needed. A much leaner alternative for those using other editors such as Visual Studio Code can instead install [Visual Studio Build Tools](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022). The build tools come with a C++ compatible compiler and standard library. Detailed development environment setup instructions can be found in the Windows [`README`](/windows/README.md).
+[Visual Studio 2022](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Enterprise&channel=Release&version=VS2022&source=VSLandingPage&cid=2030&passive=false) generally satisfies the requirements, however, the full integrated development environment (IDE) is not needed unless also building the [simulator driver](./windows/drivers/uwb/simulator/README.md). A much leaner alternative for those using other editors such as Visual Studio Code can instead install [Visual Studio Build Tools](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022). The build tools come with a C++ compatible compiler and standard library. Detailed development environment setup instructions can be found in the Windows [`README`](/windows/README.md).
 
 #### Linux
 

--- a/windows/drivers/uwb/simulator/README.md
+++ b/windows/drivers/uwb/simulator/README.md
@@ -4,7 +4,7 @@ This project is a simulated UMDF driver for Ultra-Wideband (UWB) devices on Wind
 
 ## Project Structure
 
-This project is organized to make use of the common development libraries provided by the nearobject-framework. However, being a UMDF Windows driver, it is not (yet) supported to be configured or built directly with CMake (see [here](https://gitlab.kitware.com/cmake/cmake/-/issues/23643) and [here](https://developercommunity.visualstudio.com/t/wdk-cmake-support/795126)). Consequently, it is a traditional MSBuild UMDF driver project using the `WindowsUserModeDriver10.0` platform toolset.
+This project is organized to make use of the common development libraries provided by the nearobject-framework. However, being a UMDF Windows driver, it is not (yet) supported to be configured or built directly with CMake (see [here](https://gitlab.kitware.com/cmake/cmake/-/issues/23643) and [here](https://developercommunity.visualstudio.com/t/wdk-cmake-support/795126)). Consequently, it is a traditional MSBuild UMDF driver project using the `WindowsUserModeDriver10.0` platform toolset. See the [build architecture section](#build-architecture) for additional details.
 
 ## Development Environment Setup
 
@@ -18,3 +18,37 @@ Pre-requisites:
 Follow the instructions on the [Windows WDK download page](https://learn.microsoft.com/en-us/windows-hardware/drivers/download-the-wdk) to install the above pre-requisites. In Step 1 when installing Visual Studio and selecting workloads, in addition to the `Desktop development with C++` workload, you must also install the `Linux and embedded development with C++` workload to obtain built-in support for vcpkg. The vcpkg support applies to Windows as well, but the feature started out on Linux and hasn't yet been moved to an appropriate VS installer feature set option.
 
 The project also contains a build task for Visual Studio Code. However, it is simple and only meant for convenience. Most build tasks and deployment scenarios will be much easier to accomplish from Visual Studio.
+
+## Build Architecture
+
+The simulator driver depends on a few libraries from the main nearobject-framework [project](../../../../README.md). These dependencies are resolved using the newly added [vcpkg support in Visual Studio](https://devblogs.microsoft.com/cppblog/vcpkg-environment-activation-in-visual-studio/)(Visual Studio 2022 17.4+). This is controlled by two files in the driver project:
+
+1. [vcpkg.json](./vcpkg.json): The vcpkg "manifest" which defines the dependencies this project depends on.
+2. [vcpkg-configuration.json](./vcpkg-configuration.json): The vcpkg configuration which defines where to resolve the dependencies defined in the vcpkg.json manifest.
+
+The main project defines a vcpkg called [`nearobject-framework`](../../../../packaging/vcpkg/ports/nearobject-framework/vcpkg.json) which makes its libraries available via vcpkg tooling. The package exposes a feature called `msvc-link-static-runtime` which forces its libraries to statically link against the VC++ runtime, which is required when using the `WindowsUserModeDriver10.0` platform toolset per [here](https://learn.microsoft.com/en-us/windows-hardware/drivers/develop/using-the-microsoft-c-runtime-with-user-mode-drivers-and-apps). Consequently, this feature is selected in the driver's vcpkg manifest. The package also exposes a ferature called `enable-development` which controls the version of the code the `nearobject-framework` vcpkg will make available. Typically, the package will expose a stable version of the code for public consumption. However, during early development of the feature, it is more common for the inner development loop to use the `HEAD` revision of the code. Consequently, the this feature is currently selected in the driver's vcpkg manifest. Eventually, this will be removed once a baseline working simulator driver has been established.
+
+### Quickstart: How to Build the Driver
+
+1. Check out the main project if not already done.
+2. Configure the project with CMake (see [here](../../../../README.md#cmake)).
+3. Open the simulator driver solution file [UwbSimulator.sln](UwbSimulator.sln) in Visual Studio 2022.
+4. Build the [`UwbSimulator`](./UwbSimulator.vcxproj) driver project.
+
+### Quickstart: How to push library updates into the driver project
+
+Any time new changes are made to dependent libraries in the main project (eg. `uwb`, `uwbcxadapter`, `uwbcx-driver`, etc.), Visual Studio must be instructed to rebuild the `nearobject-framework` vcpkg. The easiest way to do this is to delete the timestamp file associated with the package. This can be found under `${MSBuildProjectDirectory}/vcpkg_installed/x64-windows/.msbuildstamp-x64-windows.stamp`, for example `D:\src\nearobject-framework\windows\drivers\uwb\simulator\vcpkg_installed\x64-windows\.msbuildstamp-x64-windows.stamp`. So, the process to ingest the changes is:
+
+1. Make the changes to the main project library or libraries and ensure the `install` (or `ALL_BUILD`) target builds successfully.
+2. Commit the changes. The changes __do not__ have to be pushed to a remote; committing to the local repository is fine.
+3. Manually delete the UwbSimulator driver vcpkg timestamp file (`${MSBuildProjectDirectory}/vcpkg_installed/x64-windows/.msbuildstamp-x64-windows.stamp`).
+4. Rebuild the UwbSimulator driver project in Visual Studio.
+
+The project output window should display a line indicating the the `nerarobject-framework` vcpkg needs to be rebuilt, similar to below:
+
+```Shell
+1>The following packages will be rebuilt:
+1>    nearobject-framework[core,enable-development,msvc-link-static-runtime]:x64-windows -> 1.0.0 -- D:\src\nearobject-framework\windows\drivers\uwb\simulator\../../../../packaging/vcpkg/ports\nearobject-framework
+```
+
+The main project will eventually be updated to detect when a commit is made and automatically regenerate the vcpkg port file. Until then, this brief manual process must be followed.


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [X] Non-functional change
- [X] Documentation
- [ ] Infrastructure

### Goals

Ensure the driver can be built by other devs.

### Technical Details

* Expand the driver `README` with details of the build architecture and how to build it.

### Test Results

N/A

### Reviewer Focus

Consider whether someone unfamiliar with the driver setup could follow these instructions to produce a successful build.

### Future Work

* Some additional details about how the `vcpkg` port file and manifest are authored, including their CMake counterparts which generate the port file.

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
