### PR TITLE
Session status

### DIFF
--- a/lib/uwb/UwbDevice.cxx
+++ b/lib/uwb/UwbDevice.cxx
@@ -72,7 +72,6 @@ UwbDevice::OnSessionStatusChanged(UwbSessionStatus statusSession)
         return;
     }
 
-    PLOG_VERBOSE << "session changed state:" << session->GetSessionStatus().ToString() << " --> " << statusSession.ToString();
     session->SetSessionStatus(statusSession);
 }
 

--- a/lib/uwb/UwbDevice.cxx
+++ b/lib/uwb/UwbDevice.cxx
@@ -61,6 +61,7 @@ UwbDevice::OnSessionStatusChanged(UwbSessionStatus statusSession)
         return;
     }
 
+    PLOG_VERBOSE << "session changed state:" << session->GetSessionStatus().ToString() << " --> " << statusSession.ToString();
     session->SetSessionStatus(statusSession);
 }
 

--- a/lib/uwb/UwbDevice.cxx
+++ b/lib/uwb/UwbDevice.cxx
@@ -61,7 +61,7 @@ UwbDevice::OnSessionStatusChanged(UwbSessionStatus statusSession)
         return;
     }
 
-    // TODO: implement this
+    session->SetSessionStatus(statusSession);
 }
 
 void

--- a/lib/uwb/UwbSession.cxx
+++ b/lib/uwb/UwbSession.cxx
@@ -74,6 +74,6 @@ UwbSession::StopRanging()
 void
 UwbSession::SetSessionStatus(const uwb::protocol::fira::UwbSessionStatus& status)
 {
-    PLOG_VERBOSE << "session changed state:" << m_sessionStatus.ToString() << " --> " << status.ToString();
+    PLOG_VERBOSE << "session changed state: " << m_sessionStatus.ToString() << " --> " << status.ToString();
     m_sessionStatus = status;
 }

--- a/lib/uwb/UwbSession.cxx
+++ b/lib/uwb/UwbSession.cxx
@@ -70,3 +70,15 @@ UwbSession::StopRanging()
         return;
     }
 }
+
+void
+UwbSession::SetSessionStatus(const uwb::protocol::fira::UwbSessionStatus& status)
+{
+    m_sessionStatus = status;
+}
+
+const uwb::protocol::fira::UwbSessionStatus&
+UwbSession::GetSessionStatus()
+{
+    return m_sessionStatus;
+}

--- a/lib/uwb/UwbSession.cxx
+++ b/lib/uwb/UwbSession.cxx
@@ -74,11 +74,6 @@ UwbSession::StopRanging()
 void
 UwbSession::SetSessionStatus(const uwb::protocol::fira::UwbSessionStatus& status)
 {
+    PLOG_VERBOSE << "session changed state:" << m_sessionStatus.ToString() << " --> " << status.ToString();
     m_sessionStatus = status;
-}
-
-const uwb::protocol::fira::UwbSessionStatus&
-UwbSession::GetSessionStatus()
-{
-    return m_sessionStatus;
 }

--- a/lib/uwb/include/uwb/UwbSession.hxx
+++ b/lib/uwb/include/uwb/UwbSession.hxx
@@ -20,8 +20,8 @@ struct UwbSessionEventCallbacks;
  */
 enum class UwbSessionEndReason {
     /**
-     * @brief The session owner stopped the session. 
-     * 
+     * @brief The session owner stopped the session.
+     *
      * This is the reason used when the session ends naturally.
      */
     Stopped,
@@ -50,7 +50,7 @@ class UwbSession
 public:
     /**
      * @brief Construct a new UwbSession object.
-     * 
+     *
      * @param callbacks The callbacks to invoke for session events.
      */
     UwbSession(std::weak_ptr<UwbSessionEventCallbacks> callbacks);
@@ -62,18 +62,18 @@ public:
 
     /**
      * @brief Get the unique session id.
-     * 
-     * @return uint32_t 
+     *
+     * @return uint32_t
      */
     uint32_t
     GetId() const noexcept;
 
     /**
      * @brief Configure the session for use.
-     * 
+     *
      * TODO: This probably needs to return something to indicate whether it was
      * successful or not.
-     * 
+     *
      * @param uwbSessionData The session configuration to use. This should have
      * been obtained as a result of out-of-band negotiation.
      */
@@ -82,7 +82,7 @@ public:
 
     /**
      * @brief Set the type of mac address to be used for session participants.
-     * 
+     *
      * @param uwbMacAddressType The type of mac address to use.
      */
     void
@@ -90,7 +90,7 @@ public:
 
     /**
      * @brief Add a peer to this session.
-     * 
+     *
      * @param peerMacAddress The mac address of the peer. This is expected to be
      * in the mac address format configured for the session.
      */
@@ -98,16 +98,31 @@ public:
     AddPeer(UwbMacAddress peerMacAddress);
 
     /**
-     * @brief 
+     * @brief
      */
     void
     StartRanging();
 
     /**
-     * @brief 
+     * @brief
      */
     void
     StopRanging();
+
+    /**
+     * @brief Set the Session Status object
+     *
+     */
+    void
+    SetSessionStatus(const uwb::protocol::fira::UwbSessionStatus&);
+
+    /**
+     * @brief Get the Session Status object
+     *
+     * @return const UwbSessionStatus&
+     */
+    const uwb::protocol::fira::UwbSessionStatus&
+    GetSessionStatus();
 
 private:
     virtual void
@@ -124,6 +139,7 @@ private:
 
 protected:
     uint32_t m_sessionId{ 0 };
+    uwb::protocol::fira::UwbSessionStatus m_sessionStatus;
     UwbMacAddressType m_uwbMacAddressType{ UwbMacAddressType::Extended };
     UwbMacAddress m_uwbMacAddressSelf;
     std::atomic<bool> m_rangingActive{ false };

--- a/lib/uwb/include/uwb/UwbSession.hxx
+++ b/lib/uwb/include/uwb/UwbSession.hxx
@@ -139,7 +139,7 @@ private:
 
 protected:
     uint32_t m_sessionId{ 0 };
-    uwb::protocol::fira::UwbSessionStatus m_sessionStatus;
+    uwb::protocol::fira::UwbSessionStatus m_sessionStatus{};
     UwbMacAddressType m_uwbMacAddressType{ UwbMacAddressType::Extended };
     UwbMacAddress m_uwbMacAddressSelf;
     std::atomic<bool> m_rangingActive{ false };

--- a/lib/uwb/include/uwb/UwbSession.hxx
+++ b/lib/uwb/include/uwb/UwbSession.hxx
@@ -110,7 +110,7 @@ public:
     StopRanging();
 
     /**
-     * @brief Set the Session Status object. NOTE, this function is NOT asynch safe
+     * @brief Set the Session Status object. NOTE, this function is NOT thread safe
      *
      * @param status the new status
      */

--- a/lib/uwb/include/uwb/UwbSession.hxx
+++ b/lib/uwb/include/uwb/UwbSession.hxx
@@ -110,19 +110,12 @@ public:
     StopRanging();
 
     /**
-     * @brief Set the Session Status object
+     * @brief Set the Session Status object. NOTE, this function is NOT asynch safe
      *
+     * @param status the new status
      */
     void
-    SetSessionStatus(const uwb::protocol::fira::UwbSessionStatus&);
-
-    /**
-     * @brief Get the Session Status object
-     *
-     * @return const UwbSessionStatus&
-     */
-    const uwb::protocol::fira::UwbSessionStatus&
-    GetSessionStatus();
+    SetSessionStatus(const uwb::protocol::fira::UwbSessionStatus& status);
 
 private:
     virtual void


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

* Implements OnSessionStatusChanged

### Developer Focus

* Added a m_sessionStatus private member that keeps track of the previous session status. Does it make sense to have the m_sessionStatus.SessionId possibly out of sync with the UwbSession::m_sessionId, especially upon initialization?