### PR TITLE
Add ToString() implementations for UWB notification neutral types

### DIFF
--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -464,8 +464,8 @@ struct UwbSessionUpdateMulicastListStatus
 
     /**
      * @brief Returns a string representation of the object.
-     * 
-     * @return std::string 
+     *
+     * @return std::string
      */
     std::string
     ToString() const;
@@ -491,6 +491,14 @@ struct UwbRangingMeasurementData
     uint16_t Result;
     std::optional<uint8_t> FigureOfMerit;
     decltype(FigureOfMerit)& FoM = FigureOfMerit;
+
+    /**
+     * @brief Returns a string representation of the object.
+     *
+     * @return std::string
+     */
+    std::string
+    ToString() const;
 };
 
 struct UwbRangingMeasurement
@@ -504,6 +512,14 @@ struct UwbRangingMeasurement
     UwbRangingMeasurementData AoAElevation;
     UwbRangingMeasurementData AoaDestinationAzimuth;
     UwbRangingMeasurementData AoaDestinationElevation;
+
+    /**
+     * @brief Returns a string representation of the object.
+     *
+     * @return std::string
+     */
+    std::string
+    ToString() const;
 };
 
 struct UwbRangingData
@@ -524,6 +540,15 @@ struct UwbRangingData
 };
 
 using UwbNotificationData = std::variant<UwbStatus, UwbStatusDevice, UwbSessionStatus, UwbSessionUpdateMulicastListStatus, UwbRangingData>;
+
+/**
+ * @brief Returns a string representation of the object.
+ *
+ * @param uwbStatus
+ * @return std::string
+ */
+std::string
+ToString(const UwbStatus& uwbStatus);
 
 /**
  * @brief Returns a string representation of the object.


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Ensure neutral types related to UWB notifications have string representations so they can be output to the command line and logs.

### Technical Details

* Implement `ToString()` functions that were previously unimplemented.
* Add `ToString()` functions for types involved in UWB notifications but previously did not have prototypes.

### Test Results

Compile tested only. 

### Reviewer Focus

None

### Future Work

* The `ToString()` output format might later be formalized.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
