### PR TITLE
Add flex-array wrapper helper type

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -150,7 +150,10 @@
     "testPresets": [
         {
             "name": "dev",
-            "configurePreset": "dev"
+            "configurePreset": "dev",
+            "output": {
+                "outputOnFailure": true
+            }
         }
     ]
 }

--- a/lib/shared/notstd/CMakeLists.txt
+++ b/lib/shared/notstd/CMakeLists.txt
@@ -6,6 +6,7 @@ set(NOTSTD_DIR_PUBLIC_INCLUDE_PREFIX ${NOTSTD_DIR_PUBLIC_INCLUDE}/notstd)
 
 target_sources(notstd
     PUBLIC
+        ${NOTSTD_DIR_PUBLIC_INCLUDE_PREFIX}/flextype_wrapper.hxx
         ${NOTSTD_DIR_PUBLIC_INCLUDE_PREFIX}/hash.hxx
         ${NOTSTD_DIR_PUBLIC_INCLUDE_PREFIX}/memory.hxx
         ${NOTSTD_DIR_PUBLIC_INCLUDE_PREFIX}/range.hxx
@@ -24,6 +25,7 @@ target_include_directories(notstd
 )
 
 list(APPEND NOTSTD_PUBLIC_HEADERS
+    ${NOTSTD_DIR_PUBLIC_INCLUDE_PREFIX}/flextype_wrapper.hxx
     ${NOTSTD_DIR_PUBLIC_INCLUDE_PREFIX}/hash.hxx
     ${NOTSTD_DIR_PUBLIC_INCLUDE_PREFIX}/memory.hxx
     ${NOTSTD_DIR_PUBLIC_INCLUDE_PREFIX}/range.hxx

--- a/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
+++ b/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
@@ -44,11 +44,6 @@ enum class flex_array_type : std::size_t {
  * implementation at the cost of small over-allocation in cases where
  * padding is inserted into the containing structure.
  *
- * Important: This type *must not* be used with types that have nested flex-array
- * members since it uses 'sizeof(FlexElementT)' to determine the total required
- * size. This limitation will be removed once this class is updated to be created
- * with a total size instead of just the number of wrapped elements.
- *
  * @tparam ValueT The type being wrapped.
  * @tparam FlexElementT The array type.
  * @tparam FlexElementAdjuster The adjustment factor based on the flex array type.

--- a/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
+++ b/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
@@ -33,17 +33,17 @@ struct flextype_wrapper
     virtual ~flextype_wrapper() = default;
 
     flextype_wrapper(std::size_t numFlexElements) :
-        m_buffer(sizeof(ValueT) + (sizeof(FlexElementT) * (numFlexElements - notstd::to_underlying(FlexElementAdjuster)))),
+        m_buffer(sizeof(value_type) + (sizeof(element_type) * (numFlexElements - notstd::to_underlying(array_adjuster)))),
         m_value(*reinterpret_cast<ValueT*>(std::data(m_buffer)))
     {}
 
-    flextype_wrapper(std::size_t numFlexElements, const ValueT& value) :
+    flextype_wrapper(std::size_t numFlexElements, const value_type& value) :
         flextype_wrapper(numFlexElements)
     {
         std::memcpy(&m_value, &value, size());
     }
 
-    operator ValueT&() noexcept
+    operator value_type&() noexcept
     {
         return m_value;
     }
@@ -62,7 +62,7 @@ struct flextype_wrapper
 
 private:
     std::vector<uint8_t> m_buffer;
-    ValueT& m_value;
+    value_type& m_value;
 };
 } // namespace notstd
 

--- a/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
+++ b/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
@@ -2,10 +2,12 @@
 #ifndef FLEXTYPE_WRAPPER_HXX
 #define FLEXTYPE_WRAPPER_HXX
 
+#include <cassert>
 #include <concepts>
 #include <cstddef>
 #include <cstdint>
 #include <iterator>
+#include <memory>
 #include <type_traits>
 #include <vector>
 
@@ -102,9 +104,11 @@ struct flextype_wrapper
      * @param num_flex_elements The number of flex-array elements to acommoodate.
      */
     flextype_wrapper(std::size_t num_flex_elements) :
-        m_buffer(required_buffer_size(num_flex_elements)),
-        m_value(*reinterpret_cast<ValueT*>(std::data(m_buffer)))
-    {}
+        m_buffer(alignof(value_type) + required_buffer_size(num_flex_elements)),
+        m_value(*aligned_buffer(m_buffer, required_buffer_size(num_flex_elements)))
+    {
+        assert(reinterpret_cast<uintptr_t>(&m_value) % alignof(decltype(m_value)) == 0);
+    }
 
     /**
      * @brief Construct a new flextype wrapper object from a pre-existing value.

--- a/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
+++ b/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
@@ -27,9 +27,9 @@ template <
 requires std::is_standard_layout_v<ValueT> && std::is_standard_layout_v<FlexElementT>
 struct flextype_wrapper
 {
-    using value_type = typename ValueT;
-    using element_type = typename FlexElementT;
-    static constexpr flex_array_type array_adjusted = FlexElementAdjuster;
+    using value_type = ValueT;
+    using element_type = FlexElementT;
+    static constexpr flex_array_type array_adjuster = FlexElementAdjuster;
 
     virtual ~flextype_wrapper() = default;
 

--- a/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
+++ b/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
@@ -42,7 +42,7 @@ enum class flex_array_type : std::size_t {
  * calculation avoids the use of macros (eg. offsetof) for a cleaner
  * implementation at the cost of small over-allocation in cases where
  * padding is inserted into the containing structure.
- * 
+ *
  * Important: This type *must not* be used with types that have nested flex-array
  * members since it uses 'sizeof(FlexElementT)' to determine the total required
  * size. This limitation will be removed once this class is updated to be created
@@ -72,7 +72,7 @@ struct flextype_wrapper
      * (value_type) plus a specified number of flex-array elements
      * (element_type). The calculation does not account for padding in the
      * wrapped type and so will provide an over-estimate in these scenarios.
-     * 
+     *
      * The sum consists of:
      *  1. The complete size of the wrapped type on its own.
      *  2. The number of flex-array elements that will follow it.
@@ -104,16 +104,16 @@ struct flextype_wrapper
 
     /**
      * @brief Given an input vector, return a pointer aligned to value_type.
-     * 
+     *
      * @param buffer The vector containing the buffer to align.
      * @param num_bytes_to_align The number of bytes in the buffer to align.
-     * @return value_type* 
+     * @return value_type*
      */
     static inline value_type*
     aligned_buffer(std::vector<uint8_t>& buffer, std::size_t num_bytes_to_align)
     {
         std::size_t space = std::size(buffer);
-        void *aligned_pointer = std::data(buffer);
+        void* aligned_pointer = std::data(buffer);
         return reinterpret_cast<value_type*>(std::align(alignof(value_type), num_bytes_to_align, aligned_pointer, space));
     }
 

--- a/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
+++ b/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
@@ -154,12 +154,17 @@ struct flextype_wrapper
      * @param total_size The total size required for the wrapped type.
      */
     explicit flextype_wrapper(std::size_t total_size) :
-        m_buffer(alignof(value_type) + total_size),
-        m_value(*aligned_buffer(m_buffer, total_size)),
-        m_data(reinterpret_cast<uint8_t*>(&m_value), total_size)
-    {
-        assert(reinterpret_cast<uintptr_t>(&m_value) % alignof(decltype(m_value)) == 0);
-    }
+        flextype_wrapper(std::vector<std::uint8_t>(alignof(value_type) + total_size), total_size)
+    {}
+
+    /**
+     * @brief Construct a new flextype wrapper object copy.
+     * 
+     * @param other The other wrapper instance to copy.
+     */
+    flextype_wrapper(const flextype_wrapper& other) :
+        flextype_wrapper(other.m_buffer, std::size(other.m_data))
+    {}
 
     /**
      * @brief Construct a new flextype wrapper object from a pre-existing value.
@@ -205,6 +210,15 @@ struct flextype_wrapper
     data() noexcept
     {
         return m_data;
+    }
+
+private:
+    flextype_wrapper(std::vector<uint8_t> buffer, std::size_t total_size) :
+        m_buffer(std::move(buffer)),
+        m_value(*aligned_buffer(m_buffer, total_size)),
+        m_data(reinterpret_cast<uint8_t*>(&m_value), total_size)
+    {
+        assert(reinterpret_cast<uintptr_t>(&m_value) % alignof(decltype(m_value)) == 0);
     }
 
 private:

--- a/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
+++ b/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
@@ -23,7 +23,7 @@ template <
     typename ValueT,
     typename FlexElementT,
     flex_array_type FlexElementAdjuster = flex_array_type::anysize>
-    requires std::is_standard_layout_v<ValueT> && std::is_standard_layout_v<FlexElementT>
+    requires std::is_standard_layout_v<ValueT>
 struct flextype_wrapper
 {
     using value_type = ValueT;

--- a/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
+++ b/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
@@ -30,11 +30,11 @@ enum class flex_array_type : std::size_t {
  * @brief Wrapper for "flexible array" types. That is, those that have a
  * flexible array as their last member. Eg.
  *
- * struct Element {};
- * struct ElementContainer {
+ * struct element {};
+ * struct element_container {
  *     int index;
- *     std::size_t numElements;
- *     Element elements[];
+ *     std::size_t num_elements;
+ *     element elements[];
  * };
  *
  * This type allocates a buffer to contain the wrapped type plus the specified
@@ -42,6 +42,11 @@ enum class flex_array_type : std::size_t {
  * calculation avoids the use of macros (eg. offsetof) for a cleaner
  * implementation at the cost of small over-allocation in cases where
  * padding is inserted into the containing structure.
+ * 
+ * Important: This type *must not* be used with types that have nested flex-array
+ * members since it uses 'sizeof(FlexElementT)' to determine the total required
+ * size. This limitation will be removed once this class is updated to be created
+ * with a total size instead of just the number of wrapped elements.
  *
  * @tparam ValueT The type being wrapped.
  * @tparam FlexElementT The array type.

--- a/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
+++ b/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
@@ -103,6 +103,21 @@ struct flextype_wrapper
     }
 
     /**
+     * @brief Given an input vector, return a pointer aligned to value_type.
+     * 
+     * @param buffer The vector containing the buffer to align.
+     * @param num_bytes_to_align The number of bytes in the buffer to align.
+     * @return value_type* 
+     */
+    static inline value_type*
+    aligned_buffer(std::vector<uint8_t>& buffer, std::size_t num_bytes_to_align)
+    {
+        std::size_t space = std::size(buffer);
+        void *aligned_pointer = std::data(buffer);
+        return reinterpret_cast<value_type*>(std::align(alignof(value_type), num_bytes_to_align, aligned_pointer, space));
+    }
+
+    /**
      * @brief Construct a new flextype wrapper object with enough room for the
      * specified number of flex-array elements.
      *

--- a/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
+++ b/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
@@ -1,0 +1,70 @@
+
+#ifndef FLEXTYPE_WRAPPER_HXX
+#define FLEXTYPE_WRAPPER_HXX
+
+#include <concepts>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <type_traits>
+#include <vector>
+
+#include <notstd/utility.hxx>
+
+namespace notstd
+{
+
+enum class flex_array_type : std::size_t {
+    ZeroLength = 0,
+    Anysize = 1,
+};
+
+template <
+    typename ValueT,
+    typename FlexElementT,
+    flex_array_type FlexElementAdjuster = flex_array_type::Anysize
+>
+requires std::is_standard_layout_v<ValueT> && std::is_standard_layout_v<FlexElementT>
+struct flextype_wrapper
+{
+    using value_type = typename ValueT;
+    using element_type = typename FlexElementT;
+    static constexpr flex_array_type array_adjusted = FlexElementAdjuster;
+
+    virtual ~flextype_wrapper() = default;
+
+    flextype_wrapper(std::size_t numFlexElements) :
+        m_buffer(sizeof(ValueT) + (sizeof(FlexElementT) * (numFlexElements - notstd::to_underlying(FlexElementAdjuster)))),
+        m_value(*reinterpret_cast<ValueT*>(std::data(m_buffer)))
+    {}
+
+    flextype_wrapper(std::size_t numFlexElements, const ValueT& value) :
+        flextype_wrapper(numFlexElements)
+    {
+        std::memcpy(&m_value, &value, Size());
+    }
+
+    operator ValueT&() noexcept
+    {
+        return m_value;
+    }
+
+    std::size_t
+    Size() const noexcept
+    {
+        return std::size(m_buffer);
+    }
+
+    std::vector<uint8_t>&
+    Buffer() noexcept
+    {
+        return m_buffer;
+    }
+
+private:
+    std::vector<uint8_t> m_buffer;
+    ValueT& m_value;
+};
+} // namespace notstd
+
+#endif // FLEXTYPE_WRAPPER_HXX

--- a/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
+++ b/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
@@ -13,12 +13,38 @@
 
 namespace notstd
 {
-
+/**
+ * @brief Type of flex-array.
+ * 
+ * zero_length: This is the official C99 form: 'int flexArray[]'
+ * anysize: This is the pre-C99 form: 'int flexArray[1]'
+ */
 enum class flex_array_type : std::size_t {
     zero_length = 0,
     anysize = 1,
 };
 
+/**
+ * @brief Wrapper for "flexible array" types. That is, those that have a
+ * flexible array as their last member. Eg.
+ * 
+ * struct Element {};
+ * struct ElementContainer {
+ *     int index;
+ *     std::size_t numElements;
+ *     Element elements[];
+ * };
+ * 
+ * This type allocates a buffer to contain the wrapped type plus the specified
+ * number of elements in its trailing flexible array member. The buffer size
+ * calculation avoids the use of macros (eg. offsetof) for a cleaner
+ * implementation at the cost of small over-allocation in cases where
+ * padding is inserted into the containing structure.
+ * 
+ * @tparam ValueT The type being wrapped.
+ * @tparam FlexElementT The array type.
+ * @tparam FlexElementAdjuster The adjustment factor based on the flex array type.
+ */
 template <
     typename ValueT,
     typename FlexElementT,
@@ -32,28 +58,64 @@ struct flextype_wrapper
 
     virtual ~flextype_wrapper() = default;
 
+    /**
+     * @brief Construct a new flextype wrapper object with enough room for the
+     * specified number of flex-array elements.
+     * 
+     * @param numFlexElements The number of flex-array elements to acommoodate.
+     */
     flextype_wrapper(std::size_t numFlexElements) :
         m_buffer(sizeof(value_type) + (sizeof(element_type) * (numFlexElements - notstd::to_underlying(array_adjuster)))),
         m_value(*reinterpret_cast<ValueT*>(std::data(m_buffer)))
     {}
 
+    /**
+     * @brief Construct a new flextype wrapper object from a pre-existing value.
+     * 
+     * @param numFlexElements The number of flexible array elements in the value. 
+     * @param value The pre-existing value to copy.
+     * 
+     * TODO: the caller knows the exact size of the structure, so we should
+     * instead just take in that value instead, avoiding any possible
+     * overallocation due to padding. It probably makes sense to convert this to
+     * a static function instead.
+     */
     flextype_wrapper(std::size_t numFlexElements, const value_type& value) :
         flextype_wrapper(numFlexElements)
     {
         std::memcpy(&m_value, &value, size());
     }
 
+    /**
+     * @brief User-defined operator allowing the wrapper to be implicitly
+     * converted to the wrapped type.
+     * 
+     * @return value_type& 
+     */
     operator value_type&() noexcept
     {
         return m_value;
     }
 
+    /**
+     * @brief The total size of the buffer. Note that this may be larger than
+     * the size required to contain all of the flex-array elements since the
+     * size calculation does not calculate the length accurately to avoid
+     * requiring the field name and use of a macro.
+     * 
+     * @return std::size_t 
+     */
     std::size_t
     size() const noexcept
     {
         return std::size(m_buffer);
     }
 
+    /**
+     * @brief The buffer containing the wrapped type.
+     * 
+     * @return std::vector<uint8_t>& 
+     */
     std::vector<uint8_t>&
     data() noexcept
     {

--- a/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
+++ b/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
@@ -15,14 +15,14 @@ namespace notstd
 {
 
 enum class flex_array_type : std::size_t {
-    ZeroLength = 0,
-    Anysize = 1,
+    zero_length = 0,
+    anysize = 1,
 };
 
 template <
     typename ValueT,
     typename FlexElementT,
-    flex_array_type FlexElementAdjuster = flex_array_type::Anysize
+    flex_array_type FlexElementAdjuster = flex_array_type::anysize
 >
 requires std::is_standard_layout_v<ValueT> && std::is_standard_layout_v<FlexElementT>
 struct flextype_wrapper
@@ -41,7 +41,7 @@ struct flextype_wrapper
     flextype_wrapper(std::size_t numFlexElements, const ValueT& value) :
         flextype_wrapper(numFlexElements)
     {
-        std::memcpy(&m_value, &value, Size());
+        std::memcpy(&m_value, &value, size());
     }
 
     operator ValueT&() noexcept
@@ -50,13 +50,13 @@ struct flextype_wrapper
     }
 
     std::size_t
-    Size() const noexcept
+    size() const noexcept
     {
         return std::size(m_buffer);
     }
 
     std::vector<uint8_t>&
-    Buffer() noexcept
+    buffer() noexcept
     {
         return m_buffer;
     }

--- a/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
+++ b/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
@@ -22,9 +22,8 @@ enum class flex_array_type : std::size_t {
 template <
     typename ValueT,
     typename FlexElementT,
-    flex_array_type FlexElementAdjuster = flex_array_type::anysize
->
-requires std::is_standard_layout_v<ValueT> && std::is_standard_layout_v<FlexElementT>
+    flex_array_type FlexElementAdjuster = flex_array_type::anysize>
+    requires std::is_standard_layout_v<ValueT> && std::is_standard_layout_v<FlexElementT>
 struct flextype_wrapper
 {
     using value_type = ValueT;

--- a/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
+++ b/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
@@ -15,7 +15,7 @@ namespace notstd
 {
 /**
  * @brief Type of flex-array.
- * 
+ *
  * zero_length: This is the official C99 form: 'int flexArray[]'
  * anysize: This is the pre-C99 form: 'int flexArray[1]'
  */
@@ -27,20 +27,20 @@ enum class flex_array_type : std::size_t {
 /**
  * @brief Wrapper for "flexible array" types. That is, those that have a
  * flexible array as their last member. Eg.
- * 
+ *
  * struct Element {};
  * struct ElementContainer {
  *     int index;
  *     std::size_t numElements;
  *     Element elements[];
  * };
- * 
+ *
  * This type allocates a buffer to contain the wrapped type plus the specified
  * number of elements in its trailing flexible array member. The buffer size
  * calculation avoids the use of macros (eg. offsetof) for a cleaner
  * implementation at the cost of small over-allocation in cases where
  * padding is inserted into the containing structure.
- * 
+ *
  * @tparam ValueT The type being wrapped.
  * @tparam FlexElementT The array type.
  * @tparam FlexElementAdjuster The adjustment factor based on the flex array type.
@@ -61,7 +61,7 @@ struct flextype_wrapper
     /**
      * @brief Construct a new flextype wrapper object with enough room for the
      * specified number of flex-array elements.
-     * 
+     *
      * @param numFlexElements The number of flex-array elements to acommoodate.
      */
     flextype_wrapper(std::size_t numFlexElements) :
@@ -71,10 +71,10 @@ struct flextype_wrapper
 
     /**
      * @brief Construct a new flextype wrapper object from a pre-existing value.
-     * 
-     * @param numFlexElements The number of flexible array elements in the value. 
+     *
+     * @param numFlexElements The number of flexible array elements in the value.
      * @param value The pre-existing value to copy.
-     * 
+     *
      * TODO: the caller knows the exact size of the structure, so we should
      * instead just take in that value instead, avoiding any possible
      * overallocation due to padding. It probably makes sense to convert this to
@@ -89,8 +89,8 @@ struct flextype_wrapper
     /**
      * @brief User-defined operator allowing the wrapper to be implicitly
      * converted to the wrapped type.
-     * 
-     * @return value_type& 
+     *
+     * @return value_type&
      */
     operator value_type&() noexcept
     {
@@ -102,8 +102,8 @@ struct flextype_wrapper
      * the size required to contain all of the flex-array elements since the
      * size calculation does not calculate the length accurately to avoid
      * requiring the field name and use of a macro.
-     * 
-     * @return std::size_t 
+     *
+     * @return std::size_t
      */
     std::size_t
     size() const noexcept
@@ -113,8 +113,8 @@ struct flextype_wrapper
 
     /**
      * @brief The buffer containing the wrapped type.
-     * 
-     * @return std::vector<uint8_t>& 
+     *
+     * @return std::vector<uint8_t>&
      */
     std::vector<uint8_t>&
     data() noexcept

--- a/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
+++ b/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
@@ -55,7 +55,7 @@ struct flextype_wrapper
     }
 
     std::vector<uint8_t>&
-    buffer() noexcept
+    data() noexcept
     {
         return m_buffer;
     }

--- a/tests/unit/notstd/CMakeLists.txt
+++ b/tests/unit/notstd/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(notstd-test)
 target_sources(notstd-test
     PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/Main.cxx
+        ${CMAKE_CURRENT_LIST_DIR}/TestNotStdFlextypeWrapper.cxx
         ${CMAKE_CURRENT_LIST_DIR}/TestNotStdHash.cxx
         ${CMAKE_CURRENT_LIST_DIR}/TestNotStdRange.cxx
         ${CMAKE_CURRENT_LIST_DIR}/TestNotStdScopeExit.cxx

--- a/tests/unit/notstd/TestNotStdFlextypeWrapper.cxx
+++ b/tests/unit/notstd/TestNotStdFlextypeWrapper.cxx
@@ -36,16 +36,16 @@ struct test_flex_type
     flex_element_t elements[notstd::to_underlying(flex_element_type_array_index)];
 
     /**
-     * @brief 
-     * 
-     * @param other 
-     * @return true 
-     * @return false 
+     * @brief
+     *
+     * @param other
+     * @return true
+     * @return false
      */
     bool
     operator==(const test_flex_type& other) const noexcept
     {
-        return std::tie(this->value, this->num_elements) == std::tie(other.value, other.num_elements) && 
+        return std::tie(this->value, this->num_elements) == std::tie(other.value, other.num_elements) &&
             std::memcmp(&this->elements[0], &other.elements[0], other.num_elements * sizeof elements[0]) == 0;
     }
 
@@ -169,9 +169,15 @@ TEST_CASE("flextype_wrapper can be used as a value container with element-based 
             value.elements[i] = { i, i };
         }
 
+        // Test copy-constructor.
         auto wrapper_copy{ wrapper };
         flex_wrapper_type::value_type& value_copy = wrapper_copy;
-        REQUIRE(value == value_copy); 
+        REQUIRE(value == value_copy);
+
+        // Test copy-assignment operator.
+        auto wrapper_copy_assigned = wrapper_copy;
+        value_copy = wrapper_copy_assigned;
+        REQUIRE(value == value_copy);
     }
 
     SECTION("vlaue type is correctly reflected in moved instance")
@@ -186,9 +192,15 @@ TEST_CASE("flextype_wrapper can be used as a value container with element-based 
             value.elements[i] = { i, i };
         }
 
-        auto wrapper_copy{ std::move(wrapper) };
-        flex_wrapper_type::value_type& value_copy = wrapper_copy;
-        REQUIRE(value == value_copy); 
+        // Test move-constructor.
+        auto wrapper_moved{ std::move(wrapper) };
+        flex_wrapper_type::value_type& value_moved = wrapper_moved;
+        REQUIRE(value == value_moved);
+
+        // Test move-assignment operator.
+        auto wrapper_move_assigned = std::move(wrapper_moved);
+        value_moved = wrapper_move_assigned;
+        REQUIRE(value == value_moved);
     }
 }
 

--- a/tests/unit/notstd/TestNotStdFlextypeWrapper.cxx
+++ b/tests/unit/notstd/TestNotStdFlextypeWrapper.cxx
@@ -1,0 +1,110 @@
+
+#include <concepts>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <utility>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <notstd/flextype_wrapper.hxx>
+#include <notstd/utility.hxx>
+
+namespace notstd::test
+{
+template <
+    typename ElementT,
+    flex_array_type ElementTArrayIndex = flex_array_type::Anysize
+>
+struct test_flex_type
+{
+    using flex_element_t = typename ElementT;
+    static constexpr flex_array_type flex_element_type_array_index = ElementTArrayIndex;
+
+    uint32_t value;
+    std::size_t num_elements;
+    flex_element_t elements[notstd::to_underlying(flex_element_type_array_index)];
+
+    template <std::size_t NumElements>
+    static inline constexpr std::size_t total_size()
+    {
+        return offsetof(test_flex_type, elements[NumElements]);
+    }
+};
+
+using test_flex_type_element_byte = uint8_t;
+
+struct test_flex_type_element_compound
+{
+    uint32_t Data1;
+    uint8_t Data2;
+};
+
+/**
+ * @brief The MSVC compiler gets really confused when using this, as it attempts
+ * to deduce a template argument (and fails) even though the argument was
+ * explicitly specified. So, it's commented out for now.
+ * 
+ * @tparam value_t 
+ */
+// template <
+//     template <
+//         typename, flex_array_type
+//     > typename value_t
+// >
+// requires std::is_base_of_v<value_t, test_flex_type>
+// struct test_flex_wrapper : 
+//     public notstd::flextype_wrapper<value_t, typename value_t::flex_element_t, value_t::flex_array_type>
+// {
+//     test_flex_wrapper(std::size_t numElements) :
+//         flextype_wrapper(numElements)
+//     {}   
+// };
+} // namespace notstd::test
+
+TEST_CASE("flextype_wrapper can be used as value container", "[basic]")
+{
+    using namespace notstd;
+    using namespace notstd::test;
+
+    static constexpr std::size_t NumElements = 20;
+
+    SECTION("value type is correctly reflected with single byte flex-element")
+    {
+        // TODO
+    }
+
+    SECTION("value type is correctly reflected with compound flex-element")
+    {
+        using flex_type = test_flex_type<test_flex_type_element_compound>;
+        using flex_wrapper_type = flextype_wrapper<flex_type, flex_type::flex_element_t>;
+
+        constexpr static auto SizeTotal = flex_type::total_size<NumElements>();
+
+        flex_wrapper_type wrapper{NumElements};
+
+        // Ensure the total size matches.
+        REQUIRE(wrapper.Size() == SizeTotal);
+
+        // Populate the value.
+        flex_type& value = wrapper;
+        value.num_elements = NumElements;
+        for (uint8_t i = 0U; i < NumElements; i++) {
+            value.elements[i] = { i, i };
+        }
+
+        // Verify the value in the buffer reflects the populated value.
+        auto& buffer = wrapper.Buffer();
+        flex_type& valueFromBuffer = *reinterpret_cast<flex_type*>(std::data(buffer));
+        REQUIRE(std::memcmp(&valueFromBuffer, &value, SizeTotal) == 0);
+    }
+}
+
+TEST_CASE("flextype_wrapper can be used with an existing value", "[basic]")
+{
+    using namespace notstd::test;
+
+    SECTION("wrapped value matches original value")
+    {
+    }
+}

--- a/tests/unit/notstd/TestNotStdFlextypeWrapper.cxx
+++ b/tests/unit/notstd/TestNotStdFlextypeWrapper.cxx
@@ -25,9 +25,9 @@ struct test_flex_type
     std::size_t num_elements;
     flex_element_t elements[notstd::to_underlying(flex_element_type_array_index)];
 
-    template <std::size_t NumElements>
+    template <std::size_t num_elements>
     struct total_size :
-        public std::integral_constant<std::size_t, offsetof(test_flex_type, elements[NumElements])>
+        public std::integral_constant<std::size_t, offsetof(test_flex_type, elements[num_elements])>
     {};
 };
 

--- a/tests/unit/notstd/TestNotStdFlextypeWrapper.cxx
+++ b/tests/unit/notstd/TestNotStdFlextypeWrapper.cxx
@@ -15,7 +15,7 @@ namespace notstd::test
 {
 template <
     typename ElementT,
-    flex_array_type ElementTArrayIndex = flex_array_type::Anysize
+    flex_array_type ElementTArrayIndex = flex_array_type::anysize
 >
 struct test_flex_type
 {
@@ -34,7 +34,7 @@ struct test_flex_type
 
 template <
     typename ElementT,
-    flex_array_type FlexElementAdjuster = flex_array_type::Anysize
+    flex_array_type FlexElementAdjuster = flex_array_type::anysize
 >
 struct test_flex_wrapper : 
     public notstd::flextype_wrapper<test_flex_type<ElementT, FlexElementAdjuster>, ElementT, FlexElementAdjuster>
@@ -47,12 +47,15 @@ struct test_flex_wrapper :
     {}
 };
 
-using test_flex_type_element_byte = uint8_t;
+struct test_flex_type_element_byte
+{
+    uint8_t Data{ 0xFFU };
+};
 
 struct test_flex_type_element_compound
 {
-    uint32_t Data1;
-    uint8_t Data2;
+    uint32_t Data1{ 0xDEADBEEFU };
+    uint8_t Data2 { 0xADU };
 };
 } // namespace notstd::test
 
@@ -77,7 +80,7 @@ TEST_CASE("flextype_wrapper can be used as value container", "[basic]")
         flex_wrapper_type wrapper{NumElements};
 
         // Ensure the total size matches.
-        REQUIRE(wrapper.Size() == SizeTotal);
+        REQUIRE(wrapper.size() == SizeTotal);
 
         // Populate the value.
         flex_wrapper_type::value_type& value = wrapper;
@@ -87,7 +90,7 @@ TEST_CASE("flextype_wrapper can be used as value container", "[basic]")
         }
 
         // Verify the value in the buffer reflects the populated value.
-        auto& buffer = wrapper.Buffer();
+        auto& buffer = wrapper.buffer();
         flex_wrapper_type::value_type& valueFromBuffer = *reinterpret_cast<flex_wrapper_type::value_type*>(std::data(buffer));
         REQUIRE(std::memcmp(&valueFromBuffer, &value, SizeTotal) == 0);
     }

--- a/tests/unit/notstd/TestNotStdFlextypeWrapper.cxx
+++ b/tests/unit/notstd/TestNotStdFlextypeWrapper.cxx
@@ -39,9 +39,12 @@ template <
 struct test_flex_wrapper : 
     public notstd::flextype_wrapper<test_flex_type<ElementT, FlexElementAdjuster>, ElementT, FlexElementAdjuster>
 {
+    using value_type = test_flex_type<ElementT, FlexElementAdjuster>;
+    using flex_wrapper_type = flextype_wrapper<value_type, ElementT, FlexElementAdjuster>;
+
     test_flex_wrapper(std::size_t numElements) :
-        flextype_wrapper<test_flex_type<ElementT, FlexElementAdjuster>, ElementT, FlexElementAdjuster>(numElements)
-    {}   
+        flex_wrapper_type(numElements)
+    {}
 };
 
 using test_flex_type_element_byte = uint8_t;

--- a/tests/unit/notstd/TestNotStdFlextypeWrapper.cxx
+++ b/tests/unit/notstd/TestNotStdFlextypeWrapper.cxx
@@ -87,7 +87,7 @@ struct test_flex_type_element_compound
 };
 } // namespace notstd::test
 
-TEST_CASE("flextype_wrapper can be used as value container", "[basic]")
+TEST_CASE("flextype_wrapper can be used as a value container with element-based creational pattern", "[basic]")
 {
     using namespace notstd;
     using namespace notstd::test;
@@ -141,6 +141,13 @@ TEST_CASE("flextype_wrapper can be used as value container", "[basic]")
         flex_wrapper_type::value_type& valueFromBuffer = *reinterpret_cast<flex_wrapper_type::value_type*>(std::data(buffer));
         REQUIRE(std::memcmp(&valueFromBuffer, &value, wrapper.size()) == 0);
     }
+}
+
+TEST_CASE("flextype_wrapper can be used as value container with size-based creational pattern", "[basic]")
+{
+    using namespace notstd::test;
+
+    // TODO
 }
 
 TEST_CASE("flextype_wrapper can be used with an existing value", "[basic]")

--- a/tests/unit/notstd/TestNotStdFlextypeWrapper.cxx
+++ b/tests/unit/notstd/TestNotStdFlextypeWrapper.cxx
@@ -26,14 +26,9 @@ struct test_flex_type
     std::size_t num_elements;
     flex_element_t elements[notstd::to_underlying(flex_element_type_array_index)];
 
-    // template <std::size_t NumElements>
-    // static inline constexpr std::size_t total_size()
-    // {
-    //     return offsetof(test_flex_type, elements[NumElements]);
-    // }
-
     template <std::size_t NumElements>
-    struct total_size : public std::integral_constant<std::size_t, NumElements>
+    struct total_size : 
+        public std::integral_constant<std::size_t, offsetof(test_flex_type, elements[NumElements])>
     {};
 };
 

--- a/tests/unit/notstd/TestNotStdFlextypeWrapper.cxx
+++ b/tests/unit/notstd/TestNotStdFlextypeWrapper.cxx
@@ -13,7 +13,7 @@ namespace notstd::test
 /**
  * @brief Helper type which defines a type to be used with the flextype_wrapper.
  * The number of flex-array elements must be known at compile time, which is
- * fine for testing purpose.
+ * fine for testing purposes.
  *
  * @tparam ElementT The flex-array element type.
  * @tparam ElementTArrayIndex The type of flex-array (index) to use.

--- a/tests/unit/notstd/TestNotStdFlextypeWrapper.cxx
+++ b/tests/unit/notstd/TestNotStdFlextypeWrapper.cxx
@@ -18,7 +18,7 @@ template <
 >
 struct test_flex_type
 {
-    using flex_element_t = typename ElementT;
+    using flex_element_t = ElementT;
     static constexpr flex_array_type flex_element_type_array_index = ElementTArrayIndex;
 
     uint32_t value;

--- a/tests/unit/notstd/TestNotStdFlextypeWrapper.cxx
+++ b/tests/unit/notstd/TestNotStdFlextypeWrapper.cxx
@@ -15,8 +15,7 @@ namespace notstd::test
 {
 template <
     typename ElementT,
-    flex_array_type ElementTArrayIndex = flex_array_type::anysize
->
+    flex_array_type ElementTArrayIndex = flex_array_type::anysize>
 struct test_flex_type
 {
     using flex_element_t = ElementT;
@@ -27,16 +26,15 @@ struct test_flex_type
     flex_element_t elements[notstd::to_underlying(flex_element_type_array_index)];
 
     template <std::size_t NumElements>
-    struct total_size : 
+    struct total_size :
         public std::integral_constant<std::size_t, offsetof(test_flex_type, elements[NumElements])>
     {};
 };
 
 template <
     typename ElementT,
-    flex_array_type FlexElementAdjuster = flex_array_type::anysize
->
-struct test_flex_wrapper : 
+    flex_array_type FlexElementAdjuster = flex_array_type::anysize>
+struct test_flex_wrapper :
     public notstd::flextype_wrapper<test_flex_type<ElementT, FlexElementAdjuster>, ElementT, FlexElementAdjuster>
 {
     using value_type = test_flex_type<ElementT, FlexElementAdjuster>;
@@ -55,7 +53,7 @@ struct test_flex_type_element_byte
 struct test_flex_type_element_compound
 {
     uint32_t Data1{ 0xDEADBEEFU };
-    uint8_t Data2 { 0xADU };
+    uint8_t Data2{ 0xADU };
 };
 } // namespace notstd::test
 
@@ -77,7 +75,7 @@ TEST_CASE("flextype_wrapper can be used as value container", "[basic]")
 
         constexpr static auto SizeTotal = flex_wrapper_type::value_type::total_size<NumElements>();
 
-        flex_wrapper_type wrapper{NumElements};
+        flex_wrapper_type wrapper{ NumElements };
 
         // Ensure the total size matches.
         REQUIRE(wrapper.size() == SizeTotal);

--- a/tests/unit/notstd/TestNotStdFlextypeWrapper.cxx
+++ b/tests/unit/notstd/TestNotStdFlextypeWrapper.cxx
@@ -102,7 +102,7 @@ TEST_CASE("flextype_wrapper can be used as value container", "[basic]")
     {
         using flex_wrapper_type = test_flex_wrapper<test_flex_type_element_byte>;
 
-        flex_wrapper_type wrapper{ num_elements };
+        auto wrapper = flex_wrapper_type::from_num_elements(num_elements);
 
         // Ensure there's enough room to store the complete type including flex array elements.
         REQUIRE(wrapper.size() >= flex_wrapper_type::value_type::total_size<num_elements>());
@@ -114,7 +114,7 @@ TEST_CASE("flextype_wrapper can be used as value container", "[basic]")
             value.elements[i] = { i };
         }
 
-        auto& buffer = wrapper.data();
+        auto buffer = wrapper.data();
         flex_wrapper_type::value_type& valueFromBuffer = *reinterpret_cast<flex_wrapper_type::value_type*>(std::data(buffer));
         REQUIRE(std::memcmp(&valueFromBuffer, &value, wrapper.size()) == 0);
     }
@@ -123,7 +123,7 @@ TEST_CASE("flextype_wrapper can be used as value container", "[basic]")
     {
         using flex_wrapper_type = test_flex_wrapper<test_flex_type_element_compound>;
 
-        flex_wrapper_type wrapper{ num_elements };
+        auto wrapper = flex_wrapper_type::from_num_elements(num_elements);
 
         // Ensure there's enough room to store the complete type including flex array elements.
         REQUIRE(wrapper.size() >= flex_wrapper_type::value_type::total_size<num_elements>());
@@ -137,7 +137,7 @@ TEST_CASE("flextype_wrapper can be used as value container", "[basic]")
         }
 
         // Verify the value in the buffer reflects the populated value.
-        auto& buffer = wrapper.data();
+        auto buffer = wrapper.data();
         flex_wrapper_type::value_type& valueFromBuffer = *reinterpret_cast<flex_wrapper_type::value_type*>(std::data(buffer));
         REQUIRE(std::memcmp(&valueFromBuffer, &value, wrapper.size()) == 0);
     }

--- a/tests/unit/notstd/TestNotStdFlextypeWrapper.cxx
+++ b/tests/unit/notstd/TestNotStdFlextypeWrapper.cxx
@@ -62,14 +62,13 @@ TEST_CASE("flextype_wrapper can be used as value container", "[basic]")
     using namespace notstd;
     using namespace notstd::test;
 
-    static constexpr std::size_t NumElements = 20;
+    static constexpr std::size_t NumElements = 5;
 
     SECTION("value type is correctly reflected with single byte flex-element")
     {
         using flex_wrapper_type = test_flex_wrapper<test_flex_type_element_byte>;
         flex_wrapper_type wrapper{ NumElements };
-
-        REQUIRE(wrapper.size() == flex_wrapper_type::value_type::total_size<NumElements>());
+        REQUIRE(wrapper.size() >= flex_wrapper_type::value_type::total_size<NumElements>());
 
         flex_wrapper_type::value_type& value = wrapper;
         value.num_elements = NumElements;
@@ -79,18 +78,17 @@ TEST_CASE("flextype_wrapper can be used as value container", "[basic]")
 
         auto& buffer = wrapper.data();
         flex_wrapper_type::value_type& valueFromBuffer = *reinterpret_cast<flex_wrapper_type::value_type*>(std::data(buffer));
-        REQUIRE(std::memcmp(&valueFromBuffer, &value, wrapper.size()));
+        REQUIRE(std::memcmp(&valueFromBuffer, &value, wrapper.size()) == 0);
     }
 
     SECTION("value type is correctly reflected with compound flex-element")
     {
         using flex_wrapper_type = test_flex_wrapper<test_flex_type_element_compound>;
-        constexpr static auto SizeTotal = flex_wrapper_type::value_type::total_size<NumElements>();
 
         flex_wrapper_type wrapper{ NumElements };
 
         // Ensure the total size matches.
-        REQUIRE(wrapper.size() == SizeTotal);
+        REQUIRE(wrapper.size() >= flex_wrapper_type::value_type::total_size<NumElements>());
 
         // Populate the value.
         flex_wrapper_type::value_type& value = wrapper;
@@ -102,7 +100,7 @@ TEST_CASE("flextype_wrapper can be used as value container", "[basic]")
         // Verify the value in the buffer reflects the populated value.
         auto& buffer = wrapper.data();
         flex_wrapper_type::value_type& valueFromBuffer = *reinterpret_cast<flex_wrapper_type::value_type*>(std::data(buffer));
-        REQUIRE(std::memcmp(&valueFromBuffer, &value, SizeTotal) == 0);
+        REQUIRE(std::memcmp(&valueFromBuffer, &value, wrapper.size()) == 0);
     }
 }
 

--- a/tests/unit/notstd/TestNotStdFlextypeWrapper.cxx
+++ b/tests/unit/notstd/TestNotStdFlextypeWrapper.cxx
@@ -32,6 +32,18 @@ struct test_flex_type
     }
 };
 
+template <
+    typename ElementT,
+    flex_array_type FlexElementAdjuster = flex_array_type::Anysize
+>
+struct test_flex_wrapper : 
+    public notstd::flextype_wrapper<test_flex_type<ElementT, FlexElementAdjuster>, ElementT, FlexElementAdjuster>
+{
+    test_flex_wrapper(std::size_t numElements) :
+        flextype_wrapper<test_flex_type<ElementT, FlexElementAdjuster>, ElementT, FlexElementAdjuster>(numElements)
+    {}   
+};
+
 using test_flex_type_element_byte = uint8_t;
 
 struct test_flex_type_element_compound
@@ -39,27 +51,6 @@ struct test_flex_type_element_compound
     uint32_t Data1;
     uint8_t Data2;
 };
-
-/**
- * @brief The MSVC compiler gets really confused when using this, as it attempts
- * to deduce a template argument (and fails) even though the argument was
- * explicitly specified. So, it's commented out for now.
- * 
- * @tparam value_t 
- */
-// template <
-//     template <
-//         typename, flex_array_type
-//     > typename value_t
-// >
-// requires std::is_base_of_v<value_t, test_flex_type>
-// struct test_flex_wrapper : 
-//     public notstd::flextype_wrapper<value_t, typename value_t::flex_element_t, value_t::flex_array_type>
-// {
-//     test_flex_wrapper(std::size_t numElements) :
-//         flextype_wrapper(numElements)
-//     {}   
-// };
 } // namespace notstd::test
 
 TEST_CASE("flextype_wrapper can be used as value container", "[basic]")
@@ -72,6 +63,7 @@ TEST_CASE("flextype_wrapper can be used as value container", "[basic]")
     SECTION("value type is correctly reflected with single byte flex-element")
     {
         // TODO
+        test_flex_wrapper<test_flex_type_element_compound> wrapper{ NumElements };
     }
 
     SECTION("value type is correctly reflected with compound flex-element")


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Allow types with flex-array members to be used safely and with ease.

### Technical Details

* Add wrapper helper type `flextype_wrapper` to the `notstd` shared library.
* Add unit test for inbound use of `flextype_wrapper`.
* Update CMake 'dev' test preset to output details on failure.

### Test Results

All unit tests pass on both Linux and Windows.

### Reviewer Focus

Consider whether there are any logic errors here. This is complex code and there may be some bugs lurking.

### Future Work

* Author unit tests for the outbound case (copying an existing structure).
* Convert the existing, manually rolled flex-array adapters to use this (eg. `IUwbAppConfigurationParameter` and friends).

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
