### PR TITLE
Implement Uwb Simulator driver IOCTL_UWB_NOTIFICATION registration

### DIFF
--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -345,7 +345,7 @@ struct UwbDeviceInfoVendor
     virtual ~UwbDeviceInfoVendor() = default;
 };
 
-struct UwbDeviceInfoInformation
+struct UwbDeviceInformation
 {
     UwbVersion VersionUwb;
     UwbVersion VersionUci;

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -148,7 +148,7 @@ windows::devices::uwb::ddi::lrp::From(const UwbSessionState uwbSessionState)
 }
 
 UWB_DEVICE_INFO
-windows::devices::uwb::ddi::lrp::From(const UwbDeviceInfoInformation& uwbDeviceInfo)
+windows::devices::uwb::ddi::lrp::From(const UwbDeviceInformation& uwbDeviceInfo)
 {
     UWB_DEVICE_INFO deviceInfo{};
     deviceInfo.size = sizeof deviceInfo;

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -48,13 +48,13 @@ UWB_SESSION_STATE
 From(const ::uwb::protocol::fira::UwbSessionState uwbSessionState);
 
 /**
- * @brief Converts UwbDeviceInfoInformation to UWB_DEVICE_INFO.
+ * @brief Converts UwbDeviceInformation to UWB_DEVICE_INFO.
  *
  * @param uwbDeviceInfo
  * @return UWB_DEVICE_INFO
  */
 UWB_DEVICE_INFO
-From(const ::uwb::protocol::fira::UwbDeviceInfoInformation &uwbDeviceInfo);
+From(const ::uwb::protocol::fira::UwbDeviceInformation &uwbDeviceInfo);
 
 /**
  * @brief Converts UwbCapability to UWB_DEVICE_CAPABILITIES.

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacksLrp.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacksLrp.hxx
@@ -174,7 +174,7 @@ struct UwbSimulatorDdiCallbacksLrp
      * @param notificationData
      */
     virtual void
-    UwbNotification(UwbNotificationData& notificationData) = 0;
+    UwbNotification(UwbNotificationData &notificationData) = 0;
 };
 } // namespace windows::devices::uwb::simulator
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacksLrp.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacksLrp.hxx
@@ -41,7 +41,7 @@ struct UwbSimulatorDdiCallbacksLrp
      * @return UwbStatus
      */
     virtual UwbStatus
-    DeviceGetInformation(UwbDeviceInfoInformation &deviceInfo) = 0;
+    DeviceGetInformation(UwbDeviceInformation &deviceInfo) = 0;
 
     /**
      * @brief
@@ -174,7 +174,7 @@ struct UwbSimulatorDdiCallbacksLrp
      * @param notificationData
      */
     virtual void
-    UwbNotification(UwbNotificationData notificationData) = 0;
+    UwbNotification(UwbNotificationData& notificationData) = 0;
 };
 } // namespace windows::devices::uwb::simulator
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacksLrpNoop.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacksLrpNoop.cxx
@@ -193,7 +193,7 @@ UwbSimulatorDdiCallbacksLrpNoop::SessionGetRangingCount(uint32_t /* sessionId */
 }
 
 void
-UwbSimulatorDdiCallbacksLrpNoop::UwbNotification(UwbNotificationData& notificationData)
+UwbSimulatorDdiCallbacksLrpNoop::UwbNotification(UwbNotificationData &notificationData)
 {
     // Acquire the notification lock to ensure the notification proimise can be safely inspected and updated.
     std::unique_lock notificationLock{ m_notificationGate };

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacksLrpNoop.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacksLrpNoop.cxx
@@ -1,7 +1,6 @@
 
 #include <algorithm>
 #include <iterator>
-#include <mutex>
 
 #include <windows/devices/uwb/UwbCxAdapterDdiLrp.hxx>
 
@@ -38,7 +37,7 @@ UwbSimulatorDdiCallbacksLrpNoop::DeviceReset()
 }
 
 UwbStatus
-UwbSimulatorDdiCallbacksLrpNoop::DeviceGetInformation(UwbDeviceInfoInformation &deviceInformation)
+UwbSimulatorDdiCallbacksLrpNoop::DeviceGetInformation(UwbDeviceInformation &deviceInformation)
 {
     deviceInformation = m_deviceInformation;
     return UwbStatusOk;
@@ -194,6 +193,22 @@ UwbSimulatorDdiCallbacksLrpNoop::SessionGetRangingCount(uint32_t /* sessionId */
 }
 
 void
-UwbSimulatorDdiCallbacksLrpNoop::UwbNotification(UwbNotificationData notificationData)
+UwbSimulatorDdiCallbacksLrpNoop::UwbNotification(UwbNotificationData& notificationData)
 {
+    // Acquire the notification lock to ensure the notification proimise can be safely inspected and updated.
+    std::unique_lock notificationLock{ m_notificationGate };
+    if (m_notificationPromise.has_value()) {
+        // pre-existing promise, this should not happen. TODO: log it.
+        return;
+    }
+
+    // Create a new promise whose shared state will be updated when a notification is raised.
+    auto notificationFuture = m_notificationPromise.emplace().get_future();
+
+    // Release the lock since the shared data (promise) has been created and future obtained.
+    notificationLock.unlock();
+
+    // Lock is now released; synchronously wait indefinitely for the shared state to be updated.
+    notificationFuture.wait();
+    notificationData = notificationFuture.get();
 }

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacksLrpNoop.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacksLrpNoop.hxx
@@ -84,7 +84,6 @@ private:
     std::shared_mutex m_sessionsGate;
     std::unordered_map<uint32_t, UwbSimulatorSession> m_sessions{};
 
-    
     // Notification promise and associated lock that protects it.
     std::mutex m_notificationGate;
     std::optional<std::promise<UwbNotificationData>> m_notificationPromise;

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacksLrpNoop.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacksLrpNoop.hxx
@@ -69,7 +69,7 @@ struct UwbSimulatorDdiCallbacksLrpNoop :
     SessionGetRangingCount(uint32_t sessionId, uint32_t &rangingCount) override;
 
     virtual void
-    UwbNotification(UwbNotificationData& notificationData) override;
+    UwbNotification(UwbNotificationData &notificationData) override;
 
 protected:
     void
@@ -79,7 +79,7 @@ private:
     // Static device information.
     UwbDeviceInformation m_deviceInformation{};
     UwbCapability m_deviceCapabilities{};
-    
+
     // Session state and associated lock that protects it.
     std::shared_mutex m_sessionsGate;
     std::unordered_map<uint32_t, UwbSimulatorSession> m_sessions{};

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacksLrpNoop.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacksLrpNoop.hxx
@@ -3,7 +3,10 @@
 #define UWB_SIMULATOR_DDI_CALLBACKS_LRP_NOOP
 
 #include <cstdint>
+#include <future>
 #include <memory>
+#include <mutex>
+#include <optional>
 #include <shared_mutex>
 #include <unordered_map>
 #include <vector>
@@ -24,7 +27,7 @@ struct UwbSimulatorDdiCallbacksLrpNoop :
     DeviceReset() override;
 
     virtual UwbStatus
-    DeviceGetInformation(UwbDeviceInfoInformation &deviceInfo) override;
+    DeviceGetInformation(UwbDeviceInformation &deviceInfo) override;
 
     virtual UwbStatus
     DeviceGetCapabilities(UwbCapability &deviceCapabilities) override;
@@ -66,17 +69,25 @@ struct UwbSimulatorDdiCallbacksLrpNoop :
     SessionGetRangingCount(uint32_t sessionId, uint32_t &rangingCount) override;
 
     virtual void
-    UwbNotification(UwbNotificationData notificationData) override;
+    UwbNotification(UwbNotificationData& notificationData) override;
 
 protected:
     void
     SessionUpdateState(UwbSimulatorSession &session, UwbSessionState sessionState);
 
 private:
-    std::shared_mutex m_sessionsGate;
-    UwbDeviceInfoInformation m_deviceInformation{};
+    // Static device information.
+    UwbDeviceInformation m_deviceInformation{};
     UwbCapability m_deviceCapabilities{};
+    
+    // Session state and associated lock that protects it.
+    std::shared_mutex m_sessionsGate;
     std::unordered_map<uint32_t, UwbSimulatorSession> m_sessions{};
+
+    
+    // Notification promise and associated lock that protects it.
+    std::mutex m_notificationGate;
+    std::optional<std::promise<UwbNotificationData>> m_notificationPromise;
 };
 } // namespace windows::devices::uwb::simulator
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.cxx
@@ -88,7 +88,7 @@ UwbSimulatorDdiHandlerLrp::OnUwbGetDeviceInformation(WDFREQUEST request, std::sp
     NTSTATUS status = STATUS_SUCCESS;
 
     // Execute callback.
-    UwbDeviceInfoInformation deviceInformation{};
+    UwbDeviceInformation deviceInformation{};
     auto statusUwb = m_callbacks->DeviceGetInformation(deviceInformation);
 
     // Convert neutral types to DDI types.


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [x] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Allow registering for UWB notifications on a driver handle.

### Technical Details

* Implement the registration portion of `IOCTL_UWB_NOTIFICATION` in the simulator driver. This involves creating a `std::promise` to track the registration, whose future is updated when the next notification occurs.
* Change `UwbDeviceInfoInformation` to `UwbDeviceInformation` to eliminate typo.
* Add comments to `UwbSimulatorDdiCallbacksLrpNoop` members, describing their concurrency and access requirements.
* Update the notification calback API to accept a reference instead of a copy of `UwbNotificationData` so it can be used as an output argument.

### Test Results

Build tested only. Proper tests will be exercised once the code to update the shared state is updated.

### Reviewer Focus

Consider whether the locking strategy is sane and safe.

### Future Work

* This PR only implements the registration portion. The code to complete the promise and update its shared state needs to be implemented. In its current form, the client will wait on the file handle for the notification to complete indefinitely (it will never complete).

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
