### PR TITLE
remove timestamp upon reconfigure

### DIFF
--- a/packaging/vcpkg/CMakeLists.txt
+++ b/packaging/vcpkg/CMakeLists.txt
@@ -48,10 +48,15 @@ MESSAGE(STATUS "using vcpkg target ${NOF_VCPKG_TARGET} with ${NOF_VCPKG_GIT_URL}
 set(NOF_VCPKG_PORT_FILE_OUT ${CMAKE_CURRENT_LIST_DIR}/ports/nearobject-framework/portfile.cmake)
 set(NOF_VCPKG_PORT_FILE_IN ${NOF_VCPKG_PORT_FILE_OUT}.in)
 
-# Delete the timestamp file
-set(SIMULATOR_DRIVER_VCPKG_TIMESTAMP_FILE ${CMAKE_SOURCE_DIR}/windows/drivers/uwb/simulator/vcpkg_installed/x64-windows/.msbuildstamp-x64-windows.stamp)
-message(STATUS "removing simulator driver timestamp file: ${SIMULATOR_DRIVER_VCPKG_TIMESTAMP_FILE}")
-file(REMOVE ${SIMULATOR_DRIVER_VCPKG_TIMESTAMP_FILE})
+# Delete the vcpkg timestamp file
+
+# VS uses the MSBuild platform value ($(Platform)) to name the vcpkg timestamp file. This is not easy to obtain from CMake, so it is hardcoded for now, meaning this will only work on amd64/x64 architectures.
+set(NOF_WINDOWS_PLATFORM "x64")
+set(WINDOWS_UWB_SIMULATOR_DRIVER_VCPKG_TIMESTAMP_FILE ${CMAKE_SOURCE_DIR}/windows/drivers/uwb/simulator/vcpkg_installed/${NOF_WINDOWS_PLATFORM}-windows/.msbuildstamp-${NOF_WINDOWS_PLATFORM}-windows.stamp)
+message(STATUS "removing Windows simulator driver vcpkg timestamp file: ${WINDOWS_UWB_SIMULATOR_DRIVER_VCPKG_TIMESTAMP_FILE }")
+
+file(REMOVE ${WINDOWS_UWB_SIMULATOR_DRIVER_VCPKG_TIMESTAMP_FILE })
+
 
 # Generate portfile.cmake with selected versioning and configuration information.
 configure_file(${NOF_VCPKG_PORT_FILE_IN} ${NOF_VCPKG_PORT_FILE_OUT} @ONLY)

--- a/packaging/vcpkg/CMakeLists.txt
+++ b/packaging/vcpkg/CMakeLists.txt
@@ -53,9 +53,9 @@ set(NOF_VCPKG_PORT_FILE_IN ${NOF_VCPKG_PORT_FILE_OUT}.in)
 # VS uses the MSBuild platform value ($(Platform)) to name the vcpkg timestamp file. This is not easy to obtain from CMake, so it is hardcoded for now, meaning this will only work on amd64/x64 architectures.
 set(NOF_WINDOWS_PLATFORM "x64")
 set(WINDOWS_UWB_SIMULATOR_DRIVER_VCPKG_TIMESTAMP_FILE ${CMAKE_SOURCE_DIR}/windows/drivers/uwb/simulator/vcpkg_installed/${NOF_WINDOWS_PLATFORM}-windows/.msbuildstamp-${NOF_WINDOWS_PLATFORM}-windows.stamp)
-message(STATUS "removing Windows simulator driver vcpkg timestamp file: ${WINDOWS_UWB_SIMULATOR_DRIVER_VCPKG_TIMESTAMP_FILE }")
+message(STATUS "removing Windows simulator driver vcpkg timestamp file: ${WINDOWS_UWB_SIMULATOR_DRIVER_VCPKG_TIMESTAMP_FILE}")
 
-file(REMOVE ${WINDOWS_UWB_SIMULATOR_DRIVER_VCPKG_TIMESTAMP_FILE })
+file(REMOVE ${WINDOWS_UWB_SIMULATOR_DRIVER_VCPKG_TIMESTAMP_FILE})
 
 
 # Generate portfile.cmake with selected versioning and configuration information.

--- a/packaging/vcpkg/CMakeLists.txt
+++ b/packaging/vcpkg/CMakeLists.txt
@@ -48,5 +48,10 @@ MESSAGE(STATUS "using vcpkg target ${NOF_VCPKG_TARGET} with ${NOF_VCPKG_GIT_URL}
 set(NOF_VCPKG_PORT_FILE_OUT ${CMAKE_CURRENT_LIST_DIR}/ports/nearobject-framework/portfile.cmake)
 set(NOF_VCPKG_PORT_FILE_IN ${NOF_VCPKG_PORT_FILE_OUT}.in)
 
+# Delete the timestamp file
+set(SIMULATOR_DRIVER_VCPKG_TIMESTAMP_FILE ${CMAKE_SOURCE_DIR}/windows/drivers/uwb/simulator/vcpkg_installed/x64-windows/.msbuildstamp-x64-windows.stamp)
+message(STATUS "removing simulator driver timestamp file: ${SIMULATOR_DRIVER_VCPKG_TIMESTAMP_FILE}")
+file(REMOVE ${SIMULATOR_DRIVER_VCPKG_TIMESTAMP_FILE})
+
 # Generate portfile.cmake with selected versioning and configuration information.
 configure_file(${NOF_VCPKG_PORT_FILE_IN} ${NOF_VCPKG_PORT_FILE_OUT} @ONLY)


### PR DESCRIPTION
This change removes the timestamp, forcing the simulator driver to rebuild upon running cmake again.