### PR TITLE
Fixes for getting the simulator driver building

### DIFF
--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -4,6 +4,7 @@
 
 #include <uwb/protocols/fira/FiraDevice.hxx>
 #include <uwb/protocols/fira/UwbApplicationConfiguration.hxx>
+#include <uwb/protocols/fira/UwbCapability.hxx>
 #include <windows/devices/uwb/UwbCxDdiLrp.hxx>
 
 /**

--- a/windows/shared/logging/logging-plog-windows/CMakeLists.txt
+++ b/windows/shared/logging/logging-plog-windows/CMakeLists.txt
@@ -32,5 +32,5 @@ install(
     TARGETS logging-plog-windows
     EXPORT logging-plog-windows
     ARCHIVE
-    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/logging-plog-windows
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/logging/windows
 )

--- a/windows/shared/logging/logging-plog-windows/PlogTraceLogging.cxx
+++ b/windows/shared/logging/logging-plog-windows/PlogTraceLogging.cxx
@@ -1,2 +1,2 @@
-#include <logging/windows/PlogTraceLogging.hxx>
 
+#include <logging/windows/PlogTraceLogging.hxx>

--- a/windows/shared/logging/logging-plog-windows/include/logging/windows/PlogTraceLogging.hxx
+++ b/windows/shared/logging/logging-plog-windows/include/logging/windows/PlogTraceLogging.hxx
@@ -43,7 +43,7 @@ public:
     }
 
     virtual void
-    write(const ::plog::Record& record) PLOG_OVERRIDE
+    write(const ::plog::Record& record) override
     {
         std::wstring str = Formatter::format(record);
 

--- a/windows/shared/logging/logging-plog-windows/include/logging/windows/PlogTraceLogging.hxx
+++ b/windows/shared/logging/logging-plog-windows/include/logging/windows/PlogTraceLogging.hxx
@@ -12,9 +12,7 @@
 #include <iostream>
 #include <string>
 
-namespace logging
-{
-namespace plog
+namespace logging::plog
 {
 
 template <typename Formatter>
@@ -56,7 +54,6 @@ private:
     TraceLoggingHProvider m_providerHandle;
 };
 
-} // namespace plog
-} // namespace logging
+} // namespace logging::plog
 
 #endif // PLOG_TRACE_LOGGING_HXX


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Ensure the simulator driver builds.

### Technical Details

* Avoid use of `PLOG_OVERRIDE` since this is not defined in plog v1.1.8. For some reason, plog v1.1.8 is being resolved by vcpkg in the driver build instead of the public vcpkg portion defined version of v1.1.9.
* Add missing header `#include`.
* Set target link language explicitly and remove unneeded source file.

### Test Results

Driver builds successfully.

### Reviewer Focus

None

### Future Work

Need to determine why plog is resolving v1.1.8 instead of v1.1.9.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
