### PR TITLE
Implement UWB driver notification handler basics

### DIFF
--- a/lib/uwb/CMakeLists.txt
+++ b/lib/uwb/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(uwb
         ${CMAKE_CURRENT_LIST_DIR}/UwbVersion.cxx
     PUBLIC
         ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbDevice.hxx
+        ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbDeviceEventCallbacks.hxx
         ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbMacAddress.hxx
         ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbPeer.hxx
         ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbSession.hxx
@@ -37,6 +38,7 @@ target_link_libraries(uwb
 
 list(APPEND UWB_PUBLIC_HEADERS
     ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbDevice.hxx
+    ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbDeviceEventCallbacks.hxx
     ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbMacAddress.hxx
     ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbPeer.hxx
     ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbSession.hxx

--- a/lib/uwb/UwbDevice.cxx
+++ b/lib/uwb/UwbDevice.cxx
@@ -1,5 +1,62 @@
 
+#include <type_traits>
+#include <variant>
+
 #include <uwb/UwbDevice.hxx>
+
+using namespace uwb;
+using namespace uwb::protocol::fira;
+
+void
+UwbDevice::OnStatusChanged([[maybe_unused]] UwbStatus /* status */)
+{
+    // TODO: implement this
+}
+
+void
+UwbDevice::OnDeviceStatusChanged([[maybe_unused]] UwbStatusDevice statusDevice)
+{
+    // TODO: implement this
+}
+
+void
+UwbDevice::OnSessionStatusChanged([[maybe_unused]] UwbSessionStatus statusSession)
+{
+    // TODO: implement this
+}
+
+void
+UwbDevice::OnSessionMulticastListStatus([[maybe_unused]] UwbSessionUpdateMulicastListStatus /* statusMulticastList */)
+{
+    // TODO: implement this
+}
+
+void
+UwbDevice::OnSessionRangingData([[maybe_unused]] UwbRangingData rangingData)
+{
+    // TODO: implement this
+}
+
+void
+UwbDevice::OnUwbNotification(UwbNotificationData uwbNotificationData)
+{
+    std::visit([this](auto&& arg) {
+        using ValueType = std::decay_t<decltype(arg)>;
+
+        if constexpr (std::is_same_v<ValueType, UwbStatus>) {
+            OnStatusChanged(arg);
+        } else if constexpr (std::is_same_v<ValueType, UwbStatusDevice>) {
+            OnDeviceStatusChanged(arg);
+        } else if constexpr (std::is_same_v<ValueType, UwbSessionStatus>) {
+            OnSessionStatusChanged(arg);
+        } else if constexpr (std::is_same_v<ValueType, UwbSessionUpdateMulicastListStatus>) {
+            OnSessionMulticastListStatus(arg);
+        } else if constexpr (std::is_same_v<ValueType, UwbRangingData>) {
+            OnSessionRangingData(arg);
+        }
+    },
+        uwbNotificationData);
+}
 
 bool
 uwb::operator==(const UwbDevice& lhs, const UwbDevice& rhs) noexcept

--- a/lib/uwb/UwbDevice.cxx
+++ b/lib/uwb/UwbDevice.cxx
@@ -8,7 +8,7 @@ using namespace uwb;
 using namespace uwb::protocol::fira;
 
 void
-UwbDevice::OnStatusChanged([[maybe_unused]] UwbStatus /* status */)
+UwbDevice::OnStatusChanged([[maybe_unused]] UwbStatus status)
 {
     // TODO: implement this
 }
@@ -26,7 +26,7 @@ UwbDevice::OnSessionStatusChanged([[maybe_unused]] UwbSessionStatus statusSessio
 }
 
 void
-UwbDevice::OnSessionMulticastListStatus([[maybe_unused]] UwbSessionUpdateMulicastListStatus /* statusMulticastList */)
+UwbDevice::OnSessionMulticastListStatus([[maybe_unused]] UwbSessionUpdateMulicastListStatus statusMulticastList)
 {
     // TODO: implement this
 }

--- a/lib/uwb/include/uwb/UwbDevice.hxx
+++ b/lib/uwb/include/uwb/UwbDevice.hxx
@@ -4,8 +4,9 @@
 
 #include <memory>
 
-#include <uwb/protocols/fira/UwbCapability.hxx>
 #include <uwb/UwbSessionEventCallbacks.hxx>
+#include <uwb/protocols/fira/FiraDevice.hxx>
+#include <uwb/protocols/fira/UwbCapability.hxx>
 
 namespace uwb
 {
@@ -19,26 +20,26 @@ class UwbDevice
 public:
     /**
      * @brief Creates a new UWB session with no configuration nor peers.
-     * 
-     * @return std::unique_ptr<uwb::UwbSession> 
+     *
+     * @return std::unique_ptr<uwb::UwbSession>
      */
     virtual std::unique_ptr<UwbSession>
     CreateSession(std::weak_ptr<UwbSessionEventCallbacks> callbacks) = 0;
 
     /**
      * @brief Get the FiRa capabilities of the device.
-     * 
-     * @return uwb::protocol::fira::UwbCapability 
+     *
+     * @return uwb::protocol::fira::UwbCapability
      */
     virtual uwb::protocol::fira::UwbCapability
     GetCapabilities() const = 0;
 
     /**
      * @brief Determine if this device is the same as another.
-     * 
-     * @param other 
-     * @return true 
-     * @return false 
+     *
+     * @param other
+     * @return true
+     * @return false
      */
     virtual bool
     IsEqual(const UwbDevice& other) const noexcept = 0;
@@ -47,6 +48,56 @@ public:
      * @brief Destroy the UwbDevice object.
      */
     virtual ~UwbDevice() = default;
+
+protected:
+    /**
+     * @brief Invoked when a UWB notification has been received.
+     *
+     * @param uwbNotificationData
+     */
+    void
+    OnUwbNotification(::uwb::protocol::fira::UwbNotificationData uwbNotificationData);
+
+private:
+     /**
+     * @brief Invoked when a generic error occurs. 
+     * 
+     * @param status The generic error that occurred.
+     */
+    void
+    OnStatusChanged(::uwb::protocol::fira::UwbStatus status);
+
+    /**
+     * @brief Invoked when the device status changes.
+     * 
+     * @param statusDevice 
+     */
+    void 
+    OnDeviceStatusChanged(::uwb::protocol::fira::UwbStatusDevice statusDevice);
+
+    /**
+     * @brief Invoked when the status of a session changes.
+     * 
+     * @param statusSession The new status of the session.
+     */
+    void
+    OnSessionStatusChanged(::uwb::protocol::fira::UwbSessionStatus statusSession);
+
+    /**
+     * @brief Invoked when the multicast list for a session has a status update.
+     * 
+     * @param statusMulticastList The status of the session's multicast list.
+     */
+    void
+    OnSessionMulticastListStatus(::uwb::protocol::fira::UwbSessionUpdateMulicastListStatus statusMulticastList);
+
+    /**
+     * @brief Invoked when a session has a ranging data update. 
+     * 
+     * @param rangingData The new ranging data.
+     */
+    void
+    OnSessionRangingData(::uwb::protocol::fira::UwbRangingData rangingData);
 };
 
 bool

--- a/lib/uwb/include/uwb/UwbDevice.hxx
+++ b/lib/uwb/include/uwb/UwbDevice.hxx
@@ -59,9 +59,9 @@ protected:
     OnUwbNotification(::uwb::protocol::fira::UwbNotificationData uwbNotificationData);
 
 private:
-     /**
-     * @brief Invoked when a generic error occurs. 
-     * 
+    /**
+     * @brief Invoked when a generic error occurs.
+     *
      * @param status The generic error that occurred.
      */
     void
@@ -69,15 +69,15 @@ private:
 
     /**
      * @brief Invoked when the device status changes.
-     * 
-     * @param statusDevice 
+     *
+     * @param statusDevice
      */
-    void 
+    void
     OnDeviceStatusChanged(::uwb::protocol::fira::UwbStatusDevice statusDevice);
 
     /**
      * @brief Invoked when the status of a session changes.
-     * 
+     *
      * @param statusSession The new status of the session.
      */
     void
@@ -85,15 +85,15 @@ private:
 
     /**
      * @brief Invoked when the multicast list for a session has a status update.
-     * 
+     *
      * @param statusMulticastList The status of the session's multicast list.
      */
     void
     OnSessionMulticastListStatus(::uwb::protocol::fira::UwbSessionUpdateMulicastListStatus statusMulticastList);
 
     /**
-     * @brief Invoked when a session has a ranging data update. 
-     * 
+     * @brief Invoked when a session has a ranging data update.
+     *
      * @param rangingData The new ranging data.
      */
     void

--- a/lib/uwb/include/uwb/UwbDeviceEventCallbacks.hxx
+++ b/lib/uwb/include/uwb/UwbDeviceEventCallbacks.hxx
@@ -1,0 +1,63 @@
+
+#ifndef UWB_DEVICE_EVENT_CALLBACKS_HXX
+#define UWB_DEVICE_EVENT_CALLBACKS_HXX
+
+#include <uwb/protocols/fira/FiraDevice.hxx>
+
+namespace uwb
+{
+/**
+ * @brief Interface for receiving events from a UwbDevice. This is the primary
+ * method to receive information from the device driver.
+ */
+struct UwbDeviceEventCallbacks
+{
+    /**
+     * @brief Destroy the UwbDeviceEventCallbacks object, defined to support
+     * polymorphic deletion.
+     */
+    virtual ~UwbDeviceEventCallbacks() = default;
+
+    /**
+     * @brief Invoked when a generic error occurs. 
+     * 
+     * @param status The generic error that occurred.
+     */
+    virtual void
+    OnStatusChanged(::uwb::protocol::fira::UwbStatus status) = 0;
+
+    /**
+     * @brief Invoked when the device status changes.
+     * 
+     * @param statusDevice 
+     */
+    virtual void 
+    OnDeviceStatusChanged(::uwb::protocol::fira::UwbStatusDevice statusDevice) = 0;
+
+    /**
+     * @brief Invoked when the status of a session changes.
+     * 
+     * @param statusSession The new status of the session.
+     */
+    virtual void
+    OnSessionStatusChanged(::uwb::protocol::fira::UwbSessionStatus statusSession) = 0;
+
+    /**
+     * @brief Invoked when the multicast list for a session has a status update.
+     * 
+     * @param statusMulticastList The status of the session's multicast list.
+     */
+    virtual void
+    OnSessionMulticastListStatus(::uwb::protocol::fira::UwbSessionUpdateMulicastListStatus statusMulticastList) = 0;
+
+    /**
+     * @brief Invoke when a session has a ranging data update. 
+     * 
+     * @param rangingData The new ranging data.
+     */
+    virtual void
+    OnSessionRangingData(::uwb::protocol::fira::UwbRangingData rangingData) = 0;
+};
+} // namespace uwb
+
+#endif //  UWB_DEVICE_EVENT_CALLBACKS_HXX

--- a/lib/uwb/include/uwb/UwbDeviceEventCallbacks.hxx
+++ b/lib/uwb/include/uwb/UwbDeviceEventCallbacks.hxx
@@ -19,8 +19,8 @@ struct UwbDeviceEventCallbacks
     virtual ~UwbDeviceEventCallbacks() = default;
 
     /**
-     * @brief Invoked when a generic error occurs. 
-     * 
+     * @brief Invoked when a generic error occurs.
+     *
      * @param status The generic error that occurred.
      */
     virtual void
@@ -28,15 +28,15 @@ struct UwbDeviceEventCallbacks
 
     /**
      * @brief Invoked when the device status changes.
-     * 
-     * @param statusDevice 
+     *
+     * @param statusDevice
      */
-    virtual void 
+    virtual void
     OnDeviceStatusChanged(::uwb::protocol::fira::UwbStatusDevice statusDevice) = 0;
 
     /**
      * @brief Invoked when the status of a session changes.
-     * 
+     *
      * @param statusSession The new status of the session.
      */
     virtual void
@@ -44,15 +44,15 @@ struct UwbDeviceEventCallbacks
 
     /**
      * @brief Invoked when the multicast list for a session has a status update.
-     * 
+     *
      * @param statusMulticastList The status of the session's multicast list.
      */
     virtual void
     OnSessionMulticastListStatus(::uwb::protocol::fira::UwbSessionUpdateMulicastListStatus statusMulticastList) = 0;
 
     /**
-     * @brief Invoked when a session has a ranging data update. 
-     * 
+     * @brief Invoked when a session has a ranging data update.
+     *
      * @param rangingData The new ranging data.
      */
     virtual void

--- a/lib/uwb/include/uwb/UwbDeviceEventCallbacks.hxx
+++ b/lib/uwb/include/uwb/UwbDeviceEventCallbacks.hxx
@@ -8,7 +8,7 @@ namespace uwb
 {
 /**
  * @brief Interface for receiving events from a UwbDevice. This is the primary
- * method to receive information from the device driver.
+ * method to receive event information from the device driver.
  */
 struct UwbDeviceEventCallbacks
 {

--- a/lib/uwb/include/uwb/UwbDeviceEventCallbacks.hxx
+++ b/lib/uwb/include/uwb/UwbDeviceEventCallbacks.hxx
@@ -51,7 +51,7 @@ struct UwbDeviceEventCallbacks
     OnSessionMulticastListStatus(::uwb::protocol::fira::UwbSessionUpdateMulicastListStatus statusMulticastList) = 0;
 
     /**
-     * @brief Invoke when a session has a ranging data update. 
+     * @brief Invoked when a session has a ranging data update. 
      * 
      * @param rangingData The new ranging data.
      */

--- a/tests/unit/uwb/CMakeLists.txt
+++ b/tests/unit/uwb/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(uwb-test
         ${CMAKE_CURRENT_LIST_DIR}/protocols/fira/TestUwbFiraUwbConfiguration.cxx
         ${CMAKE_CURRENT_LIST_DIR}/protocols/fira/TestUwbFiraUwbConfigurationBuilder.cxx
         ${CMAKE_CURRENT_LIST_DIR}/TestUwbDevice.cxx
+        ${CMAKE_CURRENT_LIST_DIR}/TestUwbDeviceCallbacks.cxx
         ${CMAKE_CURRENT_LIST_DIR}/TestUwbMacAddress.cxx
         ${CMAKE_CURRENT_LIST_DIR}/TestUwbPeer.cxx
 )

--- a/tests/unit/uwb/TestUwbDeviceCallbacks.cxx
+++ b/tests/unit/uwb/TestUwbDeviceCallbacks.cxx
@@ -1,0 +1,47 @@
+
+#include <memory>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <uwb/UwbDeviceEventCallbacks.hxx>
+#include <uwb/protocols/fira/FiraDevice.hxx>
+
+namespace uwb::test
+{
+struct UwbDeviceCallbacksTest : public UwbDeviceEventCallbacks
+{
+    ~UwbDeviceCallbacksTest() = default;
+
+    void
+    OnStatusChanged(::uwb::protocol::fira::UwbStatus /* status */) override
+    {
+    }
+
+    void 
+    OnDeviceStatusChanged(::uwb::protocol::fira::UwbStatusDevice /* statusDevice */) override
+    {
+    }
+
+    void
+    OnSessionStatusChanged(::uwb::protocol::fira::UwbSessionStatus /* statusSession */) override
+    {
+    }
+
+    void
+    OnSessionMulticastListStatus(::uwb::protocol::fira::UwbSessionUpdateMulicastListStatus /* statusMulticastList */) override
+    {
+    }
+
+    void
+    OnSessionRangingData(::uwb::protocol::fira::UwbRangingData /* rangingData */) override
+    {
+    }
+};
+} // namespace uwb::test
+
+TEST_CASE("uwb device callbacks can be created", "[basic]")
+{
+    using namespace uwb;
+
+    auto callbacks = std::make_unique<test::UwbDeviceCallbacksTest>();
+}

--- a/tests/unit/uwb/TestUwbDeviceCallbacks.cxx
+++ b/tests/unit/uwb/TestUwbDeviceCallbacks.cxx
@@ -13,27 +13,27 @@ struct UwbDeviceCallbacksTest : public UwbDeviceEventCallbacks
     ~UwbDeviceCallbacksTest() = default;
 
     void
-    OnStatusChanged(::uwb::protocol::fira::UwbStatus /* status */) override
-    {
-    }
-
-    void 
-    OnDeviceStatusChanged(::uwb::protocol::fira::UwbStatusDevice /* statusDevice */) override
+    OnStatusChanged([[maybe_unused]] ::uwb::protocol::fira::UwbStatus status) override
     {
     }
 
     void
-    OnSessionStatusChanged(::uwb::protocol::fira::UwbSessionStatus /* statusSession */) override
+    OnDeviceStatusChanged([[maybe_unused]] ::uwb::protocol::fira::UwbStatusDevice statusDevice) override
     {
     }
 
     void
-    OnSessionMulticastListStatus(::uwb::protocol::fira::UwbSessionUpdateMulicastListStatus /* statusMulticastList */) override
+    OnSessionStatusChanged([[maybe_unused]] ::uwb::protocol::fira::UwbSessionStatus statusSession) override
     {
     }
 
     void
-    OnSessionRangingData(::uwb::protocol::fira::UwbRangingData /* rangingData */) override
+    OnSessionMulticastListStatus([[maybe_unused]] ::uwb::protocol::fira::UwbSessionUpdateMulicastListStatus statusMulticastList) override
+    {
+    }
+
+    void
+    OnSessionRangingData([[maybe_unused]] ::uwb::protocol::fira::UwbRangingData rangingData) override
     {
     }
 };

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -380,3 +380,11 @@ windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbNotificati
 
     return notificationData;
 }
+
+::uwb::protocol::fira::UwbNotificationData
+windows::devices::uwb::ddi::lrp::To(const UWB_NOTIFICATION_DATA& /* notificationData */)
+{
+    UwbNotificationData uwbNotificationData{};
+    // TODO: implement this
+    return uwbNotificationData;
+}

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -9,8 +9,8 @@
 #include <variant>
 #include <vector>
 
-#include <plog/Log.h>
 #include <notstd/utility.hxx>
+#include <plog/Log.h>
 #include <wil/common.h>
 
 #include <uwb/protocols/fira/UwbCapability.hxx>
@@ -402,9 +402,9 @@ namespace detail
  */
 template <std::size_t N, typename T>
 void
-ProcessSupportFromBitset(std::unordered_map<T, std::size_t> map, const std::bitset<N>& support, std::vector<T>& result)
+ProcessSupportFromBitset(std::unordered_map<T, std::size_t> map, const std::bitset<N> &support, std::vector<T> &result)
 {
-    for (const auto& [value, bit] : map) {
+    for (const auto &[value, bit] : map) {
         if (support.test(bit)) {
             result.push_back(value);
         }
@@ -413,60 +413,60 @@ ProcessSupportFromBitset(std::unordered_map<T, std::size_t> map, const std::bits
 } // namespace detail
 
 UwbCapability
-windows::devices::uwb::ddi::lrp::To(const UWB_DEVICE_CAPABILITIES& deviceCapabilities)
+windows::devices::uwb::ddi::lrp::To(const UWB_DEVICE_CAPABILITIES &deviceCapabilities)
 {
     UwbCapability uwbCapability;
 
     for (const auto capability : wil::make_range(&deviceCapabilities.capabilityParams[0], deviceCapabilities.capabilityParamsCount)) {
         switch (capability.paramType) {
         case UWB_CAPABILITY_PARAM_TYPE_RANGING_METHOD: {
-            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
+            const auto value = *reinterpret_cast<const uint8_t *>(&capability.paramValue);
             std::bitset<4> rangingMethods{ value };
             detail::ProcessSupportFromBitset(UwbCapability::RangingMethodBit, rangingMethods, uwbCapability.RangingMethods);
             break;
         }
         case UWB_CAPABILITY_PARAM_TYPE_DEVICE_ROLES: {
-            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
+            const auto value = *reinterpret_cast<const uint8_t *>(&capability.paramValue);
             std::bitset<2> deviceRoles{ value };
             detail::ProcessSupportFromBitset(UwbCapability::DeviceRoleBit, deviceRoles, uwbCapability.DeviceRoles);
             break;
         }
         case UWB_CAPABILITY_PARAM_TYPE_PHY_VERSION_RANGE: {
-            const auto value = *reinterpret_cast<const uint32_t*>(&capability.paramValue);
+            const auto value = *reinterpret_cast<const uint32_t *>(&capability.paramValue);
             uwbCapability.FiraPhyVersionRange = value;
             break;
         }
         case UWB_CAPABILITY_PARAM_TYPE_MAC_VERSION_RANGE: {
-            const auto value = *reinterpret_cast<const uint32_t*>(&capability.paramValue);
+            const auto value = *reinterpret_cast<const uint32_t *>(&capability.paramValue);
             uwbCapability.FiraMacVersionRange = value;
             break;
         }
         case UWB_CAPABILITY_PARAM_TYPE_BLOCK_STRIDING: {
-            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
+            const auto value = *reinterpret_cast<const uint8_t *>(&capability.paramValue);
             std::bitset<1> blockStriding{ value };
             uwbCapability.BlockStriding = blockStriding.test(UwbCapability::BlockStridingBit);
             break;
         }
         case UWB_CAPABILITY_PARAM_TYPE_HOPPING_MODE: {
-            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
+            const auto value = *reinterpret_cast<const uint8_t *>(&capability.paramValue);
             std::bitset<1> hoppingMode{ value };
             uwbCapability.HoppingMode = hoppingMode.test(UwbCapability::HoppingModeBit);
             break;
         }
         case UWB_CAPABILITY_PARAM_TYPE_SCHEDULED_MODE: {
-            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
+            const auto value = *reinterpret_cast<const uint8_t *>(&capability.paramValue);
             std::bitset<2> schedulingModes{ value };
             detail::ProcessSupportFromBitset(UwbCapability::SchedulingModeBit, schedulingModes, uwbCapability.SchedulingModes);
             break;
         }
         case UWB_CAPABILITY_PARAM_TYPE_RANGING_TIME_STRUCT: {
-            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
+            const auto value = *reinterpret_cast<const uint8_t *>(&capability.paramValue);
             std::bitset<2> rangingTimeStructs{ value };
             detail::ProcessSupportFromBitset(UwbCapability::RangingModeBit, rangingTimeStructs, uwbCapability.RangingTimeStructs);
             break;
         }
         case UWB_CAPABILITY_PARAM_TYPE_MULTI_NODE_MODE: {
-            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
+            const auto value = *reinterpret_cast<const uint8_t *>(&capability.paramValue);
             std::bitset<3> modes{ value };
             detail::ProcessSupportFromBitset(UwbCapability::MultiNodeModeBit, modes, uwbCapability.MultiNodeModes);
             break;
@@ -477,49 +477,49 @@ windows::devices::uwb::ddi::lrp::To(const UWB_DEVICE_CAPABILITIES& deviceCapabil
             break;
         }
         case UWB_CAPABILITY_PARAM_TYPE_STS_CONFIG: {
-            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
+            const auto value = *reinterpret_cast<const uint8_t *>(&capability.paramValue);
             std::bitset<3> stsConfigurations{ value };
             detail::ProcessSupportFromBitset(UwbCapability::StsConfigurationBit, stsConfigurations, uwbCapability.StsConfigurations);
             break;
         }
         case UWB_CAPABILITY_PARAM_TYPE_RFRAME_CONFIG: {
-            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
+            const auto value = *reinterpret_cast<const uint8_t *>(&capability.paramValue);
             std::bitset<4> rframeConfigurations{ value };
             detail::ProcessSupportFromBitset(UwbCapability::RFrameConfigurationBit, rframeConfigurations, uwbCapability.RFrameConfigurations);
             break;
         }
         case UWB_CAPABILITY_PARAM_TYPE_AOA_SUPPORT: {
-            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
+            const auto value = *reinterpret_cast<const uint8_t *>(&capability.paramValue);
             std::bitset<4> aoaTypes{ value };
             detail::ProcessSupportFromBitset(UwbCapability::AngleOfArrivalBit, aoaTypes, uwbCapability.AngleOfArrivalTypes);
             uwbCapability.AngleOfArrivalFom = aoaTypes.test(UwbCapability::AngleOfArrivalFomBit);
             break;
         }
         case UWB_CAPABILITY_PARAM_TYPE_EXTENDED_MAC_ADDRESS: {
-            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
+            const auto value = *reinterpret_cast<const uint8_t *>(&capability.paramValue);
             uwbCapability.ExtendedMacAddress = !!value;
             break;
         }
         case UWB_CAPABILITY_PARAM_TYPE_CC_CONSTRAINT_LENGTH: {
-            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
+            const auto value = *reinterpret_cast<const uint8_t *>(&capability.paramValue);
             std::bitset<2> convolutionalCodeConstraintLengths{ value };
             detail::ProcessSupportFromBitset(UwbCapability::ConvolutionalCodeConstraintLengthsBit, convolutionalCodeConstraintLengths, uwbCapability.ConvolutionalCodeConstraintLengths);
             break;
         }
         case UWB_CAPABILITY_PARAM_TYPE_CHANNELS: {
-            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
+            const auto value = *reinterpret_cast<const uint8_t *>(&capability.paramValue);
             std::bitset<8> channels{ value };
             detail::ProcessSupportFromBitset(UwbCapability::ChannelsBit, channels, uwbCapability.Channels);
             break;
         }
         case UWB_CAPABILITY_PARAM_TYPE_BPRF_PARAMETER_SETS: {
-            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
+            const auto value = *reinterpret_cast<const uint8_t *>(&capability.paramValue);
             std::bitset<6> bprfParameterSets{ value };
             detail::ProcessSupportFromBitset(UwbCapability::BprfParameterSetsBit, bprfParameterSets, uwbCapability.BprfParameterSets);
             break;
         }
         case UWB_CAPABILITY_PARAM_TYPE_HPRF_PARAMETER_SETS: {
-            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
+            const auto value = *reinterpret_cast<const uint8_t *>(&capability.paramValue);
             std::bitset<35> hprfParameterSets{ value };
             detail::ProcessSupportFromBitset(UwbCapability::HprfParameterSetsBit, hprfParameterSets, uwbCapability.HprfParameterSets);
             break;
@@ -535,7 +535,7 @@ windows::devices::uwb::ddi::lrp::To(const UWB_DEVICE_CAPABILITIES& deviceCapabil
 }
 
 UwbNotificationData
-windows::devices::uwb::ddi::lrp::To(const UWB_NOTIFICATION_DATA& /* notificationData */)
+windows::devices::uwb::ddi::lrp::To(const UWB_NOTIFICATION_DATA & /* notificationData */)
 {
     UwbNotificationData uwbNotificationData{};
     // TODO: implement this

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -1,11 +1,17 @@
 
 #include <algorithm>
+#include <bitset>
 #include <functional>
 #include <stdexcept>
 #include <type_traits>
 #include <typeindex>
 #include <unordered_map>
 #include <variant>
+#include <vector>
+
+#include <plog/Log.h>
+#include <notstd/utility.hxx>
+#include <wil/common.h>
 
 #include <uwb/protocols/fira/UwbCapability.hxx>
 #include <windows/devices/uwb/UwbCxAdapterDdiLrp.hxx>
@@ -70,7 +76,7 @@ windows::devices::uwb::ddi::lrp::From(const UwbStatus &uwbStatus)
 }
 
 UWB_DEVICE_STATE
-windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbDeviceState &uwbDeviceState)
+windows::devices::uwb::ddi::lrp::From(const UwbDeviceState &uwbDeviceState)
 {
     static const std::unordered_map<UwbDeviceState, UWB_DEVICE_STATE> DeviceStateMap{
         { UwbDeviceState::Ready, UWB_DEVICE_STATE_READY },
@@ -82,7 +88,7 @@ windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbDeviceStat
 }
 
 UWB_MULTICAST_ACTION
-windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbMulticastAction &uwbMulticastAction)
+windows::devices::uwb::ddi::lrp::From(const UwbMulticastAction &uwbMulticastAction)
 {
     static const std::unordered_map<UwbMulticastAction, UWB_MULTICAST_ACTION> ActionMap{
         { UwbMulticastAction::AddShortAddress, UWB_MULTICAST_ACTION_ADD_SHORT_ADDRESS },
@@ -93,7 +99,7 @@ windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbMulticastA
 }
 
 UWB_MULTICAST_STATUS
-windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbStatusMulticast &uwbStatusMulticast)
+windows::devices::uwb::ddi::lrp::From(const UwbStatusMulticast &uwbStatusMulticast)
 {
     static const std::unordered_map<UwbStatusMulticast, UWB_MULTICAST_STATUS> StatusMap{
         { UwbStatusMulticast::OkUpdate, UWB_MULTICAST_STATUS_OK_MULTICAST_LIST_UPDATE },
@@ -106,7 +112,7 @@ windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbStatusMult
 }
 
 UWB_MULTICAST_LIST_STATUS
-windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbMulticastListStatus &uwbStatusMulticastList)
+windows::devices::uwb::ddi::lrp::From(const UwbMulticastListStatus &uwbStatusMulticastList)
 {
     if (uwbStatusMulticastList.ControleeMacAddress.GetType() != ::uwb::UwbMacAddressType::Short) {
         throw std::runtime_error("UWB_MULTICAST_LIST_STATUS requires a short mac address");
@@ -122,7 +128,7 @@ windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbMulticastL
 }
 
 UWB_MULTICAST_CONTROLEE_LIST_ENTRY
-windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbSessionUpdateMulticastListEntry &uwbSessionUpdateMulticastListEntry)
+windows::devices::uwb::ddi::lrp::From(const UwbSessionUpdateMulticastListEntry &uwbSessionUpdateMulticastListEntry)
 {
     if (uwbSessionUpdateMulticastListEntry.ControleeMacAddress.GetType() != ::uwb::UwbMacAddressType::Short) {
         throw std::runtime_error("UWB_MULTICAST_CONTROLEE_LIST_ENTRY requires a short mac address");
@@ -137,7 +143,7 @@ windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbSessionUpd
 }
 
 UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST
-windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbSessionUpdateMulicastList &uwbSessionUpdateMulicastList)
+windows::devices::uwb::ddi::lrp::From(const UwbSessionUpdateMulicastList &uwbSessionUpdateMulicastList)
 {
     UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST sessionUpdateControllerMulticastList{};
     sessionUpdateControllerMulticastList.size = sizeof sessionUpdateControllerMulticastList; // TODO: update for variable length
@@ -150,7 +156,7 @@ windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbSessionUpd
 }
 
 UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF
-windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbSessionUpdateMulicastListStatus &uwbSessionUpdateMulicastListStatus)
+windows::devices::uwb::ddi::lrp::From(const UwbSessionUpdateMulicastListStatus &uwbSessionUpdateMulicastListStatus)
 {
     UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF multicastListStatus{};
     multicastListStatus.size = sizeof multicastListStatus; // TODO: update for variable length
@@ -163,7 +169,7 @@ windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbSessionUpd
 }
 
 UWB_RANGING_MEASUREMENT_TYPE
-windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbRangingMeasurementType &uwbRangingType)
+windows::devices::uwb::ddi::lrp::From(const UwbRangingMeasurementType &uwbRangingType)
 {
     static const std::unordered_map<UwbRangingMeasurementType, UWB_RANGING_MEASUREMENT_TYPE> RangingTypeMap{
         { UwbRangingMeasurementType::TwoWay, UWB_RANGING_MEASUREMENT_TYPE_TWO_WAY },
@@ -173,7 +179,7 @@ windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbRangingMea
 }
 
 UWB_SESSION_REASON_CODE
-windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbSessionReasonCode &uwbSessionReasonCode)
+windows::devices::uwb::ddi::lrp::From(const UwbSessionReasonCode &uwbSessionReasonCode)
 {
     static const std::unordered_map<UwbSessionReasonCode, UWB_SESSION_REASON_CODE> SessionReasonCodeMap{
         { UwbSessionReasonCode::StateChangeWithSessionManagementCommands, UWB_SESSION_REASON_CODE_STATE_CHANGE_WITH_SESSION_MANAGEMENT_COMMANDS },
@@ -191,7 +197,7 @@ windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbSessionRea
 }
 
 UWB_DEVICE_CONFIG_PARAM_TYPE
-windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbDeviceConfigurationParameterType &uwbDeviceConfigurationParameterType)
+windows::devices::uwb::ddi::lrp::From(const UwbDeviceConfigurationParameterType &uwbDeviceConfigurationParameterType)
 {
     static const std::unordered_map<UwbDeviceConfigurationParameterType, UWB_DEVICE_CONFIG_PARAM_TYPE> ConfigParamMap{
         { UwbDeviceConfigurationParameterType::DeviceState, UWB_DEVICE_CONFIG_PARAM_TYPE_DEVICE_STATE },
@@ -202,7 +208,7 @@ windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbDeviceConf
 }
 
 UWB_APP_CONFIG_PARAM_TYPE
-windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbApplicationConfigurationParameterType &uwbApplicationConfigurationParameterType)
+windows::devices::uwb::ddi::lrp::From(const UwbApplicationConfigurationParameterType &uwbApplicationConfigurationParameterType)
 {
     static const std::unordered_map<UwbApplicationConfigurationParameterType, UWB_APP_CONFIG_PARAM_TYPE> AppConfigParamMap{
         { UwbApplicationConfigurationParameterType::DeviceType, UWB_APP_CONFIG_PARAM_TYPE_DEVICE_TYPE },
@@ -270,7 +276,7 @@ windows::devices::uwb::ddi::lrp::From(const UwbSessionState uwbSessionState)
 }
 
 UWB_SESSION_STATUS
-windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbSessionStatus &uwbSessionStatus)
+windows::devices::uwb::ddi::lrp::From(const UwbSessionStatus &uwbSessionStatus)
 {
     UWB_SESSION_STATUS sessionStatus{};
     sessionStatus.size = sizeof sessionStatus;
@@ -320,7 +326,7 @@ windows::devices::uwb::ddi::lrp::From(const UwbCapability &uwbDeviceCapabilities
 }
 
 UWB_DEVICE_STATUS
-windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbStatusDevice &uwbStatusDevice)
+windows::devices::uwb::ddi::lrp::From(const UwbStatusDevice &uwbStatusDevice)
 {
     UWB_DEVICE_STATUS statusDevice{};
     statusDevice.size = sizeof statusDevice;
@@ -330,7 +336,7 @@ windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbStatusDevi
 }
 
 UWB_RANGING_DATA
-windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbRangingData &uwbRangingData)
+windows::devices::uwb::ddi::lrp::From(const UwbRangingData &uwbRangingData)
 {
     UWB_RANGING_DATA rangingData{};            // TODO: this must be allocated to account for 'RangingMeasurements' in uwbRangingData.
     rangingData.size = sizeof rangingData + 0; // TODO: fix this to account for variable length
@@ -344,7 +350,7 @@ windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbRangingDat
 }
 
 UWB_NOTIFICATION_DATA
-windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbNotificationData &uwbNotificationData)
+windows::devices::uwb::ddi::lrp::From(const UwbNotificationData &uwbNotificationData)
 {
     static const std::unordered_map<std::type_index, UWB_NOTIFICATION_TYPE> NotificationTypeMap{
         { std::type_index(typeid(UwbStatus)), UWB_NOTIFICATION_TYPE_GENERIC_ERROR },
@@ -381,7 +387,154 @@ windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbNotificati
     return notificationData;
 }
 
-::uwb::protocol::fira::UwbNotificationData
+namespace detail
+{
+/**
+ * @brief Helper to process supported parameters from a given map which
+ * associates a value with a bit position. If the specified bitmap contains
+ * support for the value, the value is added to the result container.
+ *
+ * @tparam N The size of the bitset.
+ * @tparam T The type of the value.
+ * @param map The map associating values with bit positions in the bitset.
+ * @param support The bitset defining parameter support.
+ * @param result The vector to hold supported values that are present in the bitset.
+ */
+template <std::size_t N, typename T>
+void
+ProcessSupportFromBitset(std::unordered_map<T, std::size_t> map, const std::bitset<N>& support, std::vector<T>& result)
+{
+    for (const auto& [value, bit] : map) {
+        if (support.test(bit)) {
+            result.push_back(value);
+        }
+    }
+}
+} // namespace detail
+
+UwbCapability
+windows::devices::uwb::ddi::lrp::To(const UWB_DEVICE_CAPABILITIES& deviceCapabilities)
+{
+    UwbCapability uwbCapability;
+
+    for (const auto capability : wil::make_range(&deviceCapabilities.capabilityParams[0], deviceCapabilities.capabilityParamsCount)) {
+        switch (capability.paramType) {
+        case UWB_CAPABILITY_PARAM_TYPE_RANGING_METHOD: {
+            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
+            std::bitset<4> rangingMethods{ value };
+            detail::ProcessSupportFromBitset(UwbCapability::RangingMethodBit, rangingMethods, uwbCapability.RangingMethods);
+            break;
+        }
+        case UWB_CAPABILITY_PARAM_TYPE_DEVICE_ROLES: {
+            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
+            std::bitset<2> deviceRoles{ value };
+            detail::ProcessSupportFromBitset(UwbCapability::DeviceRoleBit, deviceRoles, uwbCapability.DeviceRoles);
+            break;
+        }
+        case UWB_CAPABILITY_PARAM_TYPE_PHY_VERSION_RANGE: {
+            const auto value = *reinterpret_cast<const uint32_t*>(&capability.paramValue);
+            uwbCapability.FiraPhyVersionRange = value;
+            break;
+        }
+        case UWB_CAPABILITY_PARAM_TYPE_MAC_VERSION_RANGE: {
+            const auto value = *reinterpret_cast<const uint32_t*>(&capability.paramValue);
+            uwbCapability.FiraMacVersionRange = value;
+            break;
+        }
+        case UWB_CAPABILITY_PARAM_TYPE_BLOCK_STRIDING: {
+            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
+            std::bitset<1> blockStriding{ value };
+            uwbCapability.BlockStriding = blockStriding.test(UwbCapability::BlockStridingBit);
+            break;
+        }
+        case UWB_CAPABILITY_PARAM_TYPE_HOPPING_MODE: {
+            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
+            std::bitset<1> hoppingMode{ value };
+            uwbCapability.HoppingMode = hoppingMode.test(UwbCapability::HoppingModeBit);
+            break;
+        }
+        case UWB_CAPABILITY_PARAM_TYPE_SCHEDULED_MODE: {
+            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
+            std::bitset<2> schedulingModes{ value };
+            detail::ProcessSupportFromBitset(UwbCapability::SchedulingModeBit, schedulingModes, uwbCapability.SchedulingModes);
+            break;
+        }
+        case UWB_CAPABILITY_PARAM_TYPE_RANGING_TIME_STRUCT: {
+            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
+            std::bitset<2> rangingTimeStructs{ value };
+            detail::ProcessSupportFromBitset(UwbCapability::RangingModeBit, rangingTimeStructs, uwbCapability.RangingTimeStructs);
+            break;
+        }
+        case UWB_CAPABILITY_PARAM_TYPE_MULTI_NODE_MODE: {
+            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
+            std::bitset<3> modes{ value };
+            detail::ProcessSupportFromBitset(UwbCapability::MultiNodeModeBit, modes, uwbCapability.MultiNodeModes);
+            break;
+        }
+        case UWB_CAPABILITY_PARAM_TYPE_UWB_INITIATION_TIME: {
+            const uint8_t value = capability.paramValue[0];
+            uwbCapability.UwbInitiationTime = !!value;
+            break;
+        }
+        case UWB_CAPABILITY_PARAM_TYPE_STS_CONFIG: {
+            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
+            std::bitset<3> stsConfigurations{ value };
+            detail::ProcessSupportFromBitset(UwbCapability::StsConfigurationBit, stsConfigurations, uwbCapability.StsConfigurations);
+            break;
+        }
+        case UWB_CAPABILITY_PARAM_TYPE_RFRAME_CONFIG: {
+            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
+            std::bitset<4> rframeConfigurations{ value };
+            detail::ProcessSupportFromBitset(UwbCapability::RFrameConfigurationBit, rframeConfigurations, uwbCapability.RFrameConfigurations);
+            break;
+        }
+        case UWB_CAPABILITY_PARAM_TYPE_AOA_SUPPORT: {
+            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
+            std::bitset<4> aoaTypes{ value };
+            detail::ProcessSupportFromBitset(UwbCapability::AngleOfArrivalBit, aoaTypes, uwbCapability.AngleOfArrivalTypes);
+            uwbCapability.AngleOfArrivalFom = aoaTypes.test(UwbCapability::AngleOfArrivalFomBit);
+            break;
+        }
+        case UWB_CAPABILITY_PARAM_TYPE_EXTENDED_MAC_ADDRESS: {
+            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
+            uwbCapability.ExtendedMacAddress = !!value;
+            break;
+        }
+        case UWB_CAPABILITY_PARAM_TYPE_CC_CONSTRAINT_LENGTH: {
+            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
+            std::bitset<2> convolutionalCodeConstraintLengths{ value };
+            detail::ProcessSupportFromBitset(UwbCapability::ConvolutionalCodeConstraintLengthsBit, convolutionalCodeConstraintLengths, uwbCapability.ConvolutionalCodeConstraintLengths);
+            break;
+        }
+        case UWB_CAPABILITY_PARAM_TYPE_CHANNELS: {
+            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
+            std::bitset<8> channels{ value };
+            detail::ProcessSupportFromBitset(UwbCapability::ChannelsBit, channels, uwbCapability.Channels);
+            break;
+        }
+        case UWB_CAPABILITY_PARAM_TYPE_BPRF_PARAMETER_SETS: {
+            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
+            std::bitset<6> bprfParameterSets{ value };
+            detail::ProcessSupportFromBitset(UwbCapability::BprfParameterSetsBit, bprfParameterSets, uwbCapability.BprfParameterSets);
+            break;
+        }
+        case UWB_CAPABILITY_PARAM_TYPE_HPRF_PARAMETER_SETS: {
+            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
+            std::bitset<35> hprfParameterSets{ value };
+            detail::ProcessSupportFromBitset(UwbCapability::HprfParameterSetsBit, hprfParameterSets, uwbCapability.HprfParameterSets);
+            break;
+        }
+        default:
+            // ignore unknown parameter tags
+            PLOG_DEBUG << "ignoring unknown UwbCapability parameter tag " << notstd::to_underlying(capability.paramType);
+            break;
+        }
+    }
+
+    return uwbCapability;
+}
+
+UwbNotificationData
 windows::devices::uwb::ddi::lrp::To(const UWB_NOTIFICATION_DATA& /* notificationData */)
 {
     UwbNotificationData uwbNotificationData{};

--- a/windows/devices/uwb/UwbDevice.cxx
+++ b/windows/devices/uwb/UwbDevice.cxx
@@ -223,55 +223,6 @@ UwbDevice::Initialize()
 namespace UwbCxDdi = windows::devices::uwb::ddi::lrp;
 
 void
-UwbDevice::OnStatusChanged([[maybe_unused]] ::uwb::protocol::fira::UwbStatus /* status */)
-{
-    // TODO: implement this
-}
-
-void
-UwbDevice::OnDeviceStatusChanged([[maybe_unused]] ::uwb::protocol::fira::UwbStatusDevice /* statusDevice */)
-{
-    // TODO: implement this
-}
-void
-UwbDevice::OnSessionStatusChanged([[maybe_unused]] ::uwb::protocol::fira::UwbSessionStatus /* statusSession */)
-{
-    // TODO: implement this
-}
-void
-UwbDevice::OnSessionMulticastListStatus([[maybe_unused]] ::uwb::protocol::fira::UwbSessionUpdateMulicastListStatus /* statusMulticastList */)
-{
-    // TODO: implement this
-}
-
-void
-UwbDevice::OnSessionRangingData([[maybe_unused]] ::uwb::protocol::fira::UwbRangingData rangingData)
-{
-    // TODO: implement this
-}
-
-void
-UwbDevice::HandleNotification(::uwb::protocol::fira::UwbNotificationData uwbNotificationData)
-{
-    std::visit([this](auto&& arg) {
-        using ValueType = std::decay_t<decltype(arg)>;
-
-        if constexpr (std::is_same_v<ValueType, UwbStatus>) {
-            OnStatusChanged(arg);
-        } else if constexpr (std::is_same_v<ValueType, UwbStatusDevice>) {
-            OnDeviceStatusChanged(arg);
-        } else if constexpr (std::is_same_v<ValueType, UwbSessionStatus>) {
-            OnSessionStatusChanged(arg);
-        } else if constexpr (std::is_same_v<ValueType, UwbSessionUpdateMulicastListStatus>) {
-            OnSessionMulticastListStatus(arg);
-        } else if constexpr (std::is_same_v<ValueType, UwbRangingData>) {
-            OnSessionRangingData(arg);
-        }
-    },
-        uwbNotificationData);
-}
-
-void
 UwbDevice::HandleNotifications()
 {
     for (;;) {
@@ -312,7 +263,7 @@ UwbDevice::HandleNotifications()
         // is automatically destructed once the async lambda has completed.
         auto notificationHandlerFuture = std::make_shared<std::future<void>>();
         *notificationHandlerFuture = std::async(std::launch::async, [this, notificationHandlerFuture, uwbNotificationData = std::move(uwbNotificationData)]() {
-            HandleNotification(std::move(uwbNotificationData));
+            ::UwbDevice::OnUwbNotification(std::move(uwbNotificationData));
         });
     }
 }

--- a/windows/devices/uwb/UwbDevice.cxx
+++ b/windows/devices/uwb/UwbDevice.cxx
@@ -17,7 +17,7 @@ using namespace ::uwb::protocol::fira;
  * conversion.
  */
 namespace UwbCxDdi = windows::devices::uwb::ddi::lrp;
-      
+
 UwbDevice::UwbDevice(std::string deviceName) :
     m_deviceName(std::move(deviceName))
 {}
@@ -59,7 +59,6 @@ UwbDevice::Initialize()
         HandleNotifications();
     });
 }
-
 
 void
 UwbDevice::HandleNotifications()
@@ -119,7 +118,7 @@ UwbDevice::CreateSession(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callback
     return std::make_unique<UwbSession>(std::move(callbacks), std::move(handleDriverForSession));
 }
 
-uwb::protocol::fira::UwbCapability
+UwbCapability
 UwbDevice::GetCapabilities() const
 {
     // Determine the amount of memory required for the UWB_DEVICE_CAPABILITIES from the driver.

--- a/windows/devices/uwb/UwbDevice.cxx
+++ b/windows/devices/uwb/UwbDevice.cxx
@@ -83,13 +83,13 @@ UwbDevice::HandleNotifications()
         ioResult = DeviceIoControl(m_handleDriver.get(), IOCTL_UWB_NOTIFICATION, nullptr, 0, std::data(uwbNotificationDataBuffer), uwbNotificationDataSize, &bytesRequired, nullptr);
         if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
             HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
-            PLOG_ERROR << "error obtaining UWB notification buffer, hr=" << std::showbase << std::hex << hr << std::endl;
+            PLOG_ERROR << "error obtaining UWB notification buffer, hr=" << std::showbase << std::hex << hr;
             continue;
         }
 
         // Log a message if the output buffer is not aligned to UWB_NOTIFICATION_DATA. Ignore it for now as this should not occur often.
         if (reinterpret_cast<uintptr_t>(std::data(uwbNotificationDataBuffer)) % alignof(UWB_NOTIFICATION_DATA) != 0) {
-            PLOG_ERROR << "driver output buffer is unaligned! undefined behavior may result" << std::endl;
+            PLOG_ERROR << "driver output buffer is unaligned! undefined behavior may result";
         }
 
         // Convert to neutral type and process the notification.

--- a/windows/devices/uwb/UwbDevice.cxx
+++ b/windows/devices/uwb/UwbDevice.cxx
@@ -2,9 +2,7 @@
 #include <bitset>
 #include <future>
 #include <stdexcept>
-#include <type_traits>
 #include <unordered_map>
-#include <variant>
 
 #include <windows/devices/uwb/UwbCxAdapterDdiLrp.hxx>
 #include <windows/devices/uwb/UwbCxDdiLrp.hxx>

--- a/windows/devices/uwb/UwbDevice.cxx
+++ b/windows/devices/uwb/UwbDevice.cxx
@@ -1,8 +1,6 @@
 
-#include <bitset>
 #include <future>
 #include <stdexcept>
-#include <unordered_map>
 
 #include <windows/devices/uwb/UwbCxAdapterDdiLrp.hxx>
 #include <windows/devices/uwb/UwbCxDdiLrp.hxx>
@@ -14,164 +12,12 @@
 using namespace windows::devices::uwb;
 using namespace ::uwb::protocol::fira;
 
-namespace detail
-{
-using namespace uwb::protocol;
-
-namespace detail
-{
 /**
- * @brief Helper to process supported parameters from a given map which
- * associates a value with a bit position. If the specified bitmap contains
- * support for the value, the value is added to the result container.
- *
- * @tparam N The size of the bitset.
- * @tparam T The type of the value.
- * @param map The map associating values with bit positions in the bitset.
- * @param support The bitset defining parameter support.
- * @param result The vector to hold supported values that are present in the bitset.
+ * @brief Namespace alias to reduce typing but preserve clarity regarding DDI
+ * conversion.
  */
-template <std::size_t N, typename T>
-void
-ProcessSupportFromBitset(std::unordered_map<T, std::size_t> map, const std::bitset<N>& support, std::vector<T>& result)
-{
-    for (const auto& [value, bit] : map) {
-        if (support.test(bit)) {
-            result.push_back(value);
-        }
-    }
-}
-} // namespace detail
-
-/**
- * @brief Converts a UwbCx UWB_DEVICE_CAPABILTIIES structure to the service C++ FiRa equivalent.
- *
- * @param uwbDeviceCapabilities The device capabilities obtained from the UwbCx driver.
- * @return fira::UwbCapability
- */
-fira::UwbCapability
-FromUwbCx(const UWB_DEVICE_CAPABILITIES& uwbDeviceCapabilities)
-{
-    fira::UwbCapability uwbCapability;
-
-    for (const auto capability : wil::make_range(&uwbDeviceCapabilities.capabilityParams[0], uwbDeviceCapabilities.capabilityParamsCount)) {
-        switch (capability.paramType) {
-        case UWB_CAPABILITY_PARAM_TYPE_RANGING_METHOD: {
-            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
-            std::bitset<4> rangingMethods{ value };
-            detail::ProcessSupportFromBitset(fira::UwbCapability::RangingMethodBit, rangingMethods, uwbCapability.RangingMethods);
-            break;
-        }
-        case UWB_CAPABILITY_PARAM_TYPE_DEVICE_ROLES: {
-            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
-            std::bitset<2> deviceRoles{ value };
-            detail::ProcessSupportFromBitset(fira::UwbCapability::DeviceRoleBit, deviceRoles, uwbCapability.DeviceRoles);
-            break;
-        }
-        case UWB_CAPABILITY_PARAM_TYPE_PHY_VERSION_RANGE: {
-            const auto value = *reinterpret_cast<const uint32_t*>(&capability.paramValue);
-            uwbCapability.FiraPhyVersionRange = value;
-            break;
-        }
-        case UWB_CAPABILITY_PARAM_TYPE_MAC_VERSION_RANGE: {
-            const auto value = *reinterpret_cast<const uint32_t*>(&capability.paramValue);
-            uwbCapability.FiraMacVersionRange = value;
-            break;
-        }
-        case UWB_CAPABILITY_PARAM_TYPE_BLOCK_STRIDING: {
-            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
-            std::bitset<1> blockStriding{ value };
-            uwbCapability.BlockStriding = blockStriding.test(fira::UwbCapability::BlockStridingBit);
-            break;
-        }
-        case UWB_CAPABILITY_PARAM_TYPE_HOPPING_MODE: {
-            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
-            std::bitset<1> hoppingMode{ value };
-            uwbCapability.HoppingMode = hoppingMode.test(fira::UwbCapability::HoppingModeBit);
-            break;
-        }
-        case UWB_CAPABILITY_PARAM_TYPE_SCHEDULED_MODE: {
-            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
-            std::bitset<2> schedulingModes{ value };
-            detail::ProcessSupportFromBitset(fira::UwbCapability::SchedulingModeBit, schedulingModes, uwbCapability.SchedulingModes);
-            break;
-        }
-        case UWB_CAPABILITY_PARAM_TYPE_RANGING_TIME_STRUCT: {
-            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
-            std::bitset<2> rangingTimeStructs{ value };
-            detail::ProcessSupportFromBitset(fira::UwbCapability::RangingModeBit, rangingTimeStructs, uwbCapability.RangingTimeStructs);
-            break;
-        }
-        case UWB_CAPABILITY_PARAM_TYPE_MULTI_NODE_MODE: {
-            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
-            std::bitset<3> modes{ value };
-            detail::ProcessSupportFromBitset(fira::UwbCapability::MultiNodeModeBit, modes, uwbCapability.MultiNodeModes);
-            break;
-        }
-        case UWB_CAPABILITY_PARAM_TYPE_UWB_INITIATION_TIME: {
-            const uint8_t value = capability.paramValue[0];
-            uwbCapability.UwbInitiationTime = !!value;
-            break;
-        }
-        case UWB_CAPABILITY_PARAM_TYPE_STS_CONFIG: {
-            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
-            std::bitset<3> stsConfigurations{ value };
-            detail::ProcessSupportFromBitset(fira::UwbCapability::StsConfigurationBit, stsConfigurations, uwbCapability.StsConfigurations);
-            break;
-        }
-        case UWB_CAPABILITY_PARAM_TYPE_RFRAME_CONFIG: {
-            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
-            std::bitset<4> rframeConfigurations{ value };
-            detail::ProcessSupportFromBitset(fira::UwbCapability::RFrameConfigurationBit, rframeConfigurations, uwbCapability.RFrameConfigurations);
-            break;
-        }
-        case UWB_CAPABILITY_PARAM_TYPE_AOA_SUPPORT: {
-            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
-            std::bitset<4> aoaTypes{ value };
-            detail::ProcessSupportFromBitset(fira::UwbCapability::AngleOfArrivalBit, aoaTypes, uwbCapability.AngleOfArrivalTypes);
-            uwbCapability.AngleOfArrivalFom = aoaTypes.test(fira::UwbCapability::AngleOfArrivalFomBit);
-            break;
-        }
-        case UWB_CAPABILITY_PARAM_TYPE_EXTENDED_MAC_ADDRESS: {
-            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
-            uwbCapability.ExtendedMacAddress = !!value;
-            break;
-        }
-        case UWB_CAPABILITY_PARAM_TYPE_CC_CONSTRAINT_LENGTH: {
-            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
-            std::bitset<2> convolutionalCodeConstraintLengths{ value };
-            detail::ProcessSupportFromBitset(fira::UwbCapability::ConvolutionalCodeConstraintLengthsBit, convolutionalCodeConstraintLengths, uwbCapability.ConvolutionalCodeConstraintLengths);
-            break;
-        }
-        case UWB_CAPABILITY_PARAM_TYPE_CHANNELS: {
-            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
-            std::bitset<8> channels{ value };
-            detail::ProcessSupportFromBitset(fira::UwbCapability::ChannelsBit, channels, uwbCapability.Channels);
-            break;
-        }
-        case UWB_CAPABILITY_PARAM_TYPE_BPRF_PARAMETER_SETS: {
-            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
-            std::bitset<6> bprfParameterSets{ value };
-            detail::ProcessSupportFromBitset(fira::UwbCapability::BprfParameterSetsBit, bprfParameterSets, uwbCapability.BprfParameterSets);
-            break;
-        }
-        case UWB_CAPABILITY_PARAM_TYPE_HPRF_PARAMETER_SETS: {
-            const auto value = *reinterpret_cast<const uint8_t*>(&capability.paramValue);
-            std::bitset<35> hprfParameterSets{ value };
-            detail::ProcessSupportFromBitset(fira::UwbCapability::HprfParameterSetsBit, hprfParameterSets, uwbCapability.HprfParameterSets);
-            break;
-        }
-        default:
-            // ignore unknown parameter tags
-            PLOG_DEBUG << "ignoring unknown UwbCapability parameter tag " << notstd::to_underlying(capability.paramType);
-            break;
-        }
-    }
-
-    return uwbCapability;
-}
-} // namespace detail
-
+namespace UwbCxDdi = windows::devices::uwb::ddi::lrp;
+      
 UwbDevice::UwbDevice(std::string deviceName) :
     m_deviceName(std::move(deviceName))
 {}
@@ -214,11 +60,6 @@ UwbDevice::Initialize()
     });
 }
 
-/**
- * @brief Namespace alias to reduce typing but preserve clarity regarding DDI
- * conversion.
- */
-namespace UwbCxDdi = windows::devices::uwb::ddi::lrp;
 
 void
 UwbDevice::HandleNotifications()
@@ -301,7 +142,7 @@ UwbDevice::GetCapabilities() const
     }
 
     const UWB_DEVICE_CAPABILITIES& uwbDeviceCapabilities = *reinterpret_cast<UWB_DEVICE_CAPABILITIES*>(uwbDeviceCapabilitiesBuffer.get());
-    return detail::FromUwbCx(uwbDeviceCapabilities);
+    return UwbCxDdi::To(uwbDeviceCapabilities);
 }
 
 bool

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -191,6 +191,15 @@ From(const ::uwb::protocol::fira::UwbRangingData &uwbRangingData);
 UWB_NOTIFICATION_DATA
 From(const ::uwb::protocol::fira::UwbNotificationData &uwbNotificationData);
 
+/**
+ * @brief Converts UWB_NOTIFICATION_DATA to UwbNotificationData.
+ * 
+ * @param notificationData 
+ * @return ::uwb::protocol::fira::UwbNotificationData 
+ */
+::uwb::protocol::fira::UwbNotificationData
+To(const UWB_NOTIFICATION_DATA& notificationData);
+
 } // namespace windows::devices::uwb::ddi::lrp
 
 #endif // UWB_CX_ADAPTER_DDI_LRP_HXX

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -192,6 +192,15 @@ UWB_NOTIFICATION_DATA
 From(const ::uwb::protocol::fira::UwbNotificationData &uwbNotificationData);
 
 /**
+ * @brief Converts UWB_DEVICE_CAPABILITIES to UwbCapability.
+ * 
+ * @param deviceCapabilities 
+ * @return ::uwb::protocol::fira::UwbCapability 
+ */
+::uwb::protocol::fira::UwbCapability
+To(const UWB_DEVICE_CAPABILITIES& deviceCapabilities);
+
+/**
  * @brief Converts UWB_NOTIFICATION_DATA to UwbNotificationData.
  * 
  * @param notificationData 

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -193,21 +193,21 @@ From(const ::uwb::protocol::fira::UwbNotificationData &uwbNotificationData);
 
 /**
  * @brief Converts UWB_DEVICE_CAPABILITIES to UwbCapability.
- * 
- * @param deviceCapabilities 
- * @return ::uwb::protocol::fira::UwbCapability 
+ *
+ * @param deviceCapabilities
+ * @return ::uwb::protocol::fira::UwbCapability
  */
 ::uwb::protocol::fira::UwbCapability
-To(const UWB_DEVICE_CAPABILITIES& deviceCapabilities);
+To(const UWB_DEVICE_CAPABILITIES &deviceCapabilities);
 
 /**
  * @brief Converts UWB_NOTIFICATION_DATA to UwbNotificationData.
- * 
- * @param notificationData 
- * @return ::uwb::protocol::fira::UwbNotificationData 
+ *
+ * @param notificationData
+ * @return ::uwb::protocol::fira::UwbNotificationData
  */
 ::uwb::protocol::fira::UwbNotificationData
-To(const UWB_NOTIFICATION_DATA& notificationData);
+To(const UWB_NOTIFICATION_DATA &notificationData);
 
 } // namespace windows::devices::uwb::ddi::lrp
 

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
@@ -12,9 +12,9 @@
 #include <cfgmgr32.h>
 #include <wil/resource.h>
 
-#include <uwb/protocols/fira/FiraDevice.hxx>
 #include <uwb/UwbDevice.hxx>
 #include <uwb/UwbSessionEventCallbacks.hxx>
+#include <uwb/protocols/fira/FiraDevice.hxx>
 #include <windows/devices/DeviceResource.hxx>
 
 namespace uwb
@@ -83,7 +83,7 @@ public:
 
 private:
     /**
-     * @brief Thread function for handling UWB notifications from the driver. 
+     * @brief Thread function for handling UWB notifications from the driver.
      */
     void
     HandleNotifications();

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
@@ -82,6 +82,46 @@ public:
     IsEqual(const ::uwb::UwbDevice& other) const noexcept override;
 
 private:
+     /**
+     * @brief Invoked when a generic error occurs. 
+     * 
+     * @param status The generic error that occurred.
+     */
+    void
+    OnStatusChanged(::uwb::protocol::fira::UwbStatus status);
+
+    /**
+     * @brief Invoked when the device status changes.
+     * 
+     * @param statusDevice 
+     */
+    void 
+    OnDeviceStatusChanged(::uwb::protocol::fira::UwbStatusDevice statusDevice);
+
+    /**
+     * @brief Invoked when the status of a session changes.
+     * 
+     * @param statusSession The new status of the session.
+     */
+    void
+    OnSessionStatusChanged(::uwb::protocol::fira::UwbSessionStatus statusSession);
+
+    /**
+     * @brief Invoked when the multicast list for a session has a status update.
+     * 
+     * @param statusMulticastList The status of the session's multicast list.
+     */
+    void
+    OnSessionMulticastListStatus(::uwb::protocol::fira::UwbSessionUpdateMulicastListStatus statusMulticastList);
+
+    /**
+     * @brief Invoked when a session has a ranging data update. 
+     * 
+     * @param rangingData The new ranging data.
+     */
+    void
+    OnSessionRangingData(::uwb::protocol::fira::UwbRangingData rangingData);
+
     /**
      * @brief Handles a single UWB notification.
      * 

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include <string>
+#include <thread>
 
 // NB: This must come before any other Windows include
 #include <windows.h>
@@ -11,6 +12,7 @@
 #include <cfgmgr32.h>
 #include <wil/resource.h>
 
+#include <uwb/protocols/fira/FiraDevice.hxx>
 #include <uwb/UwbDevice.hxx>
 #include <uwb/UwbSessionEventCallbacks.hxx>
 #include <windows/devices/DeviceResource.hxx>
@@ -80,10 +82,27 @@ public:
     IsEqual(const ::uwb::UwbDevice& other) const noexcept override;
 
 private:
+    /**
+     * @brief Handles a single UWB notification.
+     * 
+     * @param uwbNotificationData 
+     */
+    void
+    HandleNotification(::uwb::protocol::fira::UwbNotificationData uwbNotificationData);
+
+    /**
+     * @brief Thread function for handling UWB notifications from the driver. 
+     */
+    void
+    HandleNotifications();
+
+private:
     const std::string m_deviceName;
 
     unique_hcmnotification m_hcmNotificationHandle;
     wil::unique_hfile m_handleDriver;
+    wil::unique_hfile m_handleDriverNotifications;
+    std::jthread m_notificationThread;
 };
 } // namespace windows::devices::uwb
 

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
@@ -82,54 +82,6 @@ public:
     IsEqual(const ::uwb::UwbDevice& other) const noexcept override;
 
 private:
-     /**
-     * @brief Invoked when a generic error occurs. 
-     * 
-     * @param status The generic error that occurred.
-     */
-    void
-    OnStatusChanged(::uwb::protocol::fira::UwbStatus status);
-
-    /**
-     * @brief Invoked when the device status changes.
-     * 
-     * @param statusDevice 
-     */
-    void 
-    OnDeviceStatusChanged(::uwb::protocol::fira::UwbStatusDevice statusDevice);
-
-    /**
-     * @brief Invoked when the status of a session changes.
-     * 
-     * @param statusSession The new status of the session.
-     */
-    void
-    OnSessionStatusChanged(::uwb::protocol::fira::UwbSessionStatus statusSession);
-
-    /**
-     * @brief Invoked when the multicast list for a session has a status update.
-     * 
-     * @param statusMulticastList The status of the session's multicast list.
-     */
-    void
-    OnSessionMulticastListStatus(::uwb::protocol::fira::UwbSessionUpdateMulicastListStatus statusMulticastList);
-
-    /**
-     * @brief Invoked when a session has a ranging data update. 
-     * 
-     * @param rangingData The new ranging data.
-     */
-    void
-    OnSessionRangingData(::uwb::protocol::fira::UwbRangingData rangingData);
-
-    /**
-     * @brief Handles a single UWB notification.
-     * 
-     * @param uwbNotificationData 
-     */
-    void
-    HandleNotification(::uwb::protocol::fira::UwbNotificationData uwbNotificationData);
-
     /**
      * @brief Thread function for handling UWB notifications from the driver. 
      */

--- a/windows/drivers/uwb/simulator/UwbSimulatorDispatchEntry.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDispatchEntry.hxx
@@ -50,7 +50,7 @@ struct UwbSimulatorDispatchEntry
      * std::size_t paramLengthTotal = sizeof (UWB_CAPABILITY_PARAM) + paramLength - 1;
      * auto paramsBuffer = std::make_unique<uint8_t[]>(paramLenghtTotal);
      * UWB_CAPABILITY_PARAM *params = reinterpret_cast<UWB_CAPABILITY_PARAM *>(paramsBuffer.get());
-     * auto hr = DeviceIoControl(handle, ..., paramsBuffer, paramLengthTotal, ...);
+     * BOOL ioResult = DeviceIoControl(handle, ..., paramsBuffer, paramLengthTotal, ...);
      *
      * <in driver>
      * std::size_t paramLengthExpected = 10;


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Ensure `UwbDevice` instances receive UWB events from the driver.

### Technical Details

* Add a new, dedicated driver handle for processing notifications from `IOCTL_UWB_NOTIFICATION`.
* Add new interface for handling events for a `UwbDevice`. It is presently unused.
* Add conversion function prototype for `UWB_NOTIFICATION_DATA` -> `UwbNotificationData`.
* Implement top-level handling of all `UWB_NOTIFICATION_DATA` events, including conversion to neutral type, and dispatching to event-specific callback functions.

### Test Results

None

### Reviewer Focus

None

### Future Work

There is a lot of outstanding work here:
* `UWB_NOTIFICATION_DATA` -> `UwbNotificationData`. conversion function needs to be implemented.
* The use fire-and-forget to process events needs to be looked at more closely.
* Stopping the notification processing loop needs to be implemented.
* All the event-specific handlers need to be implemented.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
