### PR TITLE
Update neutral <-> ddi conversion functions involving types with flex-array members

### DIFF
--- a/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
+++ b/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
@@ -53,7 +53,7 @@ template <
     typename ValueT,
     typename FlexElementT,
     flex_array_type FlexElementAdjuster = flex_array_type::anysize>
-    requires std::is_standard_layout_v<ValueT>
+    requires std::is_standard_layout_v<ValueT> && !std::is_array_v<FlexElementT>
 struct flextype_wrapper
 {
     using value_type = ValueT;

--- a/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
+++ b/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
@@ -53,7 +53,7 @@ template <
     typename ValueT,
     typename FlexElementT,
     flex_array_type FlexElementAdjuster = flex_array_type::anysize>
-    requires std::is_standard_layout_v<ValueT> && !std::is_array_v<FlexElementT>
+    requires (std::is_standard_layout_v<ValueT> && !std::is_array_v<FlexElementT>)
 struct flextype_wrapper
 {
     using value_type = ValueT;

--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -475,8 +475,11 @@ struct UwbSessionUpdateMulicastListStatus
 struct UwbSessionStatus
 {
     uint32_t SessionId;
-    UwbSessionState State;
+    UwbSessionState State{ UwbSessionState::Deinitialized };
     std::optional<UwbSessionReasonCode> ReasonCode;
+
+    auto
+    operator<=>(const UwbSessionStatus&) const noexcept = default;
 
     /**
      * @brief Returns a string representation of the object.

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -2,7 +2,6 @@
 #include <algorithm>
 #include <bitset>
 #include <functional>
-#include <ranges>
 #include <stdexcept>
 #include <type_traits>
 #include <typeindex>

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -17,6 +17,7 @@
 #include <windows/devices/uwb/UwbCxAdapterDdiLrp.hxx>
 
 using namespace ::uwb::protocol::fira;
+using namespace windows::devices::uwb::ddi::lrp;
 
 UWB_STATUS
 windows::devices::uwb::ddi::lrp::From(const UwbStatus &uwbStatus)
@@ -142,30 +143,32 @@ windows::devices::uwb::ddi::lrp::From(const UwbSessionUpdateMulticastListEntry &
     return multicastListEntry;
 }
 
-UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST
+UwbSessionUpdateMulicastListWrapper
 windows::devices::uwb::ddi::lrp::From(const UwbSessionUpdateMulicastList &uwbSessionUpdateMulicastList)
 {
-    UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST sessionUpdateControllerMulticastList{};
-    sessionUpdateControllerMulticastList.size = sizeof sessionUpdateControllerMulticastList; // TODO: update for variable length
+    auto sessionUpdateControllerMulticastListWrapper = UwbSessionUpdateMulicastListWrapper::from_num_elements(std::size(uwbSessionUpdateMulicastList.Controlees));
+    UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST& sessionUpdateControllerMulticastList = sessionUpdateControllerMulticastListWrapper;
+    sessionUpdateControllerMulticastList.size = sessionUpdateControllerMulticastListWrapper.size();
     sessionUpdateControllerMulticastList.sessionId = uwbSessionUpdateMulicastList.SessionId;
     sessionUpdateControllerMulticastList.action = From(uwbSessionUpdateMulicastList.Action);
     sessionUpdateControllerMulticastList.numberOfControlees = std::size(uwbSessionUpdateMulicastList.Controlees);
     // TODO: append controlee information
 
-    return sessionUpdateControllerMulticastList;
+    return sessionUpdateControllerMulticastListWrapper;
 }
 
-UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF
+UwbSessionUpdateMulicastListStatusWrapper
 windows::devices::uwb::ddi::lrp::From(const UwbSessionUpdateMulicastListStatus &uwbSessionUpdateMulicastListStatus)
 {
-    UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF multicastListStatus{};
-    multicastListStatus.size = sizeof multicastListStatus; // TODO: update for variable length
+    auto multicastListStatusWrapper = UwbSessionUpdateMulicastListStatusWrapper::from_num_elements(std::size(uwbSessionUpdateMulicastListStatus.Status));
+    UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF& multicastListStatus = multicastListStatusWrapper;
+    multicastListStatus.size = multicastListStatusWrapper.size();
     multicastListStatus.sessionId = uwbSessionUpdateMulicastListStatus.SessionId;
     multicastListStatus.numberOfControlees = std::size(uwbSessionUpdateMulicastListStatus.Status);
     multicastListStatus.remainingMulticastListSize = 0;
     // TODO: append status information
 
-    return multicastListStatus;
+    return multicastListStatusWrapper;
 }
 
 UWB_RANGING_MEASUREMENT_TYPE
@@ -335,18 +338,19 @@ windows::devices::uwb::ddi::lrp::From(const UwbStatusDevice &uwbStatusDevice)
     return statusDevice;
 }
 
-UWB_RANGING_DATA
+UwbRangingDataWrapper
 windows::devices::uwb::ddi::lrp::From(const UwbRangingData &uwbRangingData)
 {
-    UWB_RANGING_DATA rangingData{};            // TODO: this must be allocated to account for 'RangingMeasurements' in uwbRangingData.
-    rangingData.size = sizeof rangingData + 0; // TODO: fix this to account for variable length
+    auto rangingDataWrapper = UwbRangingDataWrapper::from_num_elements(std::size(uwbRangingData.RangingMeasurements));
+    UWB_RANGING_DATA& rangingData = rangingDataWrapper;
+    rangingData.size = rangingDataWrapper.size();
     rangingData.sequenceNumber = uwbRangingData.SequenceNumber;
     rangingData.sessionId = uwbRangingData.SessionId;
     rangingData.currentRangingInterval = uwbRangingData.CurrentRangingInterval;
     rangingData.rangingMeasurementType = From(uwbRangingData.RangingMeasurementType);
     rangingData.numberOfRangingMeasurements = std::size(uwbRangingData.RangingMeasurements);
 
-    return rangingData;
+    return rangingDataWrapper;
 }
 
 UWB_NOTIFICATION_DATA
@@ -379,7 +383,7 @@ windows::devices::uwb::ddi::lrp::From(const UwbNotificationData &uwbNotification
             notificationData.rangingData = From(arg);
         }
         // Note: no else clause is needed here since if the type is not
-        // supported, at at() call above will throw std::out_of_range, ensuring
+        // supported, the at() call above will throw std::out_of_range, ensuring
         // this code will never be reached.
     },
         uwbNotificationData);

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -627,16 +627,16 @@ windows::devices::uwb::ddi::lrp::To(const UWB_DEVICE_STATUS &deviceStatus)
 }
 
 UwbStatus
-windows::devices::uwb::ddi::lrp::To(const UWB_STATUS &genericError)
+windows::devices::uwb::ddi::lrp::To(const UWB_STATUS &status)
 {
-    auto enumId = notstd::to_underlying(genericError);
+    auto enumId = notstd::to_underlying(status);
     if (enumId < notstd::to_underlying(UWB_STATUS_ERROR_SESSION_NOT_EXIST)) {
-        return StatusToMapGeneric.at(genericError);
+        return StatusToMapGeneric.at(status);
     }
     if (enumId < notstd::to_underlying(UWB_STATUS_RANGING_TX_FAILED)) {
-        return StatusToMapSession.at(genericError);
+        return StatusToMapSession.at(status);
     }
-    return StatusToMapRanging.at(genericError);
+    return StatusToMapRanging.at(status);
 }
 
 UwbSessionStatus

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -148,14 +148,14 @@ UwbSessionUpdateMulicastListWrapper
 windows::devices::uwb::ddi::lrp::From(const UwbSessionUpdateMulicastList &uwbSessionUpdateMulicastList)
 {
     auto sessionUpdateControllerMulticastListWrapper = UwbSessionUpdateMulicastListWrapper::from_num_elements(std::size(uwbSessionUpdateMulicastList.Controlees));
-    UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST& sessionUpdateControllerMulticastList = sessionUpdateControllerMulticastListWrapper;
+    UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST &sessionUpdateControllerMulticastList = sessionUpdateControllerMulticastListWrapper;
     sessionUpdateControllerMulticastList.size = sessionUpdateControllerMulticastListWrapper.size();
     sessionUpdateControllerMulticastList.sessionId = uwbSessionUpdateMulicastList.SessionId;
     sessionUpdateControllerMulticastList.action = From(uwbSessionUpdateMulicastList.Action);
     sessionUpdateControllerMulticastList.numberOfControlees = std::size(uwbSessionUpdateMulicastList.Controlees);
 
     for (auto i = 0; i < std::size(uwbSessionUpdateMulicastList.Controlees); i++) {
-        auto& controlee = sessionUpdateControllerMulticastList.controleeList[i];
+        auto &controlee = sessionUpdateControllerMulticastList.controleeList[i];
         controlee = From(uwbSessionUpdateMulicastList.Controlees[i]);
     }
 
@@ -166,14 +166,14 @@ UwbSessionUpdateMulicastListStatusWrapper
 windows::devices::uwb::ddi::lrp::From(const UwbSessionUpdateMulicastListStatus &uwbSessionUpdateMulicastListStatus)
 {
     auto multicastListStatusWrapper = UwbSessionUpdateMulicastListStatusWrapper::from_num_elements(std::size(uwbSessionUpdateMulicastListStatus.Status));
-    UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF& multicastListStatus = multicastListStatusWrapper;
+    UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF &multicastListStatus = multicastListStatusWrapper;
     multicastListStatus.size = multicastListStatusWrapper.size();
     multicastListStatus.sessionId = uwbSessionUpdateMulicastListStatus.SessionId;
     multicastListStatus.numberOfControlees = std::size(uwbSessionUpdateMulicastListStatus.Status);
     multicastListStatus.remainingMulticastListSize = 0;
 
     for (auto i = 0; i < std::size(uwbSessionUpdateMulicastListStatus.Status); i++) {
-        auto& status = multicastListStatus.statusList[i];
+        auto &status = multicastListStatus.statusList[i];
         status = From(uwbSessionUpdateMulicastListStatus.Status[i]);
     }
 
@@ -315,7 +315,7 @@ windows::devices::uwb::ddi::lrp::From(const UwbDeviceInformation &uwbDeviceInfo)
     }
 
     auto deviceInfoWrapper = UwbDeviceInformationWrapper::from_num_elements(numElements);
-    UWB_DEVICE_INFO& deviceInfo = deviceInfoWrapper;
+    UWB_DEVICE_INFO &deviceInfo = deviceInfoWrapper;
     deviceInfo.size = deviceInfoWrapper.size();
     deviceInfo.status = From(uwbDeviceInfo.Status);
     deviceInfo.uciGenericVersionMajor = uwbDeviceInfo.VersionUci.Major;
@@ -334,14 +334,21 @@ windows::devices::uwb::ddi::lrp::From(const UwbDeviceInformation &uwbDeviceInfo)
     return deviceInfoWrapper;
 }
 
-UWB_DEVICE_CAPABILITIES
+UwbDeviceCapabilitiesWrapper
 windows::devices::uwb::ddi::lrp::From(const UwbCapability &uwbDeviceCapabilities)
 {
-    UWB_DEVICE_CAPABILITIES deviceCapabilities{};
-    deviceCapabilities.size = sizeof deviceCapabilities;
-    deviceCapabilities.capabilityParamsCount = 0;
-    // TODO: implement this properly
-    return deviceCapabilities;
+    std::size_t numElements = 2; // TODO: calculate this from uwbDeviceCapabilities
+    auto deviceCapabilitiesWrapper = UwbDeviceCapabilitiesWrapper::from_num_elements(numElements);
+
+    UWB_DEVICE_CAPABILITIES& deviceCapabilities = deviceCapabilitiesWrapper;
+    deviceCapabilities.size = deviceCapabilitiesWrapper.size();
+    deviceCapabilities.capabilityParamsCount = numElements;
+
+    // TODO: fill in deviceCapabilities.capabilityParams. There is currently no
+    // generic list of capabilities, so, we may have to convert each capability
+    // one-by-one.
+    
+    return deviceCapabilitiesWrapper;
 }
 
 UWB_DEVICE_STATUS
@@ -358,7 +365,7 @@ UwbRangingDataWrapper
 windows::devices::uwb::ddi::lrp::From(const UwbRangingData &uwbRangingData)
 {
     auto rangingDataWrapper = UwbRangingDataWrapper::from_num_elements(std::size(uwbRangingData.RangingMeasurements));
-    UWB_RANGING_DATA& rangingData = rangingDataWrapper;
+    UWB_RANGING_DATA &rangingData = rangingDataWrapper;
     rangingData.size = rangingDataWrapper.size();
     rangingData.sequenceNumber = uwbRangingData.SequenceNumber;
     rangingData.sessionId = uwbRangingData.SessionId;

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -2,6 +2,8 @@
 #ifndef UWB_CX_ADAPTER_DDI_LRP_HXX
 #define UWB_CX_ADAPTER_DDI_LRP_HXX
 
+#include <notstd/flextype_wrapper.hxx>
+
 #include <uwb/protocols/fira/FiraDevice.hxx>
 #include <uwb/protocols/fira/UwbApplicationConfiguration.hxx>
 #include <uwb/protocols/fira/UwbCapability.hxx>
@@ -74,22 +76,26 @@ From(const ::uwb::protocol::fira::UwbMulticastListStatus &uwbStatusMulticastList
 UWB_MULTICAST_CONTROLEE_LIST_ENTRY
 From(const ::uwb::protocol::fira::UwbSessionUpdateMulticastListEntry &uwbSessionUpdateMulticastListEntry);
 
+using UwbSessionUpdateMulicastListWrapper = notstd::flextype_wrapper<UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST, std::remove_extent<decltype(UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST::controleeList)>>;
+
 /**
  * @brief Converts UwbSessionUpdateMulicastList to UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST.
  *
  * @param uwbSessionUpdateMulicastList
- * @return UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST
+ * @return UwbSessionUpdateMulicastListWrapper 
  */
-UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST
+UwbSessionUpdateMulicastListWrapper
 From(const ::uwb::protocol::fira::UwbSessionUpdateMulicastList &uwbSessionUpdateMulicastList);
+
+using UwbSessionUpdateMulicastListStatusWrapper = notstd::flextype_wrapper<UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF, std::remove_extent<decltype(UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF::statusList)>>;
 
 /**
  * @brief Converts UwbSessionUpdateMulicastListStatus to UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF.
  *
  * @param uwbSessionUpdateMulicastListStatus
- * @return UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF
+ * @return UwbSessionUpdateMulicastListStatusWrapper 
  */
-UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF
+UwbSessionUpdateMulicastListStatusWrapper
 From(const ::uwb::protocol::fira::UwbSessionUpdateMulicastListStatus &uwbSessionUpdateMulicastListStatus);
 
 /**
@@ -173,13 +179,15 @@ From(const ::uwb::protocol::fira::UwbStatusDevice &uwbStatusDevice);
 UWB_DEVICE_CONFIG_PARAM_TYPE
 From(const ::uwb::protocol::fira::UwbDeviceConfigurationParameterType &uwbDeviceConfigurationParameterType);
 
+using UwbRangingDataWrapper = notstd::flextype_wrapper<UWB_RANGING_DATA, std::remove_extent<decltype(UWB_RANGING_DATA::rangingMeasurements)>>;
+
 /**
  * @brief Converts UwbRangingData to UWB_RANGING_DATA.
  *
  * @param uwbRangingData
- * @return UWB_RANGING_DATA
+ * @return UwbRangingDataWrapper
  */
-UWB_RANGING_DATA
+UwbRangingDataWrapper
 From(const ::uwb::protocol::fira::UwbRangingData &uwbRangingData);
 
 /**

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -154,13 +154,15 @@ using UwbDeviceInformationWrapper = notstd::flextype_wrapper<UWB_DEVICE_INFO, st
 UwbDeviceInformationWrapper
 From(const ::uwb::protocol::fira::UwbDeviceInformation &uwbDeviceInfo);
 
+using UwbDeviceCapabilitiesWrapper = notstd::flextype_wrapper<UWB_DEVICE_CAPABILITIES, std::remove_extent<decltype(UWB_DEVICE_CAPABILITIES::capabilityParams)>>;
+
 /**
  * @brief Converts UwbCapability to UWB_DEVICE_CAPABILITIES.
  *
  * @param uwbDeviceCapabilities
- * @return UWB_DEVICE_CAPABILITIES
+ * @return UwbDeviceCapabilitiesWrapper
  */
-UWB_DEVICE_CAPABILITIES
+UwbDeviceCapabilitiesWrapper
 From(const ::uwb::protocol::fira::UwbCapability &uwbDeviceCapabilities);
 
 /**

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -143,13 +143,15 @@ From(const ::uwb::protocol::fira::UwbSessionState uwbSessionState);
 UWB_SESSION_STATUS
 From(const ::uwb::protocol::fira::UwbSessionStatus &uwbSessionStatus);
 
+using UwbDeviceInformationWrapper = notstd::flextype_wrapper<UWB_DEVICE_INFO, std::remove_extent<decltype(UWB_DEVICE_INFO::vendorSpecificInfo)>>;
+
 /**
  * @brief Converts UwbDeviceInformation to UWB_DEVICE_INFO.
  *
  * @param uwbDeviceInfo
- * @return UWB_DEVICE_INFO
+ * @return UwbDeviceInformationWrapper
  */
-UWB_DEVICE_INFO
+UwbDeviceInformationWrapper
 From(const ::uwb::protocol::fira::UwbDeviceInformation &uwbDeviceInfo);
 
 /**


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Ensure the neutral <-> ddi conversion functions involving DDI types with flexible array member (FAM) types can be converted correctly. 

### Technical Details

* Update conversion functions with FAMs to use `flextype_wrapper`.
* Add constraint for `flextype_wrapper::element_type` to not be an array type.

### Test Results

All unit tests pass on both Linux and Windows.

### Reviewer Focus

None

### Future Work

* Unit tests for each conversion function need to be added.
* Some of the conversion functions that are not needed now were left unimplemented. These will need to be completed at some point.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
