### PR TITLE
Add a monitor mode to nocli

### DIFF
--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -160,9 +160,22 @@ NearObjectCli::AddSubcommandUwb(CLI::App* parent)
     auto uwbApp = parent->add_subcommand("uwb", "commands related to uwb")->require_subcommand()->fallthrough();
 
     // sub-commands
+    m_monitorApp = AddSubcommandUwbMonitor(uwbApp);
     m_rangeApp = AddSubcommandUwbRange(uwbApp);
 
     return uwbApp;
+}
+
+CLI::App*
+NearObjectCli::AddSubcommandUwbMonitor(CLI::App* parent)
+{
+    auto monitorApp = parent->add_subcommand("monitor", "commands relating to monitor mode")->fallthrough();
+
+    monitorApp->final_callback([this] {
+        m_cliHandler->HandleMonitorMode();
+    });
+
+    return monitorApp;
 }
 
 CLI::App*

--- a/tools/cli/NearObjectCliHandler.cxx
+++ b/tools/cli/NearObjectCliHandler.cxx
@@ -32,5 +32,5 @@ NearObjectCliHandler::HandleStopRanging() noexcept
 void
 NearObjectCliHandler::HandleMonitorMode() noexcept
 {
-
+    // TODO
 }

--- a/tools/cli/NearObjectCliHandler.cxx
+++ b/tools/cli/NearObjectCliHandler.cxx
@@ -28,3 +28,9 @@ NearObjectCliHandler::HandleStopRanging() noexcept
 {
     // TODO
 }
+
+void
+NearObjectCliHandler::HandleMonitorMode() noexcept
+{
+
+}

--- a/tools/cli/include/nearobject/cli/NearObjectCli.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCli.hxx
@@ -124,6 +124,15 @@ private:
     AddSubcommandUwb(CLI::App* parent);
 
     /**
+     * @brief Add the 'uwb monitor' sub-command. 
+     * 
+     * @param parent The parent app to add the command to.
+     * @return CLI::App* 
+     */
+    CLI::App*
+    AddSubcommandUwbMonitor(CLI::App* parent);
+
+    /**
      * @brief Add the 'uwb range' sub-command.
      *
      * @param parent The parent app to add the command to.
@@ -160,6 +169,7 @@ private:
     std::unique_ptr<CLI::App> m_cliApp;
     // The following are helper references to the subcommands of m_cliApp, the memory is managed by CLI11.
     CLI::App* m_uwbApp;
+    CLI::App* m_monitorApp;
     CLI::App* m_rangeApp;
     CLI::App* m_rangeStartApp;
     CLI::App* m_rangeStopApp;

--- a/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
@@ -50,6 +50,12 @@ struct NearObjectCliHandler
      */
     virtual void
     HandleStopRanging() noexcept;
+
+    /**
+     * @brief Invoked by the command-line driver when monitor mode is requested to be enabled.
+     */
+    virtual void
+    HandleMonitorMode() noexcept;
 };
 
 } // namespace nearobject::cli

--- a/windows/devices/util/CMakeLists.txt
+++ b/windows/devices/util/CMakeLists.txt
@@ -1,10 +1,10 @@
 
-add_library(windevutil STATIC "")
+add_library(windev-util STATIC "")
 
 set(WINDEVUTIL_DIR_PUBLIC_INCLUDE ${CMAKE_CURRENT_LIST_DIR}/include)
 set(WINDEVUTIL_DIR_PUBLIC_INCLUDE_PREFIX ${WINDEVUTIL_DIR_PUBLIC_INCLUDE}/windows/devices)
 
-target_sources(windevutil
+target_sources(windev-util
     PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/DeviceEnumerator.cxx
         ${CMAKE_CURRENT_LIST_DIR}/DevicePresenceMonitor.cxx
@@ -14,12 +14,12 @@ target_sources(windevutil
         ${WINDEVUTIL_DIR_PUBLIC_INCLUDE_PREFIX}/DeviceResource.hxx
 )
 
-target_include_directories(windevutil
+target_include_directories(windev-util
     PUBLIC
         ${WINDEVUTIL_DIR_PUBLIC_INCLUDE}
 )
 
-target_link_libraries(windevutil
+target_link_libraries(windev-util
     PRIVATE
         plog::plog
     PUBLIC
@@ -34,12 +34,12 @@ list(APPEND WINDEVUTIL_PUBLIC_HEADERS
     ${WINDEVUTIL_DIR_PUBLIC_INCLUDE_PREFIX}/DeviceResource.hxx
 )
 
-set_target_properties(windevutil PROPERTIES FOLDER windows/devices)
-set_target_properties(windevutil PROPERTIES PUBLIC_HEADER "${WINDEVUTIL_PUBLIC_HEADERS}")
+set_target_properties(windev-util PROPERTIES FOLDER windows/devices)
+set_target_properties(windev-util PROPERTIES PUBLIC_HEADER "${WINDEVUTIL_PUBLIC_HEADERS}")
 
 install(
-    TARGETS windevutil
-    EXPORT windevutil
+    TARGETS windev-util
+    EXPORT windev-util
     ARCHIVE
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/windows/devices
 )

--- a/windows/devices/uwb/CMakeLists.txt
+++ b/windows/devices/uwb/CMakeLists.txt
@@ -21,7 +21,7 @@ target_include_directories(uwbcxadapter
 
 target_link_libraries(uwbcxadapter
     PRIVATE
-        windevutil
+        windev-util
     PUBLIC
         cfgmgr32.lib
         plog::plog
@@ -69,7 +69,7 @@ target_include_directories(windev-uwb
 target_link_libraries(windev-uwb
     PRIVATE
         uwbcxadapter
-        windevutil
+        windev-util
     PUBLIC
         uwb
         uwb-proto-fira

--- a/windows/devices/uwbsimulator/CMakeLists.txt
+++ b/windows/devices/uwbsimulator/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(windev-uwb-simulator
 
 target_link_libraries(windev-uwb-simulator
     PRIVATE
-        windevutil
+        windev-util
     PUBLIC
         uwb-proto-fira
         uwbsim-driver

--- a/windows/nearobject/service/CMakeLists.txt
+++ b/windows/nearobject/service/CMakeLists.txt
@@ -22,7 +22,7 @@ target_link_libraries(nearobject-service-windows
     PUBLIC
         nearobject-service
         WIL::WIL
-        windevutil
+        windev-util
 )
 
 list(APPEND NO_SERVICE_WINDOWS_PUBLIC_HEADERS

--- a/windows/tools/devicemon/CMakeLists.txt
+++ b/windows/tools/devicemon/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(devicemon
         CLI11::CLI11
         magic_enum::magic_enum
         notstd-windows
-        windevutil
+        windev-util
         plog::plog
         logutils
 )

--- a/windows/tools/nocli/CMakeLists.txt
+++ b/windows/tools/nocli/CMakeLists.txt
@@ -18,7 +18,7 @@ target_link_libraries(nocli-win
         nocli-core
         notstd-windows
         plog::plog
-        windevutil
+        windev-util
         windev-uwb
 )
 

--- a/windows/tools/nocli/Main.cxx
+++ b/windows/tools/nocli/Main.cxx
@@ -15,8 +15,10 @@
 #include <windows/devices/DevicePresenceMonitor.hxx>
 #include <windows/devices/uwb/UwbDevice.hxx>
 
+#include <plog/Appenders/ColorConsoleAppender.h>
 #include <plog/Appenders/DebugOutputAppender.h>
 #include <plog/Appenders/RollingFileAppender.h>
+#include <plog/Formatters/MessageOnlyFormatter.h>
 #include <plog/Formatters/TxtFormatter.h>
 #include <plog/Init.h>
 #include <plog/Log.h>
@@ -28,7 +30,10 @@ main(int argc, char* argv[])
 try {
     plog::RollingFileAppender<plog::TxtFormatter> rollingFileAppender(logging::GetLogName("nocli").c_str());
     plog::DebugOutputAppender<plog::TxtFormatter> debugAppender;
-    plog::init(plog::verbose, &rollingFileAppender).addAppender(&debugAppender);
+    plog::ColorConsoleAppender<plog::MessageOnlyFormatter> colorConsoleAppender{};
+    plog::init(plog::verbose, &rollingFileAppender)
+        .addAppender(&debugAppender)
+        .addAppender(&colorConsoleAppender);
 
     auto cliData = std::make_shared<nearobject::cli::NearObjectCliDataWindows>();
     auto cliHandler = std::make_shared<nearobject::cli::NearObjectCliHandlerWindows>();

--- a/windows/tools/nocli/NearObjectCliHandlerWindows.cxx
+++ b/windows/tools/nocli/NearObjectCliHandlerWindows.cxx
@@ -3,21 +3,23 @@
 #include <string>
 #include <string_view>
 
+#include <magic_enum.hpp>
 #include <notstd/guid.hxx>
+#include <plog/Log.h>
 
 #include <windows/devices/DeviceEnumerator.hxx>
 #include <windows/devices/DevicePresenceMonitor.hxx>
 #include <windows/devices/uwb/UwbDevice.hxx>
+#include <windows/devices/uwb/UwbDeviceDriver.hxx>
 
 #include "NearObjectCliDataWindows.hxx"
 #include "NearObjectCliHandlerWindows.hxx"
 
 using namespace nearobject::cli;
+using namespace windows::devices;
 
 namespace detail
 {
-using namespace windows::devices;
-
 /**
  * @brief Get the default UWB device on the system.
  *
@@ -98,4 +100,18 @@ NearObjectCliHandlerWindows::ResolveUwbDevice(const nearobject::cli::NearObjectC
     }
 
     return detail::ResolveUwbDevice(*cliDataWindows);
+}
+
+void
+NearObjectCliHandlerWindows::HandleMonitorMode() noexcept
+try {
+    // TODO: this should probably be moved into its own function
+    GUID guidToMonitor{};
+    DevicePresenceMonitor presenceMonitor{ windows::devices::uwb::InterfaceClassUwb, [](auto&& presenceEvent, auto&& deviceName) {
+        const auto presenceEventName = magic_enum::enum_name(presenceEvent);
+        PLOG_INFO << deviceName << " " << presenceEventName << std::endl;
+    }};
+
+} catch (...) {
+    // TODO: handle this properly
 }

--- a/windows/tools/nocli/NearObjectCliHandlerWindows.cxx
+++ b/windows/tools/nocli/NearObjectCliHandlerWindows.cxx
@@ -108,10 +108,10 @@ NearObjectCliHandlerWindows::HandleMonitorMode() noexcept
 try {
     // TODO: this should probably be moved into its own function
 
-    // Keep a container of known devices. Once initialized, 
+    // Keep a container of known devices. Once initialized,
     std::vector<std::unique_ptr<windows::devices::uwb::UwbDevice>> uwbDevices{};
 
-    DevicePresenceMonitor presenceMonitor{ windows::devices::uwb::InterfaceClassUwb, [&](auto&& presenceEvent, auto&& deviceName) {
+    DevicePresenceMonitor presenceMonitor(windows::devices::uwb::InterfaceClassUwb, [&](auto&& presenceEvent, auto&& deviceName) {
         const auto presenceEventName = magic_enum::enum_name(presenceEvent);
         PLOG_INFO << deviceName << " " << presenceEventName << std::endl;
 
@@ -141,7 +141,7 @@ try {
             break;
         }
         }
-    }};
+    });
 
     presenceMonitor.Start();
 

--- a/windows/tools/nocli/NearObjectCliHandlerWindows.cxx
+++ b/windows/tools/nocli/NearObjectCliHandlerWindows.cxx
@@ -107,27 +107,51 @@ void
 NearObjectCliHandlerWindows::HandleMonitorMode() noexcept
 try {
     // TODO: this should probably be moved into its own function
+
+    // Keep a container of known devices. Once initialized, 
     std::vector<std::unique_ptr<windows::devices::uwb::UwbDevice>> uwbDevices{};
 
     DevicePresenceMonitor presenceMonitor{ windows::devices::uwb::InterfaceClassUwb, [&](auto&& presenceEvent, auto&& deviceName) {
         const auto presenceEventName = magic_enum::enum_name(presenceEvent);
         PLOG_INFO << deviceName << " " << presenceEventName << std::endl;
 
-        auto uwbDevice = std::make_unique<windows::devices::uwb::UwbDevice>(deviceName);
-        if (!uwbDevice) {
-            PLOG_ERROR << "Failed to instantiate UWB device with name " << deviceName;
-            return;
+        switch (presenceEvent) {
+        case DevicePresenceEvent::Arrived: {
+            auto uwbDevice = std::make_unique<windows::devices::uwb::UwbDevice>(deviceName);
+            if (!uwbDevice) {
+                PLOG_ERROR << "Failed to instantiate UWB device with name " << deviceName;
+                return;
+            }
+
+            uwbDevice->Initialize();
+            uwbDevices.push_back(std::move(uwbDevice));
+            break;
         }
-        uwbDevices.push_back(std::move(uwbDevice));
+        case DevicePresenceEvent::Departed: {
+            auto numErased = std::erase_if(uwbDevices, [&](const auto& uwbDevice) {
+                return uwbDevice->DeviceName() == deviceName;
+            });
+            if (numErased == 0) {
+                PLOG_WARNING << "UWB device with name " << deviceName << " not found; ignoring removal event";
+            }
+            break;
+        }
+        default: {
+            PLOG_ERROR << "Ignoring unknown presence event";
+            break;
+        }
+        }
     }};
 
     presenceMonitor.Start();
 
     // Wait for input before stopping.
-    PLOG_INFO << "UWB monitor mode started. Press any key to stop monitoring.";
+    PLOG_INFO << "UWB monitor mode started. Press <enter> to stop monitoring.";
     std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
 
     presenceMonitor.Stop();
+    PLOG_INFO << "UWB monitor mode stopped";
+
 } catch (...) {
     // TODO: handle this properly
 }

--- a/windows/tools/nocli/NearObjectCliHandlerWindows.hxx
+++ b/windows/tools/nocli/NearObjectCliHandlerWindows.hxx
@@ -15,6 +15,9 @@ struct NearObjectCliHandlerWindows :
 {
     std::shared_ptr<::uwb::UwbDevice>
     ResolveUwbDevice(const nearobject::cli::NearObjectCliData& cliData) noexcept override;
+
+    void
+    HandleMonitorMode() noexcept override;
 };
 } // namespace nearobject::cli
 

--- a/windows/tools/uwb/simulator/CMakeLists.txt
+++ b/windows/tools/uwb/simulator/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(uwbsim-win
         CLI11::CLI11
         logutils
         plog::plog
-        windevutil
+        windev-util
         windev-uwb-simulator
 )
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Allow ad-hoc debugging of UWB events through a command line tool.

### Technical Details

* Add a new common command group `monitor` which monitors device presence.
* Add color console logger to nocli so that log messages are output to the console.
* Rename `windevutil` CMake target to `windev-util` for consistency.

### Test Results

* All unit tests pass on both Linux and Windows.
* `nocli` tool in monitor mode displays the device name and presence event type upon UWB device arrivals + removals

### Reviewer Focus

None

### Future Work

The color console log appender should probably only be added for debugging and/or when verbosity is enabled.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
