### PR TITLE
Add basic session management to UwbDevice

### DIFF
--- a/lib/uwb/UwbDevice.cxx
+++ b/lib/uwb/UwbDevice.cxx
@@ -2,10 +2,35 @@
 #include <type_traits>
 #include <variant>
 
+#include <plog/Log.h>
 #include <uwb/UwbDevice.hxx>
 
 using namespace uwb;
 using namespace uwb::protocol::fira;
+
+std::shared_ptr<UwbSession>
+UwbDevice::GetSession(uint32_t sessionId)
+{
+    std::weak_ptr<UwbSession> sessionWeak;
+    {
+        std::shared_lock sessionSharedLock{ m_sessionsGate };
+        auto sessionIt = m_sessions.find(sessionId);
+        if (sessionIt == std::cend(m_sessions)) {
+            PLOG_VERBOSE << "Session with id=" << sessionId << " not found";
+            return nullptr;
+        }
+    
+        sessionWeak = sessionIt->second;
+    }
+
+    auto session = sessionWeak.lock();
+    if (!session) {
+        PLOG_VERBOSE << "Session with id=" << sessionId << " expired";
+        return nullptr;
+    }
+
+    return session;
+}
 
 void
 UwbDevice::OnStatusChanged([[maybe_unused]] UwbStatus status)
@@ -22,19 +47,37 @@ UwbDevice::OnDeviceStatusChanged([[maybe_unused]] UwbStatusDevice statusDevice)
 void
 UwbDevice::OnSessionStatusChanged([[maybe_unused]] UwbSessionStatus statusSession)
 {
-    // TODO: implement this
+    auto session = GetSession(statusSession.SessionId);
+    if (!session) {
+        PLOG_WARNING << "Ignoring StatusChanged event due to missing session";
+        return;
+    }
+
+    // TODO: implement the rest of this
 }
 
 void
 UwbDevice::OnSessionMulticastListStatus([[maybe_unused]] UwbSessionUpdateMulicastListStatus statusMulticastList)
 {
-    // TODO: implement this
+    auto session = GetSession(statusMulticastList.SessionId);
+    if (!session) {
+        PLOG_WARNING << "Ignoring MulticastListStatus event due to missing session";
+        return;
+    }
+
+    // TODO: implement the rest of this
 }
 
 void
 UwbDevice::OnSessionRangingData([[maybe_unused]] UwbRangingData rangingData)
 {
-    // TODO: implement this
+    auto session = GetSession(rangingData.SessionId);
+    if (!session) {
+        PLOG_WARNING << "Ignoring RangingData event due to missing session";
+        return;
+    }
+
+    // TODO: implement the rest of this
 }
 
 void

--- a/lib/uwb/UwbDevice.cxx
+++ b/lib/uwb/UwbDevice.cxx
@@ -64,10 +64,10 @@ UwbDevice::CreateSession(std::weak_ptr<UwbSessionEventCallbacks> callbacks)
     auto session = CreateSessionImpl(callbacks);
     {
         std::unique_lock sessionExclusiveLock{ m_sessionsGate };
-        m_sessions[session->GetId()] = std::move(session);
+        m_sessions[session->GetId()] = std::weak_ptr<UwbSession>(session);
     }
 
-    return nullptr; // FIXME: needs to be shared_ptr
+    return session;
 }
 
 bool

--- a/lib/uwb/UwbDevice.cxx
+++ b/lib/uwb/UwbDevice.cxx
@@ -19,7 +19,7 @@ UwbDevice::GetSession(uint32_t sessionId)
             PLOG_VERBOSE << "Session with id=" << sessionId << " not found";
             return nullptr;
         }
-    
+
         sessionWeak = sessionIt->second;
     }
 

--- a/lib/uwb/UwbDevice.cxx
+++ b/lib/uwb/UwbDevice.cxx
@@ -45,7 +45,7 @@ UwbDevice::OnDeviceStatusChanged([[maybe_unused]] UwbStatusDevice statusDevice)
 }
 
 void
-UwbDevice::OnSessionStatusChanged([[maybe_unused]] UwbSessionStatus statusSession)
+UwbDevice::OnSessionStatusChanged(UwbSessionStatus statusSession)
 {
     auto session = GetSession(statusSession.SessionId);
     if (!session) {
@@ -57,7 +57,7 @@ UwbDevice::OnSessionStatusChanged([[maybe_unused]] UwbSessionStatus statusSessio
 }
 
 void
-UwbDevice::OnSessionMulticastListStatus([[maybe_unused]] UwbSessionUpdateMulicastListStatus statusMulticastList)
+UwbDevice::OnSessionMulticastListStatus(UwbSessionUpdateMulicastListStatus statusMulticastList)
 {
     auto session = GetSession(statusMulticastList.SessionId);
     if (!session) {
@@ -69,7 +69,7 @@ UwbDevice::OnSessionMulticastListStatus([[maybe_unused]] UwbSessionUpdateMulicas
 }
 
 void
-UwbDevice::OnSessionRangingData([[maybe_unused]] UwbRangingData rangingData)
+UwbDevice::OnSessionRangingData(UwbRangingData rangingData)
 {
     auto session = GetSession(rangingData.SessionId);
     if (!session) {

--- a/lib/uwb/UwbDevice.cxx
+++ b/lib/uwb/UwbDevice.cxx
@@ -62,8 +62,12 @@ std::unique_ptr<UwbSession>
 UwbDevice::CreateSession(std::weak_ptr<UwbSessionEventCallbacks> callbacks)
 {
     auto session = CreateSessionImpl(callbacks);
-    // TODO: put session in map
-    return session;
+    {
+        std::unique_lock sessionExclusiveLock{ m_sessionsGate };
+        m_sessions[session->GetId()] = std::move(session);
+    }
+
+    return nullptr; // FIXME: needs to be shared_ptr
 }
 
 bool

--- a/lib/uwb/UwbDevice.cxx
+++ b/lib/uwb/UwbDevice.cxx
@@ -53,7 +53,7 @@ UwbDevice::OnSessionStatusChanged([[maybe_unused]] UwbSessionStatus statusSessio
         return;
     }
 
-    // TODO: implement the rest of this
+    // TODO: implement this
 }
 
 void
@@ -65,7 +65,7 @@ UwbDevice::OnSessionMulticastListStatus([[maybe_unused]] UwbSessionUpdateMulicas
         return;
     }
 
-    // TODO: implement the rest of this
+    // TODO: implement this
 }
 
 void
@@ -77,7 +77,7 @@ UwbDevice::OnSessionRangingData([[maybe_unused]] UwbRangingData rangingData)
         return;
     }
 
-    // TODO: implement the rest of this
+    // TODO: implement this
 }
 
 void

--- a/lib/uwb/UwbDevice.cxx
+++ b/lib/uwb/UwbDevice.cxx
@@ -58,7 +58,7 @@ UwbDevice::OnUwbNotification(UwbNotificationData uwbNotificationData)
         uwbNotificationData);
 }
 
-std::unique_ptr<UwbSession>
+std::shared_ptr<UwbSession>
 UwbDevice::CreateSession(std::weak_ptr<UwbSessionEventCallbacks> callbacks)
 {
     auto session = CreateSessionImpl(callbacks);

--- a/lib/uwb/UwbDevice.cxx
+++ b/lib/uwb/UwbDevice.cxx
@@ -58,6 +58,14 @@ UwbDevice::OnUwbNotification(UwbNotificationData uwbNotificationData)
         uwbNotificationData);
 }
 
+std::unique_ptr<UwbSession>
+UwbDevice::CreateSession(std::weak_ptr<UwbSessionEventCallbacks> callbacks)
+{
+    auto session = CreateSessionImpl(callbacks);
+    // TODO: put session in map
+    return session;
+}
+
 bool
 uwb::operator==(const UwbDevice& lhs, const UwbDevice& rhs) noexcept
 {

--- a/lib/uwb/include/uwb/UwbDevice.hxx
+++ b/lib/uwb/include/uwb/UwbDevice.hxx
@@ -20,19 +20,20 @@ class UwbDevice
 public:
     /**
      * @brief Creates a new UWB session with no configuration nor peers.
-     *
-     * @return std::unique_ptr<uwb::UwbSession>
+     * 
+     * @param callbacks 
+     * @return std::unique_ptr<UwbSession> 
      */
-    virtual std::unique_ptr<UwbSession>
-    CreateSession(std::weak_ptr<UwbSessionEventCallbacks> callbacks) = 0;
+    std::unique_ptr<UwbSession>
+    CreateSession(std::weak_ptr<UwbSessionEventCallbacks> callbacks);
 
     /**
      * @brief Get the FiRa capabilities of the device.
      *
      * @return uwb::protocol::fira::UwbCapability
      */
-    virtual uwb::protocol::fira::UwbCapability
-    GetCapabilities() const = 0;
+    uwb::protocol::fira::UwbCapability
+    GetCapabilities();
 
     /**
      * @brief Determine if this device is the same as another.
@@ -48,6 +49,24 @@ public:
      * @brief Destroy the UwbDevice object.
      */
     virtual ~UwbDevice() = default;
+
+private:
+    /**
+     * @brief Creates a new UWB session with no configuration nor peers.
+     * 
+     * @param callbacks 
+     * @return std::unique_ptr<UwbSession> 
+     */
+    virtual std::unique_ptr<UwbSession>
+    CreateSessionImpl(std::weak_ptr<UwbSessionEventCallbacks> callbacks) = 0;
+
+    /**
+     * @brief Get the FiRa capabilities of the device.
+     *
+     * @return uwb::protocol::fira::UwbCapability
+     */
+    virtual uwb::protocol::fira::UwbCapability
+    GetCapabilitiesImpl() = 0;
 
 protected:
     /**

--- a/lib/uwb/include/uwb/UwbDevice.hxx
+++ b/lib/uwb/include/uwb/UwbDevice.hxx
@@ -122,7 +122,7 @@ private:
 
 private:
     std::shared_mutex m_sessionsGate;
-    std::unordered_map<uint32_t, std::shared_ptr<uwb::UwbSession>> m_sessions{};
+    std::unordered_map<uint32_t, std::weak_ptr<uwb::UwbSession>> m_sessions{};
 };
 
 bool

--- a/lib/uwb/include/uwb/UwbDevice.hxx
+++ b/lib/uwb/include/uwb/UwbDevice.hxx
@@ -81,6 +81,15 @@ protected:
 
 private:
     /**
+     * @brief Get a reference to the specified session.
+     * 
+     * @param sessionId 
+     * @return std::shared_ptr<UwbSession> 
+     */
+    std::shared_ptr<UwbSession>
+    GetSession(uint32_t sessionId);
+
+    /**
      * @brief Invoked when a generic error occurs.
      *
      * @param status The generic error that occurred.

--- a/lib/uwb/include/uwb/UwbDevice.hxx
+++ b/lib/uwb/include/uwb/UwbDevice.hxx
@@ -3,6 +3,8 @@
 #define UWB_DEVICE_HXX
 
 #include <memory>
+#include <shared_mutex>
+#include <unordered_map>
 
 #include <uwb/UwbSessionEventCallbacks.hxx>
 #include <uwb/protocols/fira/FiraDevice.hxx>
@@ -117,6 +119,10 @@ private:
      */
     void
     OnSessionRangingData(::uwb::protocol::fira::UwbRangingData rangingData);
+
+private:
+    std::shared_mutex m_sessionsGate;
+    std::unordered_map<uint32_t, std::unique_ptr<uwb::UwbSession>> m_sessions{};
 };
 
 bool

--- a/lib/uwb/include/uwb/UwbDevice.hxx
+++ b/lib/uwb/include/uwb/UwbDevice.hxx
@@ -24,9 +24,9 @@ public:
      * @brief Creates a new UWB session with no configuration nor peers.
      * 
      * @param callbacks 
-     * @return std::unique_ptr<UwbSession> 
+     * @return std::shared_ptr<UwbSession> 
      */
-    std::unique_ptr<UwbSession>
+    std::shared_ptr<UwbSession>
     CreateSession(std::weak_ptr<UwbSessionEventCallbacks> callbacks);
 
     /**
@@ -57,9 +57,9 @@ private:
      * @brief Creates a new UWB session with no configuration nor peers.
      * 
      * @param callbacks 
-     * @return std::unique_ptr<UwbSession> 
+     * @return std::shared_ptr<UwbSession> 
      */
-    virtual std::unique_ptr<UwbSession>
+    virtual std::shared_ptr<UwbSession>
     CreateSessionImpl(std::weak_ptr<UwbSessionEventCallbacks> callbacks) = 0;
 
     /**
@@ -122,7 +122,7 @@ private:
 
 private:
     std::shared_mutex m_sessionsGate;
-    std::unordered_map<uint32_t, std::unique_ptr<uwb::UwbSession>> m_sessions{};
+    std::unordered_map<uint32_t, std::shared_ptr<uwb::UwbSession>> m_sessions{};
 };
 
 bool

--- a/linux/devices/uwb/UwbDevice.cxx
+++ b/linux/devices/uwb/UwbDevice.cxx
@@ -3,7 +3,7 @@
 
 using namespace linux::devices;
 
-std::unique_ptr<uwb::UwbSession>
+std::shared_ptr<uwb::UwbSession>
 UwbDevice::CreateSession(std::weak_ptr<uwb::UwbSessionEventCallbacks> /* callbacks */)
 {
     // TODO

--- a/linux/devices/uwb/include/linux/uwb/UwbDevice.hxx
+++ b/linux/devices/uwb/include/linux/uwb/UwbDevice.hxx
@@ -24,9 +24,9 @@ public:
     /**
      * @brief Create a new UWB session.
      * 
-     * @return std::unique_ptr<uwb::UwbSession> 
+     * @return std::shared_ptr<uwb::UwbSession> 
      */
-    std::unique_ptr<uwb::UwbSession>
+    std::shared_ptr<uwb::UwbSession>
     CreateSession(std::weak_ptr<uwb::UwbSessionEventCallbacks> callbacks);
 
     /**
@@ -52,9 +52,9 @@ private:
      * @brief Create a Session object
      * 
      * @param callbacks 
-     * @return std::unique_ptr<uwb::UwbSession> 
+     * @return std::shared_ptr<uwb::UwbSession> 
      */
-    std::unique_ptr<uwb::UwbSession>
+    std::shared_ptr<uwb::UwbSession>
     CreateSessionImpl(std::weak_ptr<uwb::UwbSessionEventCallbacks> callbacks) override;
 
     /**

--- a/linux/devices/uwb/include/linux/uwb/UwbDevice.hxx
+++ b/linux/devices/uwb/include/linux/uwb/UwbDevice.hxx
@@ -27,7 +27,7 @@ public:
      * @return std::unique_ptr<uwb::UwbSession> 
      */
     std::unique_ptr<uwb::UwbSession>
-    CreateSession(std::weak_ptr<uwb::UwbSessionEventCallbacks> callbacks) override;
+    CreateSession(std::weak_ptr<uwb::UwbSessionEventCallbacks> callbacks);
 
     /**
      * @brief Get the capabilities of the device.
@@ -35,7 +35,7 @@ public:
      * @return uwb::protocol::fira::UwbCapability 
      */
     uwb::protocol::fira::UwbCapability
-    GetCapabilities() const override;
+    GetCapabilities();
 
     /**
      * @brief Determine if this device is the same as another.
@@ -46,6 +46,24 @@ public:
      */
     bool
     IsEqual(const uwb::UwbDevice& other) const noexcept override;
+
+private:
+    /**
+     * @brief Create a Session object
+     * 
+     * @param callbacks 
+     * @return std::unique_ptr<uwb::UwbSession> 
+     */
+    std::unique_ptr<uwb::UwbSession>
+    CreateSessionImpl(std::weak_ptr<uwb::UwbSessionEventCallbacks> callbacks) override;
+
+    /**
+     * @brief Get the capabilities of the device.
+     * 
+     * @return uwb::protocol::fira::UwbCapability 
+     */
+    uwb::protocol::fira::UwbCapability
+    GetCapabilitiesImpl() override;
 };
 
 } // namespace devices

--- a/tests/unit/uwb/TestUwbDevice.cxx
+++ b/tests/unit/uwb/TestUwbDevice.cxx
@@ -20,7 +20,7 @@ struct UwbDeviceTestBase : public uwb::UwbDevice
 
     uint16_t Id;
 
-    std::unique_ptr<UwbSession>
+    std::shared_ptr<UwbSession>
     CreateSessionImpl(std::weak_ptr<UwbSessionEventCallbacks> /* callbacks */) override
     {
         return nullptr;

--- a/tests/unit/uwb/TestUwbDevice.cxx
+++ b/tests/unit/uwb/TestUwbDevice.cxx
@@ -21,13 +21,13 @@ struct UwbDeviceTestBase : public uwb::UwbDevice
     uint16_t Id;
 
     std::unique_ptr<UwbSession>
-    CreateSession(std::weak_ptr<UwbSessionEventCallbacks> /* callbacks */) override
+    CreateSessionImpl(std::weak_ptr<UwbSessionEventCallbacks> /* callbacks */) override
     {
         return nullptr;
     }
 
     uwb::protocol::fira::UwbCapability
-    GetCapabilities() const override
+    GetCapabilitiesImpl() override
     {
         return {};
     }

--- a/windows/devices/uwb/UwbDevice.cxx
+++ b/windows/devices/uwb/UwbDevice.cxx
@@ -111,7 +111,7 @@ UwbDevice::HandleNotifications()
 }
 
 std::unique_ptr<uwb::UwbSession>
-UwbDevice::CreateSession(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks)
+UwbDevice::CreateSessionImpl(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks)
 {
     // Create a duplicate handle to the driver for use by the session.
     wil::unique_hfile handleDriverForSession;
@@ -123,7 +123,7 @@ UwbDevice::CreateSession(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callback
 }
 
 UwbCapability
-UwbDevice::GetCapabilities() const
+UwbDevice::GetCapabilitiesImpl()
 {
     // Determine the amount of memory required for the UWB_DEVICE_CAPABILITIES from the driver.
     DWORD bytesRequired = 0;

--- a/windows/devices/uwb/UwbDevice.cxx
+++ b/windows/devices/uwb/UwbDevice.cxx
@@ -110,7 +110,7 @@ UwbDevice::HandleNotifications()
     }
 }
 
-std::unique_ptr<uwb::UwbSession>
+std::shared_ptr<uwb::UwbSession>
 UwbDevice::CreateSessionImpl(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks)
 {
     // Create a duplicate handle to the driver for use by the session.
@@ -119,7 +119,7 @@ UwbDevice::CreateSessionImpl(std::weak_ptr<::uwb::UwbSessionEventCallbacks> call
         return nullptr;
     }
 
-    return std::make_unique<UwbSession>(std::move(callbacks), std::move(handleDriverForSession));
+    return std::make_shared<UwbSession>(std::move(callbacks), std::move(handleDriverForSession));
 }
 
 UwbCapability

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
@@ -69,9 +69,9 @@ private:
      * @brief Create a new UWB session.
      *
      * @param callbacks The event callback instance.
-     * @return std::unique_ptr<uwb::UwbSession>
+     * @return std::shared_ptr<uwb::UwbSession>
      */
-    std::unique_ptr<::uwb::UwbSession>
+    std::shared_ptr<::uwb::UwbSession>
     CreateSessionImpl(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks) override;
 
     /**

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
@@ -55,23 +55,6 @@ public:
     Initialize();
 
     /**
-     * @brief Create a new UWB session.
-     *
-     * @param callbacks The event callback instance.
-     * @return std::unique_ptr<uwb::UwbSession>
-     */
-    std::unique_ptr<::uwb::UwbSession>
-    CreateSession(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks) override;
-
-    /**
-     * @brief Get the capabilities of the device.
-     *
-     * @return uwb::protocol::fira::UwbCapability
-     */
-    ::uwb::protocol::fira::UwbCapability
-    GetCapabilities() const override;
-
-    /**
      * @brief Determine if this device is the same as another.
      *
      * @param other
@@ -80,6 +63,24 @@ public:
      */
     bool
     IsEqual(const ::uwb::UwbDevice& other) const noexcept override;
+
+private:
+    /**
+     * @brief Create a new UWB session.
+     *
+     * @param callbacks The event callback instance.
+     * @return std::unique_ptr<uwb::UwbSession>
+     */
+    std::unique_ptr<::uwb::UwbSession>
+    CreateSessionImpl(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks) override;
+
+    /**
+     * @brief Get the capabilities of the device.
+     *
+     * @return uwb::protocol::fira::UwbCapability
+     */
+    ::uwb::protocol::fira::UwbCapability
+    GetCapabilitiesImpl() override;
 
 private:
     /**


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Allow the `UwbDevice` to track created sessions.

### Technical Details

* Add map of `UwbSession` objects to `UwbDevice` and protective shared lock.
* Add helper function for obtaining `UwbSession` for a session identifier.
* Resolve `UwbSession` for each session-related notification handler.
* Switch `UwbSession` instances to `std::shared_ptr`.
* Change OS-specific interface functions to use template function pattern (`CreateSession()`, `GetCapabilities()`).

### Test Results

All unit tests pass on both Linux and Windows.

### Reviewer Focus

None

### Future Work

* The session-based notification handlers need to be implemented.
* Actual management of the session(s) need to be implemented (eg. removal on appropriate session state change).

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
