### PR TITLE
Fix flextype_wrapper element type specification for DDI wrappers

### DIFF
--- a/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
+++ b/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
@@ -53,7 +53,7 @@ template <
     typename ValueT,
     typename FlexElementT,
     flex_array_type FlexElementAdjuster = flex_array_type::anysize>
-    requires (std::is_standard_layout_v<ValueT> && !std::is_array_v<FlexElementT>)
+    requires (std::is_standard_layout_v<ValueT> && std::is_array_v<FlexElementT>)
 struct flextype_wrapper
 {
     using value_type = ValueT;

--- a/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
+++ b/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
@@ -253,6 +253,7 @@ private:
         m_data(reinterpret_cast<uint8_t*>(&m_value), total_size)
     {
         assert(reinterpret_cast<uintptr_t>(&m_value) % alignof(decltype(m_value)) == 0);
+        m_value = value_type{};
     }
 
 private:

--- a/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
+++ b/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
@@ -156,7 +156,9 @@ struct flextype_wrapper
      */
     explicit flextype_wrapper(std::size_t total_size) :
         flextype_wrapper(std::vector<std::uint8_t>(alignof(value_type) + total_size), total_size)
-    {}
+    {
+        m_value = {};
+    }
 
     /**
      * @brief Construct a new flextype_wrapper object copy.
@@ -253,7 +255,6 @@ private:
         m_data(reinterpret_cast<uint8_t*>(&m_value), total_size)
     {
         assert(reinterpret_cast<uintptr_t>(&m_value) % alignof(decltype(m_value)) == 0);
-        m_value = value_type{};
     }
 
 private:

--- a/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
+++ b/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
@@ -53,7 +53,7 @@ template <
     typename ValueT,
     typename FlexElementT,
     flex_array_type FlexElementAdjuster = flex_array_type::anysize>
-    requires (std::is_standard_layout_v<ValueT> && std::is_array_v<FlexElementT>)
+    requires std::is_standard_layout_v<ValueT>
 struct flextype_wrapper
 {
     using value_type = ValueT;

--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -129,7 +129,7 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
                 .Controlees = controlees
             };
 
-            // test::ValidateRoundtrip(uwbSessionUpdateMulicastList);
+            test::ValidateRoundtrip(uwbSessionUpdateMulicastList);
         }
     }
 
@@ -148,7 +148,7 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
             .Status = std::move(uwbMulticastListStatus)
         };
 
-        // test::ValidateRoundtrip(uwbSessionUpdateMulicastListStatus);
+        test::ValidateRoundtrip(uwbSessionUpdateMulicastListStatus);
     }
 
     SECTION("UwbRangingMeasurementType is stable")

--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -89,7 +89,7 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
     SECTION("UwbMulticastListStatus is stable")
     {
         for (const auto& uwbStatusMulticast : magic_enum::enum_values<UwbStatusMulticast>()) {
-            UwbMulticastListStatus uwbMulticastListStatus{
+            const UwbMulticastListStatus uwbMulticastListStatus{
                 .ControleeMacAddress = ::uwb::UwbMacAddress::Random<::uwb::UwbMacAddressType::Short>(),
                 .SubSessionId = RandomDistribution(RandomEngine),
                 .Status = uwbStatusMulticast
@@ -113,16 +113,13 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
         const std::vector<UwbSessionUpdateMulticastListEntry> controlees{
             UwbSessionUpdateMulticastListEntry{
                 .ControleeMacAddress = ::uwb::UwbMacAddress::Random<::uwb::UwbMacAddressType::Short>(),
-                .SubSessionId = RandomDistribution(RandomEngine)
-            },
+                .SubSessionId = RandomDistribution(RandomEngine) },
             UwbSessionUpdateMulticastListEntry{
                 .ControleeMacAddress = ::uwb::UwbMacAddress::Random<::uwb::UwbMacAddressType::Short>(),
-                .SubSessionId = RandomDistribution(RandomEngine)
-            },
+                .SubSessionId = RandomDistribution(RandomEngine) },
             UwbSessionUpdateMulticastListEntry{
                 .ControleeMacAddress = ::uwb::UwbMacAddress::Random<::uwb::UwbMacAddressType::Short>(),
-                .SubSessionId = RandomDistribution(RandomEngine)
-            }
+                .SubSessionId = RandomDistribution(RandomEngine) }
         };
 
         for (const auto& uwbMulticastAction : magic_enum::enum_values<UwbMulticastAction>()) {
@@ -143,8 +140,7 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
             uwbMulticastListStatus.push_back(UwbMulticastListStatus{
                 .ControleeMacAddress = uwb::UwbMacAddress::Random<uwb::UwbMacAddressType::Short>(),
                 .SubSessionId = RandomDistribution(RandomEngine),
-                .Status = uwbStatusMulticast
-            });
+                .Status = uwbStatusMulticast });
         }
 
         const UwbSessionUpdateMulicastListStatus uwbSessionUpdateMulicastListStatus{

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -152,7 +152,7 @@ windows::devices::uwb::ddi::lrp::From(const UwbSessionUpdateMulicastList &uwbSes
     sessionUpdateControllerMulticastList.size = sessionUpdateControllerMulticastListWrapper.size();
     sessionUpdateControllerMulticastList.sessionId = uwbSessionUpdateMulicastList.SessionId;
     sessionUpdateControllerMulticastList.action = From(uwbSessionUpdateMulicastList.Action);
-    sessionUpdateControllerMulticastList.numberOfControlees = 0; /* FIXME: std::size(uwbSessionUpdateMulicastList.Controlees) */
+    sessionUpdateControllerMulticastList.numberOfControlees = std::size(uwbSessionUpdateMulicastList.Controlees);
 
     for (auto i = 0; i < sessionUpdateControllerMulticastList.numberOfControlees; i++) {
         auto &controlee = sessionUpdateControllerMulticastList.controleeList[i];
@@ -169,7 +169,7 @@ windows::devices::uwb::ddi::lrp::From(const UwbSessionUpdateMulicastListStatus &
     UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF &multicastListStatus = multicastListStatusWrapper;
     multicastListStatus.size = multicastListStatusWrapper.size();
     multicastListStatus.sessionId = uwbSessionUpdateMulicastListStatus.SessionId;
-    multicastListStatus.numberOfControlees = 0; /* FIXME: std::size(uwbSessionUpdateMulicastListStatus.Status); */
+    multicastListStatus.numberOfControlees = std::size(uwbSessionUpdateMulicastListStatus.Status);
     multicastListStatus.remainingMulticastListSize = 0;
 
     for (auto i = 0; i < multicastListStatus.numberOfControlees; i++) {

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -152,9 +152,9 @@ windows::devices::uwb::ddi::lrp::From(const UwbSessionUpdateMulicastList &uwbSes
     sessionUpdateControllerMulticastList.size = sessionUpdateControllerMulticastListWrapper.size();
     sessionUpdateControllerMulticastList.sessionId = uwbSessionUpdateMulicastList.SessionId;
     sessionUpdateControllerMulticastList.action = From(uwbSessionUpdateMulicastList.Action);
-    sessionUpdateControllerMulticastList.numberOfControlees = std::size(uwbSessionUpdateMulicastList.Controlees);
+    sessionUpdateControllerMulticastList.numberOfControlees = 0; /* FIXME: std::size(uwbSessionUpdateMulicastList.Controlees) */
 
-    for (auto i = 0; i < std::size(uwbSessionUpdateMulicastList.Controlees); i++) {
+    for (auto i = 0; i < sessionUpdateControllerMulticastList.numberOfControlees; i++) {
         auto &controlee = sessionUpdateControllerMulticastList.controleeList[i];
         controlee = From(uwbSessionUpdateMulicastList.Controlees[i]);
     }
@@ -169,10 +169,10 @@ windows::devices::uwb::ddi::lrp::From(const UwbSessionUpdateMulicastListStatus &
     UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF &multicastListStatus = multicastListStatusWrapper;
     multicastListStatus.size = multicastListStatusWrapper.size();
     multicastListStatus.sessionId = uwbSessionUpdateMulicastListStatus.SessionId;
-    multicastListStatus.numberOfControlees = std::size(uwbSessionUpdateMulicastListStatus.Status);
+    multicastListStatus.numberOfControlees = 0; /* FIXME: std::size(uwbSessionUpdateMulicastListStatus.Status); */
     multicastListStatus.remainingMulticastListSize = 0;
 
-    for (auto i = 0; i < std::size(uwbSessionUpdateMulicastListStatus.Status); i++) {
+    for (auto i = 0; i < multicastListStatus.numberOfControlees; i++) {
         auto &status = multicastListStatus.statusList[i];
         status = From(uwbSessionUpdateMulicastListStatus.Status[i]);
     }

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -183,6 +183,15 @@ From(const ::uwb::protocol::fira::UwbStatusDevice &uwbStatusDevice);
 UWB_DEVICE_CONFIG_PARAM_TYPE
 From(const ::uwb::protocol::fira::UwbDeviceConfigurationParameterType &uwbDeviceConfigurationParameterType);
 
+/**
+ * @brief Converts UwbRangingMeasurement to UWB_RANGING_MEASUREMENT.
+ *
+ * @param uwbRangingMeasurement 
+ * @return UWB_RANGING_MEASUREMENT 
+ */
+UWB_RANGING_MEASUREMENT
+From(const ::uwb::protocol::fira::UwbRangingMeasurement &uwbRangingMeasurement);
+
 using UwbRangingDataWrapper = notstd::flextype_wrapper<UWB_RANGING_DATA, std::remove_extent<decltype(UWB_RANGING_DATA::rangingMeasurements)>>;
 
 /**
@@ -345,6 +354,24 @@ To(const UWB_SESSION_REASON_CODE &sessionReasonCode);
  */
 ::uwb::protocol::fira::UwbApplicationConfigurationParameterType
 To(const UWB_APP_CONFIG_PARAM_TYPE &appConfigParameterType);
+
+/**
+ * @brief Converts UWB_RANGING_MEASUREMENT to UwbRangingMeasurement.
+ * 
+ * @param rangingMeasurement 
+ * @return ::uwb::protocol::fira::UwbRangingMeasurement 
+ */
+::uwb::protocol::fira::UwbRangingMeasurement
+To(const UWB_RANGING_MEASUREMENT &rangingMeasurement);
+
+/**
+ * @brief Converts UWB_RANGING_DATA to UwbRangingData.
+ * 
+ * @param rangingData 
+ * @return ::uwb::protocol::fira::UwbRangingData 
+ */
+::uwb::protocol::fira::UwbRangingData
+To(const UWB_RANGING_DATA &rangingData);
 
 /**
  * @brief Converts UWB_NOTIFICATION_DATA to UwbNotificationData.

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -76,7 +76,7 @@ From(const ::uwb::protocol::fira::UwbMulticastListStatus &uwbStatusMulticastList
 UWB_MULTICAST_CONTROLEE_LIST_ENTRY
 From(const ::uwb::protocol::fira::UwbSessionUpdateMulticastListEntry &uwbSessionUpdateMulticastListEntry);
 
-using UwbSessionUpdateMulicastListWrapper = notstd::flextype_wrapper<UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST, std::remove_extent<decltype(UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST::controleeList)>>;
+using UwbSessionUpdateMulicastListWrapper = notstd::flextype_wrapper<UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST, decltype(UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST::controleeList)>;
 
 /**
  * @brief Converts UwbSessionUpdateMulicastList to UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST.
@@ -87,7 +87,7 @@ using UwbSessionUpdateMulicastListWrapper = notstd::flextype_wrapper<UWB_SESSION
 UwbSessionUpdateMulicastListWrapper
 From(const ::uwb::protocol::fira::UwbSessionUpdateMulicastList &uwbSessionUpdateMulicastList);
 
-using UwbSessionUpdateMulicastListStatusWrapper = notstd::flextype_wrapper<UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF, std::remove_extent<decltype(UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF::statusList)>>;
+using UwbSessionUpdateMulicastListStatusWrapper = notstd::flextype_wrapper<UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF, decltype(UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF::statusList)>;
 
 /**
  * @brief Converts UwbSessionUpdateMulicastListStatus to UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF.
@@ -143,7 +143,7 @@ From(const ::uwb::protocol::fira::UwbSessionState uwbSessionState);
 UWB_SESSION_STATUS
 From(const ::uwb::protocol::fira::UwbSessionStatus &uwbSessionStatus);
 
-using UwbDeviceInformationWrapper = notstd::flextype_wrapper<UWB_DEVICE_INFO, std::remove_extent<decltype(UWB_DEVICE_INFO::vendorSpecificInfo)>>;
+using UwbDeviceInformationWrapper = notstd::flextype_wrapper<UWB_DEVICE_INFO, decltype(UWB_DEVICE_INFO::vendorSpecificInfo)>;
 
 /**
  * @brief Converts UwbDeviceInformation to UWB_DEVICE_INFO.
@@ -154,7 +154,7 @@ using UwbDeviceInformationWrapper = notstd::flextype_wrapper<UWB_DEVICE_INFO, st
 UwbDeviceInformationWrapper
 From(const ::uwb::protocol::fira::UwbDeviceInformation &uwbDeviceInfo);
 
-using UwbDeviceCapabilitiesWrapper = notstd::flextype_wrapper<UWB_DEVICE_CAPABILITIES, std::remove_extent<decltype(UWB_DEVICE_CAPABILITIES::capabilityParams)>>;
+using UwbDeviceCapabilitiesWrapper = notstd::flextype_wrapper<UWB_DEVICE_CAPABILITIES, decltype(UWB_DEVICE_CAPABILITIES::capabilityParams)>;
 
 /**
  * @brief Converts UwbCapability to UWB_DEVICE_CAPABILITIES.
@@ -183,16 +183,7 @@ From(const ::uwb::protocol::fira::UwbStatusDevice &uwbStatusDevice);
 UWB_DEVICE_CONFIG_PARAM_TYPE
 From(const ::uwb::protocol::fira::UwbDeviceConfigurationParameterType &uwbDeviceConfigurationParameterType);
 
-/**
- * @brief Converts UwbRangingMeasurement to UWB_RANGING_MEASUREMENT.
- *
- * @param uwbRangingMeasurement 
- * @return UWB_RANGING_MEASUREMENT 
- */
-UWB_RANGING_MEASUREMENT
-From(const ::uwb::protocol::fira::UwbRangingMeasurement &uwbRangingMeasurement);
-
-using UwbRangingDataWrapper = notstd::flextype_wrapper<UWB_RANGING_DATA, std::remove_extent<decltype(UWB_RANGING_DATA::rangingMeasurements)>>;
+using UwbRangingDataWrapper = notstd::flextype_wrapper<UWB_RANGING_DATA, decltype(UWB_RANGING_DATA::rangingMeasurements)>;
 
 /**
  * @brief Converts UwbRangingData to UWB_RANGING_DATA.


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Ensure memory is not accessed in an invalid manner.

### Technical Details

* Update the DDI wrapper types not to remove their array extent type, since this was causing the wrong type to be resolved which was size `1` instead of the actual size of the array element. This caused a smaller buffer than required to be allocated, resulting in heap corruption when the flex-array elements were written.

### Test Results

* All unit tests pass on both Linux and Windows.

### Reviewer Focus

None

### Future Work

* The constraint on `flextype_wrapper::FlexElementT` currently requires an array, however, it doesn't really make sense since we want the size of the array _element_. In practice it is working, however, we should investigate whether the constraint can be tightened or made easier to understand.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
