### PR TITLE
Implement additional neutral <-> ddi conversion functions

### DIFF
--- a/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
+++ b/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
@@ -53,7 +53,7 @@ template <
     typename ValueT,
     typename FlexElementT,
     flex_array_type FlexElementAdjuster = flex_array_type::anysize>
-    requires std::is_standard_layout_v<ValueT> && !std::is_array_v<FlexElementT>
+    requires (std::is_standard_layout_v<ValueT> && !std::is_array_v<FlexElementT>)
 struct flextype_wrapper
 {
     using value_type = ValueT;

--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -342,6 +342,9 @@ struct UwbStatusDevice
 {
     UwbDeviceState State;
 
+    auto
+    operator<=>(const UwbStatusDevice&) const noexcept = default;
+
     /**
      * @brief Returns a string representation of the object.
      *
@@ -372,6 +375,9 @@ struct UwbDeviceInformation
     UwbVersion VersionPhy;
     UwbStatus Status;
     std::shared_ptr<UwbDeviceInfoVendor> VendorSpecificInfo;
+
+    auto
+    operator<=>(const UwbDeviceInformation&) const noexcept = default;
 };
 
 struct UwbDeviceConfigurationParameter
@@ -431,6 +437,9 @@ struct UwbMulticastListStatus
     uint32_t SubSessionId;
     UwbStatusMulticast Status;
 
+    auto
+    operator<=>(const UwbMulticastListStatus&) const noexcept = default;
+
     /**
      * @brief Returns a string representation of the object.
      *
@@ -449,6 +458,9 @@ struct UwbSessionUpdateMulticastListEntry
 {
     UwbMacAddress ControleeMacAddress;
     uint32_t SubSessionId;
+
+    auto
+    operator<=>(const UwbSessionUpdateMulticastListEntry&) const noexcept = default;
 };
 
 struct UwbSessionUpdateMulicastList
@@ -456,12 +468,18 @@ struct UwbSessionUpdateMulicastList
     uint32_t SessionId;
     UwbMulticastAction Action;
     std::vector<UwbSessionUpdateMulticastListEntry> Controlees;
+
+    auto
+    operator<=>(const UwbSessionUpdateMulicastList&) const noexcept = default;
 };
 
 struct UwbSessionUpdateMulicastListStatus
 {
     uint32_t SessionId;
     std::vector<UwbMulticastListStatus> Status;
+
+    auto
+    operator<=>(const UwbSessionUpdateMulicastListStatus&) const noexcept = default;
 
     /**
      * @brief Returns a string representation of the object.
@@ -496,6 +514,9 @@ struct UwbRangingMeasurementData
     std::optional<uint8_t> FigureOfMerit;
     decltype(FigureOfMerit)& FoM = FigureOfMerit;
 
+    auto
+    operator<=>(const UwbRangingMeasurementData&) const noexcept = default;
+
     /**
      * @brief Returns a string representation of the object.
      *
@@ -517,6 +538,9 @@ struct UwbRangingMeasurement
     UwbRangingMeasurementData AoaDestinationAzimuth;
     UwbRangingMeasurementData AoaDestinationElevation;
 
+    auto
+    operator<=>(const UwbRangingMeasurement&) const noexcept = default;
+
     /**
      * @brief Returns a string representation of the object.
      *
@@ -533,6 +557,9 @@ struct UwbRangingData
     uint32_t CurrentRangingInterval;
     UwbRangingMeasurementType RangingMeasurementType;
     std::vector<UwbRangingMeasurement> RangingMeasurements;
+
+    auto
+    operator<=>(const UwbRangingData&) const noexcept = default;
 
     /**
      * @brief Returns a string representation of the object.

--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -302,7 +302,7 @@ enum class UwbDeviceState {
     Ready,
     Active,
     Error,
-    Uninitialized
+    Uninitialized,
 };
 enum class UwbSessionType {
     RangingSession,

--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -475,8 +475,11 @@ struct UwbSessionUpdateMulicastListStatus
 struct UwbSessionStatus
 {
     uint32_t SessionId;
-    UwbSessionState State;
+    UwbSessionState State{ UwbSessionState::Deinitialized };
     std::optional<UwbSessionReasonCode> ReasonCode;
+
+    auto
+    operator<=>(const UwbSessionStatus&) const noexcept = default;
 
     /**
      * @brief Returns a string representation of the object.

--- a/tests/unit/windows/CMakeLists.txt
+++ b/tests/unit/windows/CMakeLists.txt
@@ -7,11 +7,13 @@ target_sources(nearobject-test-windows
         ${CMAKE_CURRENT_LIST_DIR}/TestNearObjectDeviceDiscoveryAgentUwb.cxx 
         ${CMAKE_CURRENT_LIST_DIR}/TestNotStd.cxx
         ${CMAKE_CURRENT_LIST_DIR}/TestUwbAppConfiguration.cxx
+        ${CMAKE_CURRENT_LIST_DIR}/TestUwbCxAdapterDdiLrpConversion.cxx 
 )
 
 target_link_libraries(nearobject-test-windows
     PRIVATE
         Catch2::Catch2WithMain
+        magic_enum::magic_enum
         nearobject-service-windows
         notstd-windows
         uwb

--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -100,22 +100,59 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
 
     SECTION("UwbSessionUpdateMulticastListEntry is stable")
     {
-        UwbSessionUpdateMulticastListEntry uwbSessionUpdateMulticastListEntry{
+        const UwbSessionUpdateMulticastListEntry uwbSessionUpdateMulticastListEntry{
             .ControleeMacAddress = ::uwb::UwbMacAddress::Random<::uwb::UwbMacAddressType::Short>(),
             .SubSessionId = RandomDistribution(RandomEngine)
         };
+
+        test::ValidateRoundtrip(uwbSessionUpdateMulticastListEntry);
     }
 
     SECTION("UwbSessionUpdateMulicastList is stable")
     {
-        UwbSessionUpdateMulicastListStatus uwbSessionUpdateMulicastListStatus{};
-        // TODO
+        const std::vector<UwbSessionUpdateMulticastListEntry> controlees{
+            UwbSessionUpdateMulticastListEntry{
+                .ControleeMacAddress = ::uwb::UwbMacAddress::Random<::uwb::UwbMacAddressType::Short>(),
+                .SubSessionId = RandomDistribution(RandomEngine)
+            },
+            UwbSessionUpdateMulticastListEntry{
+                .ControleeMacAddress = ::uwb::UwbMacAddress::Random<::uwb::UwbMacAddressType::Short>(),
+                .SubSessionId = RandomDistribution(RandomEngine)
+            },
+            UwbSessionUpdateMulticastListEntry{
+                .ControleeMacAddress = ::uwb::UwbMacAddress::Random<::uwb::UwbMacAddressType::Short>(),
+                .SubSessionId = RandomDistribution(RandomEngine)
+            }
+        };
+
+        for (const auto& uwbMulticastAction : magic_enum::enum_values<UwbMulticastAction>()) {
+            const UwbSessionUpdateMulicastList uwbSessionUpdateMulicastList{
+                .SessionId = RandomDistribution(RandomEngine),
+                .Action = uwbMulticastAction,
+                .Controlees = controlees
+            };
+
+            // test::ValidateRoundtrip(uwbSessionUpdateMulicastList);
+        }
     }
 
     SECTION("UwbSessionUpdateMulicastListStatus is stable")
     {
-        UwbSessionUpdateMulicastListStatus uwbSessionUpdateMulicastListStatus{};
-        // TODO
+        std::vector<UwbMulticastListStatus> uwbMulticastListStatus{};
+        for (const auto& uwbStatusMulticast : magic_enum::enum_values<UwbStatusMulticast>()) {
+            uwbMulticastListStatus.push_back(UwbMulticastListStatus{
+                .ControleeMacAddress = uwb::UwbMacAddress::Random<uwb::UwbMacAddressType::Short>(),
+                .SubSessionId = RandomDistribution(RandomEngine),
+                .Status = uwbStatusMulticast
+            });
+        }
+
+        const UwbSessionUpdateMulicastListStatus uwbSessionUpdateMulicastListStatus{
+            .SessionId = RandomDistribution(RandomEngine),
+            .Status = std::move(uwbMulticastListStatus)
+        };
+
+        // test::ValidateRoundtrip(uwbSessionUpdateMulicastListStatus);
     }
 
     SECTION("UwbRangingMeasurementType is stable")

--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -11,6 +11,18 @@ namespace UwbCxDdi = windows::devices::uwb::ddi::lrp;
 
 namespace windows::devices::uwb::ddi::lrp::test
 {
+/**
+ * @brief Helper to perform a round-trip conversion of a neutral type.
+ * 
+ * This takes a neutral type, converts it to the DDI type, then converts the DDI
+ * type back to the neutral type. If the resulting neutral type matches the
+ * original neutral type instance, this proves that no information is lost in
+ * the conversion, or is "stable".
+ * 
+ * @tparam NeutralT The neutral type.
+ * @param instance An instance of the neutral type.
+ * @return NeutralT 
+ */
 template <typename NeutralT>
 NeutralT
 ConvertRoundtrip(const NeutralT& instance)
@@ -18,6 +30,12 @@ ConvertRoundtrip(const NeutralT& instance)
     return UwbCxDdi::To(UwbCxDdi::From(instance));
 }
 
+/**
+ * @brief Validate a neutral type round-trip conversion works.
+ * 
+ * @tparam NeutralT 
+ * @param instance An instance of the neutral type to validate.
+ */
 template <typename NeutralT>
 void
 ValidateRoundtrip(const NeutralT& instance)

--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -85,39 +85,11 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
         }
     }
 
-    SECTION("UwbSessionState is stable")
-    {
-        for (const auto& uwbSessionState : magic_enum::enum_values<UwbSessionState>()) {
-            test::ValidateRoundtrip(uwbSessionState);
-        }
-    }
-
-    SECTION("UwbSessionReasonCode is stable")
-    {
-        for (const auto& uwbReasonCode : magic_enum::enum_values<UwbSessionReasonCode>()) {
-            test::ValidateRoundtrip(uwbReasonCode);
-        }
-    }
-
-    SECTION("UwbRangingMeasurementType is stable")
-    {
-        for (const auto& uwbMeasurementType : magic_enum::enum_values<UwbRangingMeasurementType>()) {
-            test::ValidateRoundtrip(uwbMeasurementType);
-        }
-    }
-
-    SECTION("UwbApplicationConfigurationParameterType is stable")
-    {
-        for (const auto& uwbApplicationConfigurationParameterType : magic_enum::enum_values<UwbApplicationConfigurationParameterType>()) {
-            test::ValidateRoundtrip(uwbApplicationConfigurationParameterType);
-        }
-    }
-
     SECTION("UwbMulticastListStatus is stable")
     {
 
     }
-    
+
     SECTION("UwbSessionUpdateMulticastListEntry is stable")
     {
 
@@ -131,6 +103,34 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
     SECTION("UwbSessionUpdateMulicastListStatus is stable")
     {
 
+    }
+
+    SECTION("UwbRangingMeasurementType is stable")
+    {
+        for (const auto& uwbMeasurementType : magic_enum::enum_values<UwbRangingMeasurementType>()) {
+            test::ValidateRoundtrip(uwbMeasurementType);
+        }
+    }
+
+    SECTION("UwbSessionReasonCode is stable")
+    {
+        for (const auto& uwbReasonCode : magic_enum::enum_values<UwbSessionReasonCode>()) {
+            test::ValidateRoundtrip(uwbReasonCode);
+        }
+    }
+
+    SECTION("UwbApplicationConfigurationParameterType is stable")
+    {
+        for (const auto& uwbApplicationConfigurationParameterType : magic_enum::enum_values<UwbApplicationConfigurationParameterType>()) {
+            test::ValidateRoundtrip(uwbApplicationConfigurationParameterType);
+        }
+    }
+
+    SECTION("UwbSessionState is stable")
+    {
+        for (const auto& uwbSessionState : magic_enum::enum_values<UwbSessionState>()) {
+            test::ValidateRoundtrip(uwbSessionState);
+        }
     }
 
     SECTION("UwbSessionStatus is stable")
@@ -147,5 +147,35 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
                 test::ValidateRoundtrip(uwbSessionStatus);
             }
         }
+    }
+
+    SECTION("UwbDeviceInformation is stable")
+    {
+
+    }
+
+    SECTION("UwbCapability is stable")
+    {
+
+    }
+
+    SECTION("UwbStatusDevice is stable")
+    {
+
+    }
+
+    SECTION("UwbDeviceConfigurationParameterType is stable")
+    {
+
+    }
+
+    SECTION("UwbRangingData is stable")
+    {
+
+    }
+
+    SECTION("UwbNotificationData is stable")
+    {
+
     }
 }

--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -4,6 +4,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <magic_enum.hpp>
 
+#include <uwb/UwbMacAddress.hxx>
 #include <uwb/protocols/fira/FiraDevice.hxx>
 #include <windows/devices/uwb/UwbCxAdapterDdiLrp.hxx>
 
@@ -13,15 +14,15 @@ namespace windows::devices::uwb::ddi::lrp::test
 {
 /**
  * @brief Helper to perform a round-trip conversion of a neutral type.
- * 
+ *
  * This takes a neutral type, converts it to the DDI type, then converts the DDI
  * type back to the neutral type. If the resulting neutral type matches the
  * original neutral type instance, this proves that no information is lost in
  * the conversion, or is "stable".
- * 
+ *
  * @tparam NeutralT The neutral type.
  * @param instance An instance of the neutral type.
- * @return NeutralT 
+ * @return NeutralT
  */
 template <typename NeutralT>
 NeutralT
@@ -32,8 +33,8 @@ ConvertRoundtrip(const NeutralT& instance)
 
 /**
  * @brief Validate a neutral type round-trip conversion works.
- * 
- * @tparam NeutralT 
+ *
+ * @tparam NeutralT
  * @param instance An instance of the neutral type to validate.
  */
 template <typename NeutralT>
@@ -87,22 +88,26 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
 
     SECTION("UwbMulticastListStatus is stable")
     {
-
     }
 
     SECTION("UwbSessionUpdateMulticastListEntry is stable")
     {
-
     }
 
     SECTION("UwbSessionUpdateMulicastList is stable")
     {
-
     }
 
     SECTION("UwbSessionUpdateMulicastListStatus is stable")
     {
-
+        for (const auto& uwbStatusMulticast : magic_enum::enum_values<UwbStatusMulticast>()) {
+            UwbMulticastListStatus uwbMulticastListStatus{
+                .ControleeMacAddress = ::uwb::UwbMacAddress::Random<::uwb::UwbMacAddressType::Short>(),
+                .SubSessionId = RandomDistribution(RandomEngine),
+                .Status = uwbStatusMulticast
+            };
+            test::ValidateRoundtrip(uwbMulticastListStatus);
+        }
     }
 
     SECTION("UwbRangingMeasurementType is stable")
@@ -151,12 +156,10 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
 
     SECTION("UwbDeviceInformation is stable")
     {
-
     }
 
     SECTION("UwbCapability is stable")
     {
-
     }
 
     SECTION("UwbStatusDevice is stable")
@@ -181,11 +184,9 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
 
     SECTION("UwbRangingData is stable")
     {
-
     }
 
     SECTION("UwbNotificationData is stable")
     {
-
     }
 }

--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -88,18 +88,6 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
 
     SECTION("UwbMulticastListStatus is stable")
     {
-    }
-
-    SECTION("UwbSessionUpdateMulticastListEntry is stable")
-    {
-    }
-
-    SECTION("UwbSessionUpdateMulicastList is stable")
-    {
-    }
-
-    SECTION("UwbSessionUpdateMulicastListStatus is stable")
-    {
         for (const auto& uwbStatusMulticast : magic_enum::enum_values<UwbStatusMulticast>()) {
             UwbMulticastListStatus uwbMulticastListStatus{
                 .ControleeMacAddress = ::uwb::UwbMacAddress::Random<::uwb::UwbMacAddressType::Short>(),
@@ -108,6 +96,22 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
             };
             test::ValidateRoundtrip(uwbMulticastListStatus);
         }
+    }
+
+    SECTION("UwbSessionUpdateMulticastListEntry is stable")
+    {
+        UwbSessionUpdateMulticastListEntry uwbSessionUpdateMulticastListEntry{
+            .ControleeMacAddress = ::uwb::UwbMacAddress::Random<::uwb::UwbMacAddressType::Short>(),
+            .SubSessionId = RandomDistribution(RandomEngine)
+        };
+    }
+
+    SECTION("UwbSessionUpdateMulicastList is stable")
+    {
+    }
+
+    SECTION("UwbSessionUpdateMulicastListStatus is stable")
+    {
     }
 
     SECTION("UwbRangingMeasurementType is stable")

--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -139,7 +139,7 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
         for (const auto& uwbSessionState : magic_enum::enum_values<UwbSessionState>()) {
             // Generate all possible session reason codes.
             for (const auto& uwbSessionReasonCode : magic_enum::enum_values<UwbSessionReasonCode>()) {
-                UwbSessionStatus uwbSessionStatus{
+                const UwbSessionStatus uwbSessionStatus{
                     .SessionId = RandomDistribution(RandomEngine),
                     .State = uwbSessionState,
                     .ReasonCode = uwbSessionReasonCode
@@ -161,12 +161,22 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
 
     SECTION("UwbStatusDevice is stable")
     {
-
+        for (const auto& uwbDeviceState : magic_enum::enum_values<UwbDeviceState>()) {
+            // Avoid roundtrip test for neutral enum value which has no corresponding DDI value.
+            if (uwbDeviceState != UwbDeviceState::Uninitialized) {
+                const UwbStatusDevice uwbStatusDevice{
+                    .State = uwbDeviceState
+                };
+                test::ValidateRoundtrip(uwbStatusDevice);
+            }
+        }
     }
 
     SECTION("UwbDeviceConfigurationParameterType is stable")
     {
-
+        for (const auto& uwbDeviceConfigurationParameterType : magic_enum::enum_values<UwbDeviceConfigurationParameterType>()) {
+            test::ValidateRoundtrip(uwbDeviceConfigurationParameterType);
+        }
     }
 
     SECTION("UwbRangingData is stable")

--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -78,6 +78,13 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
         }
     }
 
+    SECTION("UwbStatusMulticast is stable")
+    {
+        for (const auto& uwbStatusMulticast : magic_enum::enum_values<UwbStatusMulticast>()) {
+            test::ValidateRoundtrip(uwbStatusMulticast);
+        }
+    }
+
     SECTION("UwbSessionState is stable")
     {
         for (const auto& uwbSessionState : magic_enum::enum_values<UwbSessionState>()) {

--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -99,6 +99,40 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
         }
     }
 
+    SECTION("UwbRangingMeasurementType is stable")
+    {
+        for (const auto& uwbMeasurementType : magic_enum::enum_values<UwbRangingMeasurementType>()) {
+            test::ValidateRoundtrip(uwbMeasurementType);
+        }
+    }
+
+    SECTION("UwbApplicationConfigurationParameterType is stable")
+    {
+        for (const auto& uwbApplicationConfigurationParameterType : magic_enum::enum_values<UwbApplicationConfigurationParameterType>()) {
+            test::ValidateRoundtrip(uwbApplicationConfigurationParameterType);
+        }
+    }
+
+    SECTION("UwbMulticastListStatus is stable")
+    {
+
+    }
+    
+    SECTION("UwbSessionUpdateMulticastListEntry is stable")
+    {
+
+    }
+
+    SECTION("UwbSessionUpdateMulicastList is stable")
+    {
+
+    }
+
+    SECTION("UwbSessionUpdateMulicastListStatus is stable")
+    {
+
+    }
+
     SECTION("UwbSessionStatus is stable")
     {
         // Generate all possible session states.

--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -1,0 +1,92 @@
+
+#include <random>
+
+#include <catch2/catch_test_macros.hpp>
+#include <magic_enum.hpp>
+
+#include <uwb/protocols/fira/FiraDevice.hxx>
+#include <windows/devices/uwb/UwbCxAdapterDdiLrp.hxx>
+
+namespace UwbCxDdi = windows::devices::uwb::ddi::lrp;
+
+namespace windows::devices::uwb::ddi::lrp::test
+{
+template <typename NeutralT>
+NeutralT
+ConvertRoundtrip(const NeutralT& instance)
+{
+    return UwbCxDdi::To(UwbCxDdi::From(instance));
+}
+
+template <typename NeutralT>
+void
+ValidateRoundtrip(const NeutralT& instance)
+{
+    auto instanceCopy = ConvertRoundtrip(instance);
+    REQUIRE(instanceCopy == instance);
+}
+} // namespace windows::devices::uwb::ddi::lrp::test
+
+TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][windows][ddi]")
+{
+    using namespace windows::devices::uwb::ddi::lrp;
+    using namespace uwb::protocol::fira;
+
+    std::mt19937 RandomEngine{ std::random_device{}() };
+    std::uniform_int_distribution<uint32_t> RandomDistribution{};
+
+    SECTION("UwbStatus is stable")
+    {
+        for (const auto& uwbStatusGeneric : magic_enum::enum_values<UwbStatusGeneric>()) {
+            const UwbStatus status{ uwbStatusGeneric };
+            test::ValidateRoundtrip(status);
+        }
+    }
+
+    SECTION("UwbDeviceState is stable")
+    {
+        for (const auto& uwbDeviceState : magic_enum::enum_values<UwbDeviceState>()) {
+            // Avoid roundtrip test for neutral enum value which has no corresponding DDI value.
+            if (uwbDeviceState != UwbDeviceState::Uninitialized) {
+                test::ValidateRoundtrip(uwbDeviceState);
+            }
+        }
+    }
+
+    SECTION("UwbMulticastAction is stable")
+    {
+        for (const auto& uwbMulticastAction : magic_enum::enum_values<UwbMulticastAction>()) {
+            test::ValidateRoundtrip(uwbMulticastAction);
+        }
+    }
+
+    SECTION("UwbSessionState is stable")
+    {
+        for (const auto& uwbSessionState : magic_enum::enum_values<UwbSessionState>()) {
+            test::ValidateRoundtrip(uwbSessionState);
+        }
+    }
+
+    SECTION("UwbSessionReasonCode is stable")
+    {
+        for (const auto& uwbReasonCode : magic_enum::enum_values<UwbSessionReasonCode>()) {
+            test::ValidateRoundtrip(uwbReasonCode);
+        }
+    }
+
+    SECTION("UwbSessionStatus is stable")
+    {
+        // Generate all possible session states.
+        for (const auto& uwbSessionState : magic_enum::enum_values<UwbSessionState>()) {
+            // Generate all possible session reason codes.
+            for (const auto& uwbSessionReasonCode : magic_enum::enum_values<UwbSessionReasonCode>()) {
+                UwbSessionStatus uwbSessionStatus{
+                    .SessionId = RandomDistribution(RandomEngine),
+                    .State = uwbSessionState,
+                    .ReasonCode = uwbSessionReasonCode
+                };
+                test::ValidateRoundtrip(uwbSessionStatus);
+            }
+        }
+    }
+}

--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -108,10 +108,14 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
 
     SECTION("UwbSessionUpdateMulicastList is stable")
     {
+        UwbSessionUpdateMulicastListStatus uwbSessionUpdateMulicastListStatus{};
+        // TODO
     }
 
     SECTION("UwbSessionUpdateMulicastListStatus is stable")
     {
+        UwbSessionUpdateMulicastListStatus uwbSessionUpdateMulicastListStatus{};
+        // TODO
     }
 
     SECTION("UwbRangingMeasurementType is stable")

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <bitset>
 #include <functional>
+#include <ranges>
 #include <stdexcept>
 #include <type_traits>
 #include <typeindex>

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -671,6 +671,16 @@ windows::devices::uwb::ddi::lrp::To(const UWB_SESSION_STATE &sessionState)
     return SessionStateToMap.at(sessionState);
 }
 
+UwbRangingMeasurementType
+windows::devices::uwb::ddi::lrp::To(const UWB_RANGING_MEASUREMENT_TYPE &rangingMeasurementType)
+{
+    static const std::unordered_map<UWB_RANGING_MEASUREMENT_TYPE, UwbRangingMeasurementType> RangingTypeMap{
+        { UWB_RANGING_MEASUREMENT_TYPE_TWO_WAY, UwbRangingMeasurementType::TwoWay },
+    };
+
+    return RangingTypeMap.at(rangingMeasurementType);
+}
+
 UwbSessionReasonCode
 windows::devices::uwb::ddi::lrp::To(const UWB_SESSION_REASON_CODE &sessionReasonCode)
 {
@@ -687,6 +697,61 @@ windows::devices::uwb::ddi::lrp::To(const UWB_SESSION_REASON_CODE &sessionReason
     };
 
     return SessionReasonCodeToMap.at(sessionReasonCode);
+}
+
+UwbApplicationConfigurationParameterType
+windows::devices::uwb::ddi::lrp::To(const UWB_APP_CONFIG_PARAM_TYPE &appConfigParameterType)
+{
+    static const std::unordered_map<UWB_APP_CONFIG_PARAM_TYPE, UwbApplicationConfigurationParameterType> AppConfigParamMap{
+        { UWB_APP_CONFIG_PARAM_TYPE_DEVICE_TYPE, UwbApplicationConfigurationParameterType::DeviceType },
+        { UWB_APP_CONFIG_PARAM_TYPE_RANGING_ROUND_USAGE, UwbApplicationConfigurationParameterType::RangingRoundUsage },
+        { UWB_APP_CONFIG_PARAM_TYPE_STS_CONFIG, UwbApplicationConfigurationParameterType::StsConfiguration },
+        { UWB_APP_CONFIG_PARAM_TYPE_MULTI_NODE_MODE, UwbApplicationConfigurationParameterType::MultiNodeMode },
+        { UWB_APP_CONFIG_PARAM_TYPE_CHANNEL_NUMBER, UwbApplicationConfigurationParameterType::ChannelNumber },
+        { UWB_APP_CONFIG_PARAM_TYPE_NUMBER_OF_CONTROLEES, UwbApplicationConfigurationParameterType::NumberOfControlees },
+        { UWB_APP_CONFIG_PARAM_TYPE_DEVICE_MAC_ADDRESS, UwbApplicationConfigurationParameterType::DeviceMacAddress },
+        { UWB_APP_CONFIG_PARAM_TYPE_DST_MAC_ADDRESS, UwbApplicationConfigurationParameterType::ControleeMacAddress },
+        { UWB_APP_CONFIG_PARAM_TYPE_SLOT_DURATION, UwbApplicationConfigurationParameterType::SlotDuration },
+        { UWB_APP_CONFIG_PARAM_TYPE_RANGING_INTERVAL, UwbApplicationConfigurationParameterType::RangingInterval },
+        { UWB_APP_CONFIG_PARAM_TYPE_STS_INDEX, UwbApplicationConfigurationParameterType::StsIndex },
+        { UWB_APP_CONFIG_PARAM_TYPE_MAC_FCS_TYPE, UwbApplicationConfigurationParameterType::MacFcsType,  },
+        { UWB_APP_CONFIG_PARAM_TYPE_RANGING_ROUND_CONTROL, UwbApplicationConfigurationParameterType::RangingRoundControl },
+        { UWB_APP_CONFIG_PARAM_TYPE_AOA_RESULT_REQ, UwbApplicationConfigurationParameterType::AoAResultRequest },
+        { UWB_APP_CONFIG_PARAM_TYPE_RANGE_DATA_NTF_CONFIG, UwbApplicationConfigurationParameterType::RangeDataNotificationConfig },
+        { UWB_APP_CONFIG_PARAM_TYPE_RANGE_DATA_NTF_PROXIMITY_NEAR, UwbApplicationConfigurationParameterType::RangeDataNotificationProximityNear },
+        { UWB_APP_CONFIG_PARAM_TYPE_RANGE_DATA_NTF_PROXIMITY_FAR, UwbApplicationConfigurationParameterType::RangeDataNotificationProximityFar },
+        { UWB_APP_CONFIG_PARAM_TYPE_DEVICE_ROLE, UwbApplicationConfigurationParameterType::DeviceRole },
+        { UWB_APP_CONFIG_PARAM_TYPE_RFRAME_CONFIG, UwbApplicationConfigurationParameterType::RFrameConfiguration },
+        { UWB_APP_CONFIG_PARAM_TYPE_PREAMBLE_CODE_INDEX, UwbApplicationConfigurationParameterType::PreambleCodeIndex },
+        { UWB_APP_CONFIG_PARAM_TYPE_SFD_ID, UwbApplicationConfigurationParameterType::SfdId },
+        { UWB_APP_CONFIG_PARAM_TYPE_PSDU_DATA_RATE, UwbApplicationConfigurationParameterType::PsduDataRate },
+        { UWB_APP_CONFIG_PARAM_TYPE_PREAMBLE_DURATION, UwbApplicationConfigurationParameterType::PreambleDuration },
+        { UWB_APP_CONFIG_PARAM_TYPE_RANGING_TIME_STRUCT, UwbApplicationConfigurationParameterType::RangingTimeStruct },
+        { UWB_APP_CONFIG_PARAM_TYPE_SLOTS_PER_RR, UwbApplicationConfigurationParameterType::SlotsPerRangingRound },
+        { UWB_APP_CONFIG_PARAM_TYPE_TX_ADAPTIVE_PAYLOAD_POWER, UwbApplicationConfigurationParameterType::TxAdaptivePayloadPower },
+        { UWB_APP_CONFIG_PARAM_TYPE_RESPONDER_SLOT_INDEX, UwbApplicationConfigurationParameterType::ResponderSlotIndex },
+        { UWB_APP_CONFIG_PARAM_TYPE_PRF_MODE, UwbApplicationConfigurationParameterType::PrfMode },
+        { UWB_APP_CONFIG_PARAM_TYPE_SCHEDULED_MODE, UwbApplicationConfigurationParameterType::ScheduledMode },
+        { UWB_APP_CONFIG_PARAM_TYPE_KEY_ROTATION, UwbApplicationConfigurationParameterType::KeyRotation },
+        { UWB_APP_CONFIG_PARAM_TYPE_KEY_ROTATION_RATE, UwbApplicationConfigurationParameterType::KeyRotationRate },
+        { UWB_APP_CONFIG_PARAM_TYPE_SESSION_PRIORITY, UwbApplicationConfigurationParameterType::SessionPriority },
+        { UWB_APP_CONFIG_PARAM_TYPE_MAC_ADDRESS_MODE, UwbApplicationConfigurationParameterType::MacAddressMode },
+        { UWB_APP_CONFIG_PARAM_TYPE_VENDOR_ID, UwbApplicationConfigurationParameterType::VendorId },
+        { UWB_APP_CONFIG_PARAM_TYPE_STATIC_STS_IV, UwbApplicationConfigurationParameterType::StaticStsIv },
+        { UWB_APP_CONFIG_PARAM_TYPE_NUMBER_OF_STS_SEGMENTS, UwbApplicationConfigurationParameterType::NumberOfStsSegments },
+        { UWB_APP_CONFIG_PARAM_TYPE_MAX_RR_RETRY, UwbApplicationConfigurationParameterType::MaxRangingRoundRetry },
+        { UWB_APP_CONFIG_PARAM_TYPE_UWB_INITIATION_TIME, UwbApplicationConfigurationParameterType::UwbInitiationTime },
+        { UWB_APP_CONFIG_PARAM_TYPE_HOPPING_MODE, UwbApplicationConfigurationParameterType::HoppingMode },
+        { UWB_APP_CONFIG_PARAM_TYPE_BLOCK_STRIDE_LENGTH, UwbApplicationConfigurationParameterType::BlockStrideLength },
+        { UWB_APP_CONFIG_PARAM_TYPE_RESULT_REPORT_CONFIG, UwbApplicationConfigurationParameterType::ResultReportConfig },
+        { UWB_APP_CONFIG_PARAM_TYPE_IN_BAND_TERMINATION_ATTEMPT_COUNT, UwbApplicationConfigurationParameterType::InBandTerminationAttemptCount },
+        { UWB_APP_CONFIG_PARAM_TYPE_SUB_SESSION_ID, UwbApplicationConfigurationParameterType::SubSessionId },
+        { UWB_APP_CONFIG_PARAM_TYPE_BPRF_PHR_DATA_RATE, UwbApplicationConfigurationParameterType::BprfPhrDataRate },
+        { UWB_APP_CONFIG_PARAM_TYPE_MAX_NUMBER_OF_MEASUREMENTS, UwbApplicationConfigurationParameterType::MaxNumberOfMeasurements },
+        { UWB_APP_CONFIG_PARAM_TYPE_STS_LENGTH, UwbApplicationConfigurationParameterType::StsLength },
+    };
+
+    return AppConfigParamMap.at(appConfigParameterType);
 }
 
 UwbSessionStatus

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -2,7 +2,6 @@
 #include <algorithm>
 #include <bitset>
 #include <functional>
-#include <ranges>
 #include <stdexcept>
 #include <type_traits>
 #include <typeindex>

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -627,16 +627,16 @@ windows::devices::uwb::ddi::lrp::To(const UWB_DEVICE_STATUS &deviceStatus)
 }
 
 UwbStatus
-windows::devices::uwb::ddi::lrp::To(const UWB_STATUS &genericError)
+windows::devices::uwb::ddi::lrp::To(const UWB_STATUS &status)
 {
-    auto enumId = notstd::to_underlying(genericError);
+    auto enumId = notstd::to_underlying(status);
     if (enumId < notstd::to_underlying(UWB_STATUS_ERROR_SESSION_NOT_EXIST)) {
-        return StatusToMapGeneric.at(genericError);
+        return StatusToMapGeneric.at(status);
     }
     if (enumId < notstd::to_underlying(UWB_STATUS_RANGING_TX_FAILED)) {
-        return StatusToMapSession.at(genericError);
+        return StatusToMapSession.at(status);
     }
-    return StatusToMapRanging.at(genericError);
+    return StatusToMapRanging.at(status);
 }
 
 UwbSessionStatus

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -560,34 +560,22 @@ windows::devices::uwb::ddi::lrp::To(const UWB_DEVICE_CAPABILITIES &deviceCapabil
     return uwbCapability;
 }
 
-static const std::unordered_map<UWB_STATUS, UwbStatusGeneric> StatusToMapGeneric{
-    { UWB_STATUS_OK, UwbStatusGeneric::Ok },
-    { UWB_STATUS_REJECTED, UwbStatusGeneric::Rejected },
-    { UWB_STATUS_FAILED, UwbStatusGeneric::Failed },
-    { UWB_STATUS_SYNTAX_ERROR, UwbStatusGeneric::SyntaxError },
-    { UWB_STATUS_INVALID_PARAM, UwbStatusGeneric::InvalidParameter },
-    { UWB_STATUS_INVALID_RANGE, UwbStatusGeneric::InvalidRange },
-    { UWB_STATUS_INVALID_MESSAGE_SIZE, UwbStatusGeneric::InvalidMessageSize },
-    { UWB_STATUS_UNKNOWN_GID, UwbStatusGeneric::UnknownGid },
-    { UWB_STATUS_UNKNOWN_OID, UwbStatusGeneric::UnknownOid },
-    { UWB_STATUS_READ_ONLY, UwbStatusGeneric::ReadOnly },
-    { UWB_STATUS_COMMAND_RETRY, UwbStatusGeneric::CommandRetry },
-};
-static const std::unordered_map<UWB_STATUS, UwbStatusSession> StatusToMapSession{
-    { UWB_STATUS_ERROR_SESSION_NOT_EXIST, UwbStatusSession::NotExist },
-    { UWB_STATUS_ERROR_SESSION_DUPLICATE, UwbStatusSession::Duplicate },
-    { UWB_STATUS_ERROR_SESSION_ACTIVE, UwbStatusSession::Active },
-    { UWB_STATUS_ERROR_MAX_SESSIONS_EXCEEDED, UwbStatusSession::MaxSessionsExceeded },
-    { UWB_STATUS_ERROR_SESSION_NOT_CONFIGURED, UwbStatusSession::NotConfigured },
-    { UWB_STATUS_ERROR_ACTIVE_SESSIONS_ONGOING, UwbStatusSession::ActiveSessionsOngoing },
-    { UWB_STATUS_ERROR_MULTICAST_LIST_FULL, UwbStatusSession::MulticastListFull },
-    { UWB_STATUS_ERROR_ADDRESS_NOT_FOUND, UwbStatusSession::AddressNotFound },
-    { UWB_STATUS_ERROR_ADDRESS_ALREADY_PRESENT, UwbStatusSession::AddressAlreadyPresent },
-};
-
 UwbStatus
 windows::devices::uwb::ddi::lrp::To(const UWB_STATUS &status)
 {
+    static const std::unordered_map<UWB_STATUS, UwbStatusGeneric> StatusToMapGeneric{
+        { UWB_STATUS_OK, UwbStatusGeneric::Ok },
+        { UWB_STATUS_REJECTED, UwbStatusGeneric::Rejected },
+        { UWB_STATUS_FAILED, UwbStatusGeneric::Failed },
+        { UWB_STATUS_SYNTAX_ERROR, UwbStatusGeneric::SyntaxError },
+        { UWB_STATUS_INVALID_PARAM, UwbStatusGeneric::InvalidParameter },
+        { UWB_STATUS_INVALID_RANGE, UwbStatusGeneric::InvalidRange },
+        { UWB_STATUS_INVALID_MESSAGE_SIZE, UwbStatusGeneric::InvalidMessageSize },
+        { UWB_STATUS_UNKNOWN_GID, UwbStatusGeneric::UnknownGid },
+        { UWB_STATUS_UNKNOWN_OID, UwbStatusGeneric::UnknownOid },
+        { UWB_STATUS_READ_ONLY, UwbStatusGeneric::ReadOnly },
+        { UWB_STATUS_COMMAND_RETRY, UwbStatusGeneric::CommandRetry },
+    };
     static const std::unordered_map<UWB_STATUS, UwbStatusRanging> StatusToMapRanging{
         { UWB_STATUS_RANGING_TX_FAILED, UwbStatusRanging::TxFailed },
         { UWB_STATUS_RANGING_RX_TIMEOUT, UwbStatusRanging::RxTimeout },
@@ -597,6 +585,17 @@ windows::devices::uwb::ddi::lrp::To(const UWB_STATUS &status)
         { UWB_STATUS_RANGING_RX_MAC_DEC_FAILED, UwbStatusRanging::MacDecodingFailed },
         { UWB_STATUS_RANGING_RX_MAC_IE_DEC_FAILED, UwbStatusRanging::RxMacIeDecodingFailed },
         { UWB_STATUS_RANGING_RX_MAC_IE_MISSING, UwbStatusRanging::RxMacIeMissing },
+    };
+    static const std::unordered_map<UWB_STATUS, UwbStatusSession> StatusToMapSession{
+        { UWB_STATUS_ERROR_SESSION_NOT_EXIST, UwbStatusSession::NotExist },
+        { UWB_STATUS_ERROR_SESSION_DUPLICATE, UwbStatusSession::Duplicate },
+        { UWB_STATUS_ERROR_SESSION_ACTIVE, UwbStatusSession::Active },
+        { UWB_STATUS_ERROR_MAX_SESSIONS_EXCEEDED, UwbStatusSession::MaxSessionsExceeded },
+        { UWB_STATUS_ERROR_SESSION_NOT_CONFIGURED, UwbStatusSession::NotConfigured },
+        { UWB_STATUS_ERROR_ACTIVE_SESSIONS_ONGOING, UwbStatusSession::ActiveSessionsOngoing },
+        { UWB_STATUS_ERROR_MULTICAST_LIST_FULL, UwbStatusSession::MulticastListFull },
+        { UWB_STATUS_ERROR_ADDRESS_NOT_FOUND, UwbStatusSession::AddressNotFound },
+        { UWB_STATUS_ERROR_ADDRESS_ALREADY_PRESENT, UwbStatusSession::AddressAlreadyPresent },
     };
 
     auto enumId = notstd::to_underlying(status);

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -673,10 +673,10 @@ windows::devices::uwb::ddi::lrp::To(const UWB_MULTICAST_STATUS &statusMulticast)
 UwbMulticastListStatus
 windows::devices::uwb::ddi::lrp::To(const UWB_MULTICAST_LIST_STATUS &multicastListStatus)
 {
-    ::uwb::UwbMacAddress controleeMacAddress{ std::array<uint8_t, ::uwb::UwbMacAddressLength::Short>{ 
+    ::uwb::UwbMacAddress controleeMacAddress{ std::array<uint8_t, ::uwb::UwbMacAddressLength::Short>{
         (multicastListStatus.controleeMacAddress & 0x00FFU) >> 0U,
         (multicastListStatus.controleeMacAddress & 0xFF00U) >> 8U,
-    }};
+    } };
 
     UwbMulticastListStatus uwbMulticastListStatus{
         .ControleeMacAddress = std::move(controleeMacAddress),
@@ -690,10 +690,10 @@ windows::devices::uwb::ddi::lrp::To(const UWB_MULTICAST_LIST_STATUS &multicastLi
 UwbSessionUpdateMulticastListEntry
 windows::devices::uwb::ddi::lrp::To(const UWB_MULTICAST_CONTROLEE_LIST_ENTRY &sessionUpdateMulticastListEntry)
 {
-    ::uwb::UwbMacAddress controleeMacAddress{ std::array<uint8_t, ::uwb::UwbMacAddressLength::Short>{ 
+    ::uwb::UwbMacAddress controleeMacAddress{ std::array<uint8_t, ::uwb::UwbMacAddressLength::Short>{
         (sessionUpdateMulticastListEntry.shortAddress & 0x00FFU) >> 0U,
         (sessionUpdateMulticastListEntry.shortAddress & 0xFF00U) >> 8U,
-    }};
+    } };
 
     UwbSessionUpdateMulticastListEntry uwbSessionUpdateMulticastListEntry{
         .ControleeMacAddress = std::move(controleeMacAddress),

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -148,14 +148,14 @@ UwbSessionUpdateMulicastListWrapper
 windows::devices::uwb::ddi::lrp::From(const UwbSessionUpdateMulicastList &uwbSessionUpdateMulicastList)
 {
     auto sessionUpdateControllerMulticastListWrapper = UwbSessionUpdateMulicastListWrapper::from_num_elements(std::size(uwbSessionUpdateMulicastList.Controlees));
-    UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST& sessionUpdateControllerMulticastList = sessionUpdateControllerMulticastListWrapper;
+    UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST &sessionUpdateControllerMulticastList = sessionUpdateControllerMulticastListWrapper;
     sessionUpdateControllerMulticastList.size = sessionUpdateControllerMulticastListWrapper.size();
     sessionUpdateControllerMulticastList.sessionId = uwbSessionUpdateMulicastList.SessionId;
     sessionUpdateControllerMulticastList.action = From(uwbSessionUpdateMulicastList.Action);
     sessionUpdateControllerMulticastList.numberOfControlees = std::size(uwbSessionUpdateMulicastList.Controlees);
 
     for (auto i = 0; i < std::size(uwbSessionUpdateMulicastList.Controlees); i++) {
-        auto& controlee = sessionUpdateControllerMulticastList.controleeList[i];
+        auto &controlee = sessionUpdateControllerMulticastList.controleeList[i];
         controlee = From(uwbSessionUpdateMulicastList.Controlees[i]);
     }
 
@@ -166,14 +166,14 @@ UwbSessionUpdateMulicastListStatusWrapper
 windows::devices::uwb::ddi::lrp::From(const UwbSessionUpdateMulicastListStatus &uwbSessionUpdateMulicastListStatus)
 {
     auto multicastListStatusWrapper = UwbSessionUpdateMulicastListStatusWrapper::from_num_elements(std::size(uwbSessionUpdateMulicastListStatus.Status));
-    UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF& multicastListStatus = multicastListStatusWrapper;
+    UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF &multicastListStatus = multicastListStatusWrapper;
     multicastListStatus.size = multicastListStatusWrapper.size();
     multicastListStatus.sessionId = uwbSessionUpdateMulicastListStatus.SessionId;
     multicastListStatus.numberOfControlees = std::size(uwbSessionUpdateMulicastListStatus.Status);
     multicastListStatus.remainingMulticastListSize = 0;
 
     for (auto i = 0; i < std::size(uwbSessionUpdateMulicastListStatus.Status); i++) {
-        auto& status = multicastListStatus.statusList[i];
+        auto &status = multicastListStatus.statusList[i];
         status = From(uwbSessionUpdateMulicastListStatus.Status[i]);
     }
 
@@ -315,7 +315,7 @@ windows::devices::uwb::ddi::lrp::From(const UwbDeviceInformation &uwbDeviceInfo)
     }
 
     auto deviceInfoWrapper = UwbDeviceInformationWrapper::from_num_elements(numElements);
-    UWB_DEVICE_INFO& deviceInfo = deviceInfoWrapper;
+    UWB_DEVICE_INFO &deviceInfo = deviceInfoWrapper;
     deviceInfo.size = deviceInfoWrapper.size();
     deviceInfo.status = From(uwbDeviceInfo.Status);
     deviceInfo.uciGenericVersionMajor = uwbDeviceInfo.VersionUci.Major;
@@ -334,14 +334,21 @@ windows::devices::uwb::ddi::lrp::From(const UwbDeviceInformation &uwbDeviceInfo)
     return deviceInfoWrapper;
 }
 
-UWB_DEVICE_CAPABILITIES
+UwbDeviceCapabilitiesWrapper
 windows::devices::uwb::ddi::lrp::From(const UwbCapability &uwbDeviceCapabilities)
 {
-    UWB_DEVICE_CAPABILITIES deviceCapabilities{};
-    deviceCapabilities.size = sizeof deviceCapabilities;
-    deviceCapabilities.capabilityParamsCount = 0;
-    // TODO: implement this properly
-    return deviceCapabilities;
+    std::size_t numElements = 2; // TODO: calculate this from uwbDeviceCapabilities
+    auto deviceCapabilitiesWrapper = UwbDeviceCapabilitiesWrapper::from_num_elements(numElements);
+
+    UWB_DEVICE_CAPABILITIES& deviceCapabilities = deviceCapabilitiesWrapper;
+    deviceCapabilities.size = deviceCapabilitiesWrapper.size();
+    deviceCapabilities.capabilityParamsCount = numElements;
+
+    // TODO: fill in deviceCapabilities.capabilityParams. There is currently no
+    // generic list of capabilities, so, we may have to convert each capability
+    // one-by-one.
+    
+    return deviceCapabilitiesWrapper;
 }
 
 UWB_DEVICE_STATUS
@@ -358,7 +365,7 @@ UwbRangingDataWrapper
 windows::devices::uwb::ddi::lrp::From(const UwbRangingData &uwbRangingData)
 {
     auto rangingDataWrapper = UwbRangingDataWrapper::from_num_elements(std::size(uwbRangingData.RangingMeasurements));
-    UWB_RANGING_DATA& rangingData = rangingDataWrapper;
+    UWB_RANGING_DATA &rangingData = rangingDataWrapper;
     rangingData.size = rangingDataWrapper.size();
     rangingData.sequenceNumber = uwbRangingData.SequenceNumber;
     rangingData.sessionId = uwbRangingData.SessionId;

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -13,6 +13,7 @@
 #include <plog/Log.h>
 #include <wil/common.h>
 
+#include <uwb/UwbMacAddress.hxx>
 #include <uwb/protocols/fira/UwbCapability.hxx>
 #include <windows/devices/uwb/UwbCxAdapterDdiLrp.hxx>
 
@@ -627,7 +628,7 @@ windows::devices::uwb::ddi::lrp::To(const UWB_DEVICE_CONFIG_PARAM_TYPE &deviceCo
 {
     static const std::unordered_map<UWB_DEVICE_CONFIG_PARAM_TYPE, UwbDeviceConfigurationParameterType> ConfigParamMap{
         { UWB_DEVICE_CONFIG_PARAM_TYPE_DEVICE_STATE, UwbDeviceConfigurationParameterType::DeviceState },
-        { UWB_DEVICE_CONFIG_PARAM_TYPE_LOW_POWER_MODE, UwbDeviceConfigurationParameterType::LowPowerMode  },
+        { UWB_DEVICE_CONFIG_PARAM_TYPE_LOW_POWER_MODE, UwbDeviceConfigurationParameterType::LowPowerMode },
     };
 
     return ConfigParamMap.at(deviceConfigurationParameterType);
@@ -667,6 +668,22 @@ windows::devices::uwb::ddi::lrp::To(const UWB_MULTICAST_STATUS &statusMulticast)
     };
 
     return StatusMap.at(statusMulticast);
+}
+
+UwbMulticastListStatus
+windows::devices::uwb::ddi::lrp::To(const UWB_MULTICAST_LIST_STATUS &multicastListStatus)
+{
+    ::uwb::UwbMacAddress controleeMacAddress{ std::array<uint8_t, ::uwb::UwbMacAddressLength::Short>{ 
+        (multicastListStatus.controleeMacAddress & 0x00FFU) >> 0U,
+        (multicastListStatus.controleeMacAddress & 0xFF00U) >> 8U,
+    }};
+
+    UwbMulticastListStatus uwbMulticastListStatus{};
+    uwbMulticastListStatus.ControleeMacAddress = std::move(controleeMacAddress);
+    uwbMulticastListStatus.SubSessionId = multicastListStatus.subSessionId;
+    uwbMulticastListStatus.Status = To(multicastListStatus.status);
+
+    return uwbMulticastListStatus;
 }
 
 UwbSessionState
@@ -725,7 +742,7 @@ windows::devices::uwb::ddi::lrp::To(const UWB_APP_CONFIG_PARAM_TYPE &appConfigPa
         { UWB_APP_CONFIG_PARAM_TYPE_SLOT_DURATION, UwbApplicationConfigurationParameterType::SlotDuration },
         { UWB_APP_CONFIG_PARAM_TYPE_RANGING_INTERVAL, UwbApplicationConfigurationParameterType::RangingInterval },
         { UWB_APP_CONFIG_PARAM_TYPE_STS_INDEX, UwbApplicationConfigurationParameterType::StsIndex },
-        { UWB_APP_CONFIG_PARAM_TYPE_MAC_FCS_TYPE, UwbApplicationConfigurationParameterType::MacFcsType,  },
+        { UWB_APP_CONFIG_PARAM_TYPE_MAC_FCS_TYPE, UwbApplicationConfigurationParameterType::MacFcsType },
         { UWB_APP_CONFIG_PARAM_TYPE_RANGING_ROUND_CONTROL, UwbApplicationConfigurationParameterType::RangingRoundControl },
         { UWB_APP_CONFIG_PARAM_TYPE_AOA_RESULT_REQ, UwbApplicationConfigurationParameterType::AoAResultRequest },
         { UWB_APP_CONFIG_PARAM_TYPE_RANGE_DATA_NTF_CONFIG, UwbApplicationConfigurationParameterType::RangeDataNotificationConfig },

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -708,7 +708,7 @@ windows::devices::uwb::ddi::lrp::To(const UWB_SESSION_UPDATE_CONTROLLER_MULTICAS
 {
     std::vector<UwbSessionUpdateMulticastListEntry> controlees{};
     for (std::size_t i = 0; i < sessionUpdateMulicastList.numberOfControlees; i++) {
-        const auto& multicastControleeListEntry = sessionUpdateMulicastList.controleeList[i];
+        const auto &multicastControleeListEntry = sessionUpdateMulicastList.controleeList[i];
         controlees.push_back(To(multicastControleeListEntry));
     }
 
@@ -717,6 +717,7 @@ windows::devices::uwb::ddi::lrp::To(const UWB_SESSION_UPDATE_CONTROLLER_MULTICAS
         .Action = To(sessionUpdateMulicastList.action),
         .Controlees = std::move(controlees)
     };
+
     return uwbSessionUpdateMulicastList;
 }
 
@@ -736,9 +737,9 @@ windows::devices::uwb::ddi::lrp::To(const UWB_SESSION_STATE &sessionState)
 UwbSessionUpdateMulicastListStatus
 windows::devices::uwb::ddi::lrp::To(const UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF &sessionUpdateControllerMulticastListNtf)
 {
-    std::vector<UwbMulticastListStatus> status{}; 
+    std::vector<UwbMulticastListStatus> status{};
     for (std::size_t i = 0; i < sessionUpdateControllerMulticastListNtf.numberOfControlees; i++) {
-        const auto& multicastListStatus = sessionUpdateControllerMulticastListNtf.statusList[i];
+        const auto &multicastListStatus = sessionUpdateControllerMulticastListNtf.statusList[i];
         status.push_back(To(multicastListStatus));
     }
 

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -703,6 +703,23 @@ windows::devices::uwb::ddi::lrp::To(const UWB_MULTICAST_CONTROLEE_LIST_ENTRY &se
     return uwbSessionUpdateMulticastListEntry;
 }
 
+UwbSessionUpdateMulicastList
+windows::devices::uwb::ddi::lrp::To(const UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST &sessionUpdateMulicastList)
+{
+    std::vector<UwbSessionUpdateMulticastListEntry> controlees{};
+    for (std::size_t i = 0; i < sessionUpdateMulicastList.numberOfControlees; i++) {
+        const auto& multicastControleeListEntry = sessionUpdateMulicastList.controleeList[i];
+        controlees.push_back(To(multicastControleeListEntry));
+    }
+
+    UwbSessionUpdateMulicastList uwbSessionUpdateMulicastList{
+        .SessionId = sessionUpdateMulicastList.sessionId,
+        .Action = To(sessionUpdateMulicastList.action),
+        .Controlees = std::move(controlees)
+    };
+    return uwbSessionUpdateMulicastList;
+}
+
 UwbSessionState
 windows::devices::uwb::ddi::lrp::To(const UWB_SESSION_STATE &sessionState)
 {
@@ -714,6 +731,23 @@ windows::devices::uwb::ddi::lrp::To(const UWB_SESSION_STATE &sessionState)
     };
 
     return SessionStateToMap.at(sessionState);
+}
+
+UwbSessionUpdateMulicastListStatus
+windows::devices::uwb::ddi::lrp::To(const UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF &sessionUpdateControllerMulticastListNtf)
+{
+    std::vector<UwbMulticastListStatus> status{}; 
+    for (std::size_t i = 0; i < sessionUpdateControllerMulticastListNtf.numberOfControlees; i++) {
+        const auto& multicastListStatus = sessionUpdateControllerMulticastListNtf.statusList[i];
+        status.push_back(To(multicastListStatus));
+    }
+
+    UwbSessionUpdateMulicastListStatus uwbSessionUpdateMulicastListStatus{
+        .SessionId = sessionUpdateControllerMulticastListNtf.sessionId,
+        .Status = std::move(status)
+    };
+
+    return uwbSessionUpdateMulicastListStatus;
 }
 
 UwbRangingMeasurementType

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -646,6 +646,19 @@ windows::devices::uwb::ddi::lrp::To(const UWB_MULTICAST_ACTION &multicastAction)
     return ActionMap.at(multicastAction);
 }
 
+UwbStatusMulticast
+windows::devices::uwb::ddi::lrp::To(const UWB_MULTICAST_STATUS &statusMulticast)
+{
+    static const std::unordered_map<UWB_MULTICAST_STATUS, UwbStatusMulticast> StatusMap{
+        { UWB_MULTICAST_STATUS_OK_MULTICAST_LIST_UPDATE, UwbStatusMulticast::OkUpdate },
+        { UWB_MULTICAST_STATUS_ERROR_MULTICAST_LIST_FULL, UwbStatusMulticast::ErrorListFull },
+        { UWB_MULTICAST_STATUS_ERROR_KEY_FETCH_FAIL, UwbStatusMulticast::ErrorKeyFetchFail },
+        { UWB_MULTICAST_STATUS_ERROR_SUB_SESSION_ID_NOT_FOUND, UwbStatusMulticast::ErrorSubSessionIdNotFound },
+    };
+
+    return StatusMap.at(statusMulticast);
+}
+
 UwbSessionState
 windows::devices::uwb::ddi::lrp::To(const UWB_SESSION_STATE &sessionState)
 {

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -678,12 +678,29 @@ windows::devices::uwb::ddi::lrp::To(const UWB_MULTICAST_LIST_STATUS &multicastLi
         (multicastListStatus.controleeMacAddress & 0xFF00U) >> 8U,
     }};
 
-    UwbMulticastListStatus uwbMulticastListStatus{};
-    uwbMulticastListStatus.ControleeMacAddress = std::move(controleeMacAddress);
-    uwbMulticastListStatus.SubSessionId = multicastListStatus.subSessionId;
-    uwbMulticastListStatus.Status = To(multicastListStatus.status);
+    UwbMulticastListStatus uwbMulticastListStatus{
+        .ControleeMacAddress = std::move(controleeMacAddress),
+        .SubSessionId = multicastListStatus.subSessionId,
+        .Status = To(multicastListStatus.status)
+    };
 
     return uwbMulticastListStatus;
+}
+
+UwbSessionUpdateMulticastListEntry
+windows::devices::uwb::ddi::lrp::To(const UWB_MULTICAST_CONTROLEE_LIST_ENTRY &sessionUpdateMulticastListEntry)
+{
+    ::uwb::UwbMacAddress controleeMacAddress{ std::array<uint8_t, ::uwb::UwbMacAddressLength::Short>{ 
+        (sessionUpdateMulticastListEntry.shortAddress & 0x00FFU) >> 0U,
+        (sessionUpdateMulticastListEntry.shortAddress & 0xFF00U) >> 8U,
+    }};
+
+    UwbSessionUpdateMulticastListEntry uwbSessionUpdateMulticastListEntry{
+        .ControleeMacAddress = std::move(controleeMacAddress),
+        .SubSessionId = sessionUpdateMulticastListEntry.subSessionId
+    };
+
+    return uwbSessionUpdateMulticastListEntry;
 }
 
 UwbSessionState

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -622,6 +622,17 @@ windows::devices::uwb::ddi::lrp::To(const UWB_DEVICE_STATUS &deviceStatus)
     };
 }
 
+UwbDeviceConfigurationParameterType
+windows::devices::uwb::ddi::lrp::To(const UWB_DEVICE_CONFIG_PARAM_TYPE &deviceConfigurationParameterType)
+{
+    static const std::unordered_map<UWB_DEVICE_CONFIG_PARAM_TYPE, UwbDeviceConfigurationParameterType> ConfigParamMap{
+        { UWB_DEVICE_CONFIG_PARAM_TYPE_DEVICE_STATE, UwbDeviceConfigurationParameterType::DeviceState },
+        { UWB_DEVICE_CONFIG_PARAM_TYPE_LOW_POWER_MODE, UwbDeviceConfigurationParameterType::LowPowerMode  },
+    };
+
+    return ConfigParamMap.at(deviceConfigurationParameterType);
+}
+
 UwbDeviceState
 windows::devices::uwb::ddi::lrp::To(const UWB_DEVICE_STATE &deviceState)
 {

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -249,6 +249,15 @@ To(const UWB_DEVICE_STATE &deviceState);
 To(const UWB_MULTICAST_ACTION &multicastAction);
 
 /**
+ * @brief Converts UWB_MULTICAST_STATUS to UwbStatusMulticast.
+ * 
+ * @param statusMulticast 
+ * @return ::uwb::protocol::fira::UwbStatusMulticast 
+ */
+::uwb::protocol::fira::UwbStatusMulticast
+To(const UWB_MULTICAST_STATUS &statusMulticast);
+
+/**
  * @brief Converts UWB_SESSION_STATE to UwbSessionState.
  *
  * @param sessionState

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -250,9 +250,9 @@ To(const UWB_MULTICAST_ACTION &multicastAction);
 
 /**
  * @brief Converts UWB_MULTICAST_STATUS to UwbStatusMulticast.
- * 
- * @param statusMulticast 
- * @return ::uwb::protocol::fira::UwbStatusMulticast 
+ *
+ * @param statusMulticast
+ * @return ::uwb::protocol::fira::UwbStatusMulticast
  */
 ::uwb::protocol::fira::UwbStatusMulticast
 To(const UWB_MULTICAST_STATUS &statusMulticast);
@@ -275,6 +275,15 @@ To(const UWB_SESSION_STATE &sessionState);
 To(const UWB_SESSION_STATUS &sessionStatus);
 
 /**
+ * @brief Converts UWB_RANGING_MEASUREMENT_TYPE to UwbRangingMeasurementType.
+ *
+ * @param rangingMeasurementType
+ * @return ::uwb::protocol::fira::UwbRangingMeasurementType
+ */
+::uwb::protocol::fira::UwbRangingMeasurementType
+To(const UWB_RANGING_MEASUREMENT_TYPE &rangingMeasurementType);
+
+/**
  * @brief Converts UWB_SESSION_REASON_CODE to UwbSessionReasonCode.
  *
  * @param sessionReasonCode
@@ -282,6 +291,15 @@ To(const UWB_SESSION_STATUS &sessionStatus);
  */
 ::uwb::protocol::fira::UwbSessionReasonCode
 To(const UWB_SESSION_REASON_CODE &sessionReasonCode);
+
+/**
+ * @brief Converts UWB_APP_CONFIG_PARAM_TYPE to UwbApplicationConfigurationParameterType.
+ *
+ * @param appConfigParameterType
+ * @return ::uwb::protocol::fira::UwbApplicationConfigurationParameterType
+ */
+::uwb::protocol::fira::UwbApplicationConfigurationParameterType
+To(const UWB_APP_CONFIG_PARAM_TYPE &appConfigParameterType);
 
 /**
  * @brief Converts UWB_NOTIFICATION_DATA to UwbNotificationData.

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -154,13 +154,15 @@ using UwbDeviceInformationWrapper = notstd::flextype_wrapper<UWB_DEVICE_INFO, st
 UwbDeviceInformationWrapper
 From(const ::uwb::protocol::fira::UwbDeviceInformation &uwbDeviceInfo);
 
+using UwbDeviceCapabilitiesWrapper = notstd::flextype_wrapper<UWB_DEVICE_CAPABILITIES, std::remove_extent<decltype(UWB_DEVICE_CAPABILITIES::capabilityParams)>>;
+
 /**
  * @brief Converts UwbCapability to UWB_DEVICE_CAPABILITIES.
  *
  * @param uwbDeviceCapabilities
- * @return UWB_DEVICE_CAPABILITIES
+ * @return UwbDeviceCapabilitiesWrapper
  */
-UWB_DEVICE_CAPABILITIES
+UwbDeviceCapabilitiesWrapper
 From(const ::uwb::protocol::fira::UwbCapability &uwbDeviceCapabilities);
 
 /**

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -223,9 +223,9 @@ To(const UWB_DEVICE_STATUS &deviceStatus);
 
 /**
  * @brief Converts UWB_DEVICE_CONFIG_PARAM_TYPE to UwbDeviceConfigurationParameterType.
- * 
- * @param deviceConfigurationParameterType 
- * @return ::uwb::protocol::fira::UwbDeviceConfigurationParameterType 
+ *
+ * @param deviceConfigurationParameterType
+ * @return ::uwb::protocol::fira::UwbDeviceConfigurationParameterType
  */
 ::uwb::protocol::fira::UwbDeviceConfigurationParameterType
 To(const UWB_DEVICE_CONFIG_PARAM_TYPE &deviceConfigurationParameterType);
@@ -268,18 +268,18 @@ To(const UWB_MULTICAST_STATUS &statusMulticast);
 
 /**
  * @brief Converts UWB_MULTICAST_LIST_STATUS to UwbMulticastListStatus.
- * 
- * @param multicastListStatus 
- * @return ::uwb::protocol::fira::UwbMulticastListStatus 
+ *
+ * @param multicastListStatus
+ * @return ::uwb::protocol::fira::UwbMulticastListStatus
  */
 ::uwb::protocol::fira::UwbMulticastListStatus
 To(const UWB_MULTICAST_LIST_STATUS &multicastListStatus);
 
 /**
  * @brief Converts UWB_MULTICAST_CONTROLEE_LIST_ENTRY to UwbSessionUpdateMulticastListEntry.
- * 
- * @param sessionUpdateMulticastListEntry 
- * @return ::uwb::protocol::fira::UwbSessionUpdateMulticastListEntry 
+ *
+ * @param sessionUpdateMulticastListEntry
+ * @return ::uwb::protocol::fira::UwbSessionUpdateMulticastListEntry
  */
 ::uwb::protocol::fira::UwbSessionUpdateMulticastListEntry
 To(const UWB_MULTICAST_CONTROLEE_LIST_ENTRY &sessionUpdateMulticastListEntry);

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -286,9 +286,9 @@ To(const UWB_MULTICAST_CONTROLEE_LIST_ENTRY &sessionUpdateMulticastListEntry);
 
 /**
  * @brief Converts UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST to UwbSessionUpdateMulicastList.
- * 
- * @param sessionUpdateMulicastList 
- * @return ::uwb::protocol::fira::UwbSessionUpdateMulicastList 
+ *
+ * @param sessionUpdateMulicastList
+ * @return ::uwb::protocol::fira::UwbSessionUpdateMulicastList
  */
 ::uwb::protocol::fira::UwbSessionUpdateMulicastList
 To(const UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST &sessionUpdateMulicastList);
@@ -312,9 +312,9 @@ To(const UWB_SESSION_STATUS &sessionStatus);
 
 /**
  * @brief Converts UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF to UwbSessionUpdateMulicastListStatus.
- * 
- * @param sessionUpdateControllerMulticastListNtf 
- * @return ::uwb::protocol::fira::UwbSessionUpdateMulicastListStatus 
+ *
+ * @param sessionUpdateControllerMulticastListNtf
+ * @return ::uwb::protocol::fira::UwbSessionUpdateMulicastListStatus
  */
 ::uwb::protocol::fira::UwbSessionUpdateMulicastListStatus
 To(const UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF &sessionUpdateControllerMulticastListNtf);

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -276,6 +276,15 @@ To(const UWB_MULTICAST_STATUS &statusMulticast);
 To(const UWB_MULTICAST_LIST_STATUS &multicastListStatus);
 
 /**
+ * @brief Converts UWB_MULTICAST_CONTROLEE_LIST_ENTRY to UwbSessionUpdateMulticastListEntry.
+ * 
+ * @param sessionUpdateMulticastListEntry 
+ * @return ::uwb::protocol::fira::UwbSessionUpdateMulticastListEntry 
+ */
+::uwb::protocol::fira::UwbSessionUpdateMulticastListEntry
+To(const UWB_MULTICAST_CONTROLEE_LIST_ENTRY &sessionUpdateMulticastListEntry);
+
+/**
  * @brief Converts UWB_SESSION_STATE to UwbSessionState.
  *
  * @param sessionState

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -222,6 +222,15 @@ To(const UWB_DEVICE_CAPABILITIES &deviceCapabilities);
 To(const UWB_DEVICE_STATUS &deviceStatus);
 
 /**
+ * @brief Converts UWB_DEVICE_CONFIG_PARAM_TYPE to UwbDeviceConfigurationParameterType.
+ * 
+ * @param deviceConfigurationParameterType 
+ * @return ::uwb::protocol::fira::UwbDeviceConfigurationParameterType 
+ */
+::uwb::protocol::fira::UwbDeviceConfigurationParameterType
+To(const UWB_DEVICE_CONFIG_PARAM_TYPE &deviceConfigurationParameterType);
+
+/**
  * @brief Converts UWB_STATUS to UwbStatus.
  *
  * @param status

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -267,6 +267,15 @@ To(const UWB_MULTICAST_ACTION &multicastAction);
 To(const UWB_MULTICAST_STATUS &statusMulticast);
 
 /**
+ * @brief Converts UWB_MULTICAST_LIST_STATUS to UwbMulticastListStatus.
+ * 
+ * @param multicastListStatus 
+ * @return ::uwb::protocol::fira::UwbMulticastListStatus 
+ */
+::uwb::protocol::fira::UwbMulticastListStatus
+To(const UWB_MULTICAST_LIST_STATUS &multicastListStatus);
+
+/**
  * @brief Converts UWB_SESSION_STATE to UwbSessionState.
  *
  * @param sessionState

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -285,6 +285,15 @@ To(const UWB_MULTICAST_LIST_STATUS &multicastListStatus);
 To(const UWB_MULTICAST_CONTROLEE_LIST_ENTRY &sessionUpdateMulticastListEntry);
 
 /**
+ * @brief Converts UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST to UwbSessionUpdateMulicastList.
+ * 
+ * @param sessionUpdateMulicastList 
+ * @return ::uwb::protocol::fira::UwbSessionUpdateMulicastList 
+ */
+::uwb::protocol::fira::UwbSessionUpdateMulicastList
+To(const UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST &sessionUpdateMulicastList);
+
+/**
  * @brief Converts UWB_SESSION_STATE to UwbSessionState.
  *
  * @param sessionState
@@ -300,6 +309,15 @@ To(const UWB_SESSION_STATE &sessionState);
  */
 ::uwb::protocol::fira::UwbSessionStatus
 To(const UWB_SESSION_STATUS &sessionStatus);
+
+/**
+ * @brief Converts UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF to UwbSessionUpdateMulicastListStatus.
+ * 
+ * @param sessionUpdateControllerMulticastListNtf 
+ * @return ::uwb::protocol::fira::UwbSessionUpdateMulicastListStatus 
+ */
+::uwb::protocol::fira::UwbSessionUpdateMulicastListStatus
+To(const UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF &sessionUpdateControllerMulticastListNtf);
 
 /**
  * @brief Converts UWB_RANGING_MEASUREMENT_TYPE to UwbRangingMeasurementType.


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Allow additional DDI types to be converted to their neutral equivalents.

### Technical Details

* Add stability tests for existing neutral <-> ddi conversion functions.
* Add conversion functions for various types, including all the multicast related types.
* Add default spaceship operator to most neutral types that need it for equality comparisons.

### Test Results

* All unit tests pass on both Linux and Windows.

### Reviewer Focus

None

### Future Work

* Additional tests need to be written to validate correctness of conversion functions. The stability tests, while good, aren't sufficient since the `To/From` functions could introduce an error, then fix the error.
* Conversion functions are still needed for some DDI types.
* Conversion functions involving maps need to have the map data de-duplicated.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
