### PR TITLE
Expose the UWB LRP DDI from the simulator driver 

### DIFF
--- a/lib/nearobject/service/CMakeLists.txt
+++ b/lib/nearobject/service/CMakeLists.txt
@@ -50,3 +50,9 @@ target_link_libraries(nearobject-service
 )
 
 set_target_properties(nearobject-service PROPERTIES FOLDER lib/nearobject/service)
+
+install(
+    TARGETS nearobject-service
+    EXPORT nearobject-service
+    ARCHIVE
+)

--- a/windows/drivers/uwb/simulator/UwbSimulatorIoQueue.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorIoQueue.cxx
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include <windows.h>
+#include <windows/devices/uwb/UwbCxLrpDevice.h>
 
 #include "UwbSimulatorDdi.h"
 #include "UwbSimulatorDeviceFile.hxx"
@@ -46,6 +47,16 @@ UwbSimulatorIoQueue::Initialize()
             TraceLoggingNTStatus(status, "Status"));
         return status;
     }
+
+     status = WdfDeviceCreateDeviceInterface(wdfDevice, &GUID_UWB_DEVICE_INTERFACE, nullptr);
+     if (!NT_SUCCESS(status)) {
+         TraceLoggingWrite(
+             UwbSimulatorTraceloggingProvider,
+             "Queue WdfDeviceCreateDeviceInterface failed",
+             TraceLoggingLevel(TRACE_LEVEL_ERROR),
+             TraceLoggingNTStatus(status, "Status"));
+         return status;
+     }
 
     return STATUS_SUCCESS;
 }

--- a/windows/drivers/uwb/simulator/UwbSimulatorIoQueue.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorIoQueue.cxx
@@ -48,15 +48,15 @@ UwbSimulatorIoQueue::Initialize()
         return status;
     }
 
-     status = WdfDeviceCreateDeviceInterface(wdfDevice, &GUID_UWB_DEVICE_INTERFACE, nullptr);
-     if (!NT_SUCCESS(status)) {
-         TraceLoggingWrite(
-             UwbSimulatorTraceloggingProvider,
-             "Queue WdfDeviceCreateDeviceInterface failed",
-             TraceLoggingLevel(TRACE_LEVEL_ERROR),
-             TraceLoggingNTStatus(status, "Status"));
-         return status;
-     }
+    status = WdfDeviceCreateDeviceInterface(wdfDevice, &GUID_UWB_DEVICE_INTERFACE, nullptr);
+    if (!NT_SUCCESS(status)) {
+        TraceLoggingWrite(
+            UwbSimulatorTraceloggingProvider,
+            "Queue WdfDeviceCreateDeviceInterface failed",
+            TraceLoggingLevel(TRACE_LEVEL_ERROR),
+            TraceLoggingNTStatus(status, "Status"));
+        return status;
+    }
 
     return STATUS_SUCCESS;
 }


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Allow the simulator driver to be directly identified as a UWB LRP device.

### Technical Details

* Expose the UWB DDI interface on device creation.
* Expand `nearobject-service` target to be installed and exported.

### Test Results

* Verified that `noclie.exe uwb monitor` showed the simulator driver arriving and departing.

### Reviewer Focus

None

### Future Work

Eventually, the DDIs exposed from the simulator driver should be controlled by a configuration file, or extern configuration message.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
