### PR TITLE
OnDeviceStatusChanged

### DIFF
--- a/lib/uwb/UwbDevice.cxx
+++ b/lib/uwb/UwbDevice.cxx
@@ -41,7 +41,15 @@ UwbDevice::OnStatusChanged([[maybe_unused]] UwbStatus status)
 void
 UwbDevice::OnDeviceStatusChanged([[maybe_unused]] UwbStatusDevice statusDevice)
 {
-    // TODO: implement this
+    if (m_status.State == UwbDeviceState::Uninitialized) {
+        m_status = statusDevice;
+        PLOG_VERBOSE << "initialized device status as " << m_status.ToString();
+        return;
+    }
+    if (m_status.State != statusDevice.State) {
+        PLOG_VERBOSE << "changed state: " << m_status.ToString() << " --> " << statusDevice.ToString();
+        m_status = statusDevice;
+    }
 }
 
 void

--- a/lib/uwb/include/uwb/UwbDevice.hxx
+++ b/lib/uwb/include/uwb/UwbDevice.hxx
@@ -130,9 +130,9 @@ private:
     OnSessionRangingData(::uwb::protocol::fira::UwbRangingData rangingData);
 
 private:
+    ::uwb::protocol::fira::UwbStatusDevice m_status;
     std::shared_mutex m_sessionsGate;
     std::unordered_map<uint32_t, std::weak_ptr<uwb::UwbSession>> m_sessions{};
-    UwbStatusDevice m_status;
 };
 
 bool

--- a/lib/uwb/include/uwb/UwbDevice.hxx
+++ b/lib/uwb/include/uwb/UwbDevice.hxx
@@ -132,6 +132,7 @@ private:
 private:
     std::shared_mutex m_sessionsGate;
     std::unordered_map<uint32_t, std::weak_ptr<uwb::UwbSession>> m_sessions{};
+    UwbStatusDevice m_status;
 };
 
 bool

--- a/lib/uwb/include/uwb/UwbDevice.hxx
+++ b/lib/uwb/include/uwb/UwbDevice.hxx
@@ -22,9 +22,9 @@ class UwbDevice
 public:
     /**
      * @brief Creates a new UWB session with no configuration nor peers.
-     * 
-     * @param callbacks 
-     * @return std::shared_ptr<UwbSession> 
+     *
+     * @param callbacks
+     * @return std::shared_ptr<UwbSession>
      */
     std::shared_ptr<UwbSession>
     CreateSession(std::weak_ptr<UwbSessionEventCallbacks> callbacks);
@@ -55,9 +55,9 @@ public:
 private:
     /**
      * @brief Creates a new UWB session with no configuration nor peers.
-     * 
-     * @param callbacks 
-     * @return std::shared_ptr<UwbSession> 
+     *
+     * @param callbacks
+     * @return std::shared_ptr<UwbSession>
      */
     virtual std::shared_ptr<UwbSession>
     CreateSessionImpl(std::weak_ptr<UwbSessionEventCallbacks> callbacks) = 0;
@@ -82,9 +82,9 @@ protected:
 private:
     /**
      * @brief Get a reference to the specified session.
-     * 
-     * @param sessionId 
-     * @return std::shared_ptr<UwbSession> 
+     *
+     * @param sessionId
+     * @return std::shared_ptr<UwbSession>
      */
     std::shared_ptr<UwbSession>
     GetSession(uint32_t sessionId);
@@ -130,7 +130,7 @@ private:
     OnSessionRangingData(::uwb::protocol::fira::UwbRangingData rangingData);
 
 private:
-    ::uwb::protocol::fira::UwbStatusDevice m_status;
+    ::uwb::protocol::fira::UwbStatusDevice m_status{ .State = ::uwb::protocol::fira::UwbDeviceState::Uninitialized };
     std::shared_mutex m_sessionsGate;
     std::unordered_map<uint32_t, std::weak_ptr<uwb::UwbSession>> m_sessions{};
 };

--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -302,6 +302,7 @@ enum class UwbDeviceState {
     Ready,
     Active,
     Error,
+    Uninitialized
 };
 enum class UwbSessionType {
     RangingSession,

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -575,6 +575,25 @@ static const std::unordered_map<UWB_STATUS, UwbStatusRanging> StatusToMapRanging
     { UWB_STATUS_RANGING_RX_MAC_IE_MISSING, UwbStatusRanging::RxMacIeMissing },
 };
 
+static const std::unordered_map<UWB_SESSION_STATE, UwbSessionState> SessionStateToMap{
+    { UWB_SESSION_STATE_INIT, UwbSessionState::Initialized },
+    { UWB_SESSION_STATE_DEINIT, UwbSessionState::Deinitialized },
+    { UWB_SESSION_STATE_ACTIVE, UwbSessionState::Active },
+    { UWB_SESSION_STATE_IDLE, UwbSessionState::Idle },
+};
+
+static const std::unordered_map<UWB_SESSION_REASON_CODE, UwbSessionReasonCode> SessionReasonCodeToMap{
+    { UWB_SESSION_REASON_CODE_STATE_CHANGE_WITH_SESSION_MANAGEMENT_COMMANDS, UwbSessionReasonCode::StateChangeWithSessionManagementCommands },
+    { UWB_SESSION_REASON_CODE_MAX_RANGING_ROUND_RETRY_COUNT_REACHED, UwbSessionReasonCode::MaxRangignRoundRetryCountReached },
+    { UWB_SESSION_REASON_CODE_MAX_NUMBER_OF_MEASUREMENTS_REACHED, UwbSessionReasonCode::MaxNumberOfMeasurementsReached },
+    { UWB_SESSION_REASON_CODE_ERROR_SLOT_LENGTH_NOT_SUPPORTED, UwbSessionReasonCode::ErrorSlotLengthNotSupported },
+    { UWB_SESSION_REASON_CODE_ERROR_INSUFFICIENT_SLOTS_PER_RR, UwbSessionReasonCode::ErrorInsufficientSlotsPerRangingRound },
+    { UWB_SESSION_REASON_CODE_ERROR_MAC_ADDRESS_MODE_NOT_SUPPORTED, UwbSessionReasonCode::ErrorMacAddressModeNotSupported },
+    { UWB_SESSION_REASON_CODE_ERROR_INVALID_RANGING_INTERVAL, UwbSessionReasonCode::ErrorInvalidRangingInterval },
+    { UWB_SESSION_REASON_CODE_ERROR_INVALID_STS_CONFIG, UwbSessionReasonCode::ErrorInvalidStsConfiguration },
+    { UWB_SESSION_REASON_CODE_ERROR_INVALID_RFRAME_CONFIG, UwbSessionReasonCode::ErrorInvalidRFrameConfiguration },
+};
+
 UwbNotificationData
 windows::devices::uwb::ddi::lrp::To(const UWB_NOTIFICATION_DATA &notificationData)
 {
@@ -593,8 +612,15 @@ windows::devices::uwb::ddi::lrp::To(const UWB_NOTIFICATION_DATA &notificationDat
         }
         return StatusToMapRanging.at(notificationData.genericError);
     }
-    case UWB_NOTIFICATION_TYPE_SESSION_STATUS:
-    case UWB_NOTIFICATION_TYPE_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST:
+    case UWB_NOTIFICATION_TYPE_SESSION_STATUS: {
+        auto sessionStatus = notificationData.sessionStatus;
+        return UwbSessionStatus{ .SessionId = sessionStatus.sessionId,
+            .State = SessionStateToMap.at(sessionStatus.state),
+            .ReasonCode = SessionReasonCodeToMap.at(sessionStatus.reasonCode) };
+    }
+    case UWB_NOTIFICATION_TYPE_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST: {
+        break;
+    }
     case UWB_NOTIFICATION_TYPE_RANGING_DATA:
         break;
     }

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -201,6 +201,32 @@ From(const ::uwb::protocol::fira::UwbNotificationData &uwbNotificationData);
 To(const UWB_DEVICE_CAPABILITIES &deviceCapabilities);
 
 /**
+ * @brief Converts UWB_DEVICE_STATUS to UwbStatusDevice.
+ *
+ * @param device_status
+ * @return ::uwb::protocol::fira::UwbStatusDevice
+ */
+::uwb::protocol::fira::UwbStatusDevice
+To(const UWB_DEVICE_STATUS &deviceStatus);
+
+/**
+ * @brief Converts UWB_STATUS to UwbStatus
+ *
+ * @param status
+ * @return ::uwb::protocol::fira::UwbStatus
+ */
+::uwb::protocol::fira::UwbStatus
+To(const UWB_STATUS &status);
+
+/**
+ * @brief Converts UWB_SESSION_STATUS to UwbSessionStatus
+ *
+ * @return ::uwb::protocol::fira::UwbSessionStatus
+ */
+::uwb::protocol::fira::UwbSessionStatus
+To(const UWB_SESSION_STATUS &sessionStatus);
+
+/**
  * @brief Converts UWB_NOTIFICATION_DATA to UwbNotificationData.
  *
  * @param notificationData


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [x] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

* Implement the handler function OnDeviceStatusChanged
* Implement the conversion to neutral type for deviceStatus, genericError, sessionStatus
 
### Technical Details

* Added an Uninitialized value to the enum UwbDeviceState so we can print something different when the device is first initialized.
* Added some static const maps from ddi type to neutral type

### Test Results
None yet

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
