### PR TITLE
On session multicast list status

### DIFF
--- a/lib/uwb/UwbDevice.cxx
+++ b/lib/uwb/UwbDevice.cxx
@@ -86,7 +86,6 @@ UwbDevice::OnSessionMulticastListStatus(UwbSessionUpdateMulicastListStatus statu
 
     for (const auto& peerAddStatus : statusMulticastList.Status) {
         if (peerAddStatus.Status == UwbStatusMulticast::OkUpdate) {
-            PLOG_VERBOSE << "Session: " << statusMulticastList.SessionId << " Adding peer " << peerAddStatus.ControleeMacAddress.ToString();
             session->InsertPeer(peerAddStatus.ControleeMacAddress);
         }
     }

--- a/lib/uwb/UwbDevice.cxx
+++ b/lib/uwb/UwbDevice.cxx
@@ -84,7 +84,11 @@ UwbDevice::OnSessionMulticastListStatus(UwbSessionUpdateMulicastListStatus statu
         return;
     }
 
-    // TODO: implement this
+    for(const auto& peerAddStatus : statusMulticastList.Status){
+        if(peerAddStatus.Status == UwbStatusMulticast::OkUpdate){
+            session->InsertPeer(peerAddStatus.ControleeMacAddress);
+        }
+    }
 }
 
 void

--- a/lib/uwb/UwbDevice.cxx
+++ b/lib/uwb/UwbDevice.cxx
@@ -84,8 +84,9 @@ UwbDevice::OnSessionMulticastListStatus(UwbSessionUpdateMulicastListStatus statu
         return;
     }
 
-    for(const auto& peerAddStatus : statusMulticastList.Status){
-        if(peerAddStatus.Status == UwbStatusMulticast::OkUpdate){
+    for (const auto& peerAddStatus : statusMulticastList.Status) {
+        if (peerAddStatus.Status == UwbStatusMulticast::OkUpdate) {
+            PLOG_VERBOSE << "Session: " << statusMulticastList.SessionId << " Adding peer " << peerAddStatus.ControleeMacAddress.ToString();
             session->InsertPeer(peerAddStatus.ControleeMacAddress);
         }
     }

--- a/lib/uwb/UwbSession.cxx
+++ b/lib/uwb/UwbSession.cxx
@@ -81,5 +81,6 @@ UwbSession::SetSessionStatus(const uwb::protocol::fira::UwbSessionStatus& status
 void
 UwbSession::InsertPeer(const uwb::UwbMacAddress& peerAddress)
 {
+    std::scoped_lock peersLock{ m_peerGate };
     m_peers.insert(peerAddress);
 }

--- a/lib/uwb/UwbSession.cxx
+++ b/lib/uwb/UwbSession.cxx
@@ -77,3 +77,9 @@ UwbSession::SetSessionStatus(const uwb::protocol::fira::UwbSessionStatus& status
     PLOG_VERBOSE << "session changed state: " << m_sessionStatus.ToString() << " --> " << status.ToString();
     m_sessionStatus = status;
 }
+
+void
+UwbSession::InsertPeer(const uwb::UwbMacAddress& peerAddress)
+{
+    m_peers.insert(peerAddress);
+}

--- a/lib/uwb/UwbSession.cxx
+++ b/lib/uwb/UwbSession.cxx
@@ -83,4 +83,5 @@ UwbSession::InsertPeer(const uwb::UwbMacAddress& peerAddress)
 {
     std::scoped_lock peersLock{ m_peerGate };
     m_peers.insert(peerAddress);
+    PLOG_VERBOSE << "Added peer " << peerAddress.ToString();
 }

--- a/lib/uwb/include/uwb/UwbSession.hxx
+++ b/lib/uwb/include/uwb/UwbSession.hxx
@@ -117,6 +117,14 @@ public:
     void
     SetSessionStatus(const uwb::protocol::fira::UwbSessionStatus& status);
 
+    /**
+     * @brief Temporarily public function to directly add a peer to m_peers
+     *
+     * @param peerAddress
+     */
+    void
+    InsertPeer(const uwb::UwbMacAddress& peerAddress);
+
 private:
     virtual void
     ConfigureImpl(const protocol::fira::UwbSessionData& uwbSessionData) = 0;

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -858,7 +858,7 @@ windows::devices::uwb::ddi::lrp::To(const UWB_NOTIFICATION_DATA &notificationDat
         return To(notificationData.sessionStatus);
     }
     case UWB_NOTIFICATION_TYPE_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST: {
-        break;
+        return To(notificationData.sessionUpdateControllerMulticastList);
     }
     case UWB_NOTIFICATION_TYPE_RANGING_DATA:
         break;


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Implement the handler for adding a peer device 

### Reviewer Focus

For now, we have the UwbSession::InsertPeer function exposed as public. Ideally, we want only UwbDevice to be able to call that function. We should decide in the future how best to deal with this.

Some ideas: 
* make UwbDevice a friend class to UwbSession
* make UwbDevice a function to access UwbSession::m_peers and make that function a friend in UwbSession

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
