### PR TITLE
Enable building the UWB simulator driver based on CMake cache variable option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.16)
 # Project configuration options.
 option(NOF_USE_MSVC_STATIC_RUNTIME, "Statically link against the VC++ runtime library" OFF)
 option(NOF_CODE_COVERAGE "Enable instrumenting the build with code coverage" OFF)
+option(NOF_BUILD_WINDOWS_UWB_SIMULATOR_DRIVER "Enable building the Windows UWB Simulator driver" OFF)
 
 # Build environment definitions.
 # 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -99,7 +99,8 @@
                 "value": "host=x64"
             },
             "cacheVariables": {
-                "CMAKE_CXX_COMPILER": "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.34.31933/bin/Hostx64/x64/cl.exe"
+                "CMAKE_CXX_COMPILER": "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.34.31933/bin/Hostx64/x64/cl.exe",
+                "NOF_BUILD_WINDOWS_UWB_SIMULATOR_DRIVER": true
             }
         },
         {

--- a/windows/drivers/uwb/simulator/CMakeLists.txt
+++ b/windows/drivers/uwb/simulator/CMakeLists.txt
@@ -11,3 +11,13 @@ target_include_directories(uwbsim-driver
     INTERFACE 
         ${CMAKE_CURRENT_LIST_DIR}/include
 )
+
+# Build the simulator driver if enabled.
+if (NOF_BUILD_WINDOWS_UWB_SIMULATOR_DRIVER)
+  include_external_msproject(uwbsim-driver-msbuild 
+    ${CMAKE_CURRENT_LIST_DIR}/UwbSimulator.sln
+    uwb
+    uwbcxadapter
+    windev-uwb
+  )
+endif()


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [X] Infrastructure

### Goals

Allow building the simulator driver using CMake.

### Technical Details

* Add a new target `uwbsim-driver-msbuild` which is configured as an external MSBuild project. The target is conditionally defined based on a CMake cache option `NOF_BUILD_WINDOWS_UWB_SIMULATOR_DRIVER` which is off by default.

### Test Results

* Ensured the driver was built with the `"Development (driver)` CMake preset.
* Ensured the driver doesn't build when using any other CMake preset.

### Reviewer Focus

None

### Future Work

Enable automatic regeneration of `portfile.cmake` when a new commit is made, such that the driver will automatically pick up those changes.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
