### PR TITLE
Implement neutral <-> ddi conversion functions for UwbRangingData and related types

### DIFF
--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -251,7 +251,6 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
 
     SECTION("UwbRangingMeasurement is stable")
     {
-
     }
 
     SECTION("UwbRangingData is stable")

--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -72,6 +72,13 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
         }
     }
 
+    SECTION("UwbLineOfSightIndicator is stable")
+    {
+        for (const auto& uwbLineOfSightIndicator : magic_enum::enum_values<UwbLineOfSightIndicator>()) {
+            test::ValidateRoundtrip(uwbLineOfSightIndicator);
+        }
+    }
+
     SECTION("UwbMulticastAction is stable")
     {
         for (const auto& uwbMulticastAction : magic_enum::enum_values<UwbMulticastAction>()) {
@@ -216,11 +223,35 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
         }
     }
 
+    SECTION("UwbMacAddressType is stable")
+    {
+        for (const auto& uwbMacAddressType : magic_enum::enum_values<::uwb::UwbMacAddressType>()) {
+            test::ValidateRoundtrip(uwbMacAddressType);
+        }
+    }
+
+    SECTION("UwbMacAddress (short) is stable")
+    {
+        const auto uwbMacAddress = ::uwb::UwbMacAddress::Random<::uwb::UwbMacAddressType::Short>();
+        test::ValidateRoundtrip(uwbMacAddress);
+    }
+
+    SECTION("UwbMacAddress (extended) is stable")
+    {
+        const auto uwbMacAddress = ::uwb::UwbMacAddress::Random<::uwb::UwbMacAddressType::Extended>();
+        test::ValidateRoundtrip(uwbMacAddress);
+    }
+
     SECTION("UwbDeviceConfigurationParameterType is stable")
     {
         for (const auto& uwbDeviceConfigurationParameterType : magic_enum::enum_values<UwbDeviceConfigurationParameterType>()) {
             test::ValidateRoundtrip(uwbDeviceConfigurationParameterType);
         }
+    }
+
+    SECTION("UwbRangingMeasurement is stable")
+    {
+
     }
 
     SECTION("UwbRangingData is stable")

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -418,7 +418,7 @@ windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbRangingMea
     rangingMeasurement.macAddrPeer = From(uwbRangingMeasurement.PeerMacAddress);
     rangingMeasurement.lineOfSightIndicator = From(uwbRangingMeasurement.LineOfSignIndicator);
     rangingMeasurement.distance = uwbRangingMeasurement.Distance;
-    rangingMeasurement.aoaAzimuth[0] = (uwbRangingMeasurement.AoAAzimuth.Result & 0x00FFU)
+    rangingMeasurement.aoaAzimuth[0] = (uwbRangingMeasurement.AoAAzimuth.Result & 0x00FFU);
     rangingMeasurement.aoaAzimuth[1] = (uwbRangingMeasurement.AoAAzimuth.Result & 0xFF00U) >> 8U; // TODO: verify masking
     rangingMeasurement.aoaAzimuthFigureOfMerit = uwbRangingMeasurement.AoAAzimuth.FigureOfMerit.value_or(0);
     rangingMeasurement.aoaElevation[0] = (uwbRangingMeasurement.AoAElevation.Result & 0x00FFU);
@@ -427,7 +427,7 @@ windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbRangingMea
     rangingMeasurement.aoaDestinationAzimuth[0] = (uwbRangingMeasurement.AoaDestinationAzimuth.Result & 0x00FFU);
     rangingMeasurement.aoaDestinationAzimuth[1] = (uwbRangingMeasurement.AoaDestinationAzimuth.Result & 0xFF00U) >> 8U;
     rangingMeasurement.aoaElevationFigureOfMerit = uwbRangingMeasurement.AoaDestinationAzimuth.FigureOfMerit.value_or(0);
-    rangingMeasurement.aoaDestinationElevation[0] = (uwbRangingMeasurement.AoaDestinationElevation.Result & 0x00FFU)
+    rangingMeasurement.aoaDestinationElevation[0] = (uwbRangingMeasurement.AoaDestinationElevation.Result & 0x00FFU);
     rangingMeasurement.aoaDestinationElevation[1] = (uwbRangingMeasurement.AoaDestinationElevation.Result & 0xFF00U) >> 8U;
     rangingMeasurement.aoaDestinationElevationFigureOfMerit = uwbRangingMeasurement.AoaDestinationElevation.FigureOfMerit.value_or(0);
     rangingMeasurement.slotIndex = uwbRangingMeasurement.SlotIndex;
@@ -965,17 +965,10 @@ windows::devices::uwb::ddi::lrp::To(const UWB_RANGING_MEASUREMENT &rangingMeasur
         .PeerMacAddress = To(rangingMeasurement.macAddrPeer),
         .LineOfSignIndicator = To(rangingMeasurement.lineOfSightIndicator),
         .AoAAzimuth = {
-            .Result = *reinterpret_cast<const uint16_t*>(&rangingMeasurement.aoaAzimuth[0])
-        },
-        .AoAElevation = {
-            .Result = *reinterpret_cast<const uint16_t*>(&rangingMeasurement.aoaElevation[0])
-        },
-        .AoaDestinationAzimuth = {
-            .Result = *reinterpret_cast<const uint16_t*>(&rangingMeasurement.aoaDestinationAzimuth[0])
-        },
-        .AoaDestinationElevation = {
-            .Result = *reinterpret_cast<const uint16_t*>(&rangingMeasurement.aoaDestinationElevation[0])
-        }
+            .Result = *reinterpret_cast<const uint16_t *>(&rangingMeasurement.aoaAzimuth[0]) },
+        .AoAElevation = { .Result = *reinterpret_cast<const uint16_t *>(&rangingMeasurement.aoaElevation[0]) },
+        .AoaDestinationAzimuth = { .Result = *reinterpret_cast<const uint16_t *>(&rangingMeasurement.aoaDestinationAzimuth[0]) },
+        .AoaDestinationElevation = { .Result = *reinterpret_cast<const uint16_t *>(&rangingMeasurement.aoaDestinationElevation[0]) }
     };
     return uwbRangingMeasurement;
 }
@@ -991,7 +984,7 @@ windows::devices::uwb::ddi::lrp::To(const UWB_RANGING_DATA &rangingData)
     };
 
     for (std::size_t i = 0; i < rangingData.numberOfRangingMeasurements; i++) {
-        const auto& rangingMeasurement = rangingData.rangingMeasurements[i];
+        const auto &rangingMeasurement = rangingData.rangingMeasurements[i];
         uwbRangingData.RangingMeasurements.push_back(To(rangingMeasurement));
     }
 

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -420,7 +420,7 @@ windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbRangingMea
     rangingMeasurement.lineOfSightIndicator = From(uwbRangingMeasurement.LineOfSignIndicator);
     rangingMeasurement.distance = uwbRangingMeasurement.Distance;
     rangingMeasurement.aoaAzimuth[0] = (uwbRangingMeasurement.AoAAzimuth.Result & 0x00FFU);
-    rangingMeasurement.aoaAzimuth[1] = (uwbRangingMeasurement.AoAAzimuth.Result & 0xFF00U) >> 8U; // TODO: verify masking
+    rangingMeasurement.aoaAzimuth[1] = (uwbRangingMeasurement.AoAAzimuth.Result & 0xFF00U) >> 8U;
     rangingMeasurement.aoaAzimuthFigureOfMerit = uwbRangingMeasurement.AoAAzimuth.FigureOfMerit.value_or(0);
     rangingMeasurement.aoaElevation[0] = (uwbRangingMeasurement.AoAElevation.Result & 0x00FFU);
     rangingMeasurement.aoaElevation[1] = (uwbRangingMeasurement.AoAElevation.Result & 0xFF00U) >> 8U;

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -388,6 +388,7 @@ UWB_MAC_ADDRESS
 windows::devices::uwb::ddi::lrp::From(const ::uwb::UwbMacAddress &uwbMacAddress)
 {
     UWB_MAC_ADDRESS macAddress{
+        .size = sizeof(macAddress),
         .addressType = From(uwbMacAddress.GetType())
     };
 

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -1,5 +1,6 @@
 
 #include <algorithm>
+#include <bit>
 #include <bitset>
 #include <functional>
 #include <stdexcept>
@@ -965,11 +966,10 @@ windows::devices::uwb::ddi::lrp::To(const UWB_RANGING_MEASUREMENT &rangingMeasur
         .Status = To(rangingMeasurement.status),
         .PeerMacAddress = To(rangingMeasurement.macAddrPeer),
         .LineOfSignIndicator = To(rangingMeasurement.lineOfSightIndicator),
-        .AoAAzimuth = {
-            .Result = *reinterpret_cast<const uint16_t *>(&rangingMeasurement.aoaAzimuth[0]) },
-        .AoAElevation = { .Result = *reinterpret_cast<const uint16_t *>(&rangingMeasurement.aoaElevation[0]) },
-        .AoaDestinationAzimuth = { .Result = *reinterpret_cast<const uint16_t *>(&rangingMeasurement.aoaDestinationAzimuth[0]) },
-        .AoaDestinationElevation = { .Result = *reinterpret_cast<const uint16_t *>(&rangingMeasurement.aoaDestinationElevation[0]) }
+        .AoAAzimuth = { .Result = std::bit_cast<uint16_t>(rangingMeasurement.aoaAzimuth) },
+        .AoAElevation = { .Result = std::bit_cast<uint16_t>(rangingMeasurement.aoaElevation) },
+        .AoaDestinationAzimuth = { .Result = std::bit_cast<uint16_t>(rangingMeasurement.aoaDestinationAzimuth) },
+        .AoaDestinationElevation = { .Result = std::bit_cast<uint16_t>(rangingMeasurement.aoaDestinationElevation) },
     };
     return uwbRangingMeasurement;
 }

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -418,17 +418,17 @@ windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbRangingMea
     rangingMeasurement.macAddrPeer = From(uwbRangingMeasurement.PeerMacAddress);
     rangingMeasurement.lineOfSightIndicator = From(uwbRangingMeasurement.LineOfSignIndicator);
     rangingMeasurement.distance = uwbRangingMeasurement.Distance;
-    rangingMeasurement.aoaAzimuth[0] = (uwbRangingMeasurement.AoAAzimuth.Result & 0x00FFU) << 0U;
-    rangingMeasurement.aoaAzimuth[1] = (uwbRangingMeasurement.AoAAzimuth.Result & 0xFF00U) << 8U; // TODO: verify masking
+    rangingMeasurement.aoaAzimuth[0] = (uwbRangingMeasurement.AoAAzimuth.Result & 0x00FFU)
+    rangingMeasurement.aoaAzimuth[1] = (uwbRangingMeasurement.AoAAzimuth.Result & 0xFF00U) >> 8U; // TODO: verify masking
     rangingMeasurement.aoaAzimuthFigureOfMerit = uwbRangingMeasurement.AoAAzimuth.FigureOfMerit.value_or(0);
-    rangingMeasurement.aoaElevation[0] = (uwbRangingMeasurement.AoAElevation.Result & 0x00FFU) << 0U;
-    rangingMeasurement.aoaElevation[1] = (uwbRangingMeasurement.AoAElevation.Result & 0xFF00U) << 8U;
+    rangingMeasurement.aoaElevation[0] = (uwbRangingMeasurement.AoAElevation.Result & 0x00FFU);
+    rangingMeasurement.aoaElevation[1] = (uwbRangingMeasurement.AoAElevation.Result & 0xFF00U) >> 8U;
     rangingMeasurement.aoaElevationFigureOfMerit = uwbRangingMeasurement.AoAElevation.FigureOfMerit.value_or(0);
-    rangingMeasurement.aoaDestinationAzimuth[0] = (uwbRangingMeasurement.AoaDestinationAzimuth.Result & 0x00FFU) << 0U;
-    rangingMeasurement.aoaDestinationAzimuth[1] = (uwbRangingMeasurement.AoaDestinationAzimuth.Result & 0xFF00U) << 8U;
+    rangingMeasurement.aoaDestinationAzimuth[0] = (uwbRangingMeasurement.AoaDestinationAzimuth.Result & 0x00FFU);
+    rangingMeasurement.aoaDestinationAzimuth[1] = (uwbRangingMeasurement.AoaDestinationAzimuth.Result & 0xFF00U) >> 8U;
     rangingMeasurement.aoaElevationFigureOfMerit = uwbRangingMeasurement.AoaDestinationAzimuth.FigureOfMerit.value_or(0);
-    rangingMeasurement.aoaDestinationElevation[0] = (uwbRangingMeasurement.AoaDestinationElevation.Result & 0x00FFU) << 0U;
-    rangingMeasurement.aoaDestinationElevation[1] = (uwbRangingMeasurement.AoaDestinationElevation.Result & 0xFF00U) << 8U;
+    rangingMeasurement.aoaDestinationElevation[0] = (uwbRangingMeasurement.AoaDestinationElevation.Result & 0x00FFU)
+    rangingMeasurement.aoaDestinationElevation[1] = (uwbRangingMeasurement.AoaDestinationElevation.Result & 0xFF00U) >> 8U;
     rangingMeasurement.aoaDestinationElevationFigureOfMerit = uwbRangingMeasurement.AoaDestinationElevation.FigureOfMerit.value_or(0);
     rangingMeasurement.slotIndex = uwbRangingMeasurement.SlotIndex;
 

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -42,9 +42,9 @@ From(const ::uwb::protocol::fira::UwbDeviceState &uwbDeviceState);
 
 /**
  * @brief Converts UwbLineOfSightIndicator to UWB_LINE_OF_SIGHT_INDICATOR.
- * 
- * @param uwbLineOfSightIndicator 
- * @return UWB_LINE_OF_SIGHT_INDICATOR 
+ *
+ * @param uwbLineOfSightIndicator
+ * @return UWB_LINE_OF_SIGHT_INDICATOR
  */
 UWB_LINE_OF_SIGHT_INDICATOR
 From(const ::uwb::protocol::fira::UwbLineOfSightIndicator &uwbLineOfSightIndicator);
@@ -185,30 +185,30 @@ From(const ::uwb::protocol::fira::UwbStatusDevice &uwbStatusDevice);
 
 /**
  * @brief Converts UwbMacAddressType to UWB_MAC_ADDRESS_MODE_INDICATOR.
- * 
- * @param uwbMacAddressModeIndicator 
- * @return UWB_MAC_ADDRESS_MODE_INDICATOR 
+ *
+ * @param uwbMacAddressModeIndicator
+ * @return UWB_MAC_ADDRESS_MODE_INDICATOR
  */
 UWB_MAC_ADDRESS_MODE_INDICATOR
 From(const ::uwb::UwbMacAddressType &uwbMacAddressModeIndicator);
 
 /**
  * @brief Converts UwbMacAddress to UWB_MAC_ADDRESS.
- * 
- * @param uwbMacAddress 
- * @return UWB_MAC_ADDRESS 
+ *
+ * @param uwbMacAddress
+ * @return UWB_MAC_ADDRESS
  */
 UWB_MAC_ADDRESS
 From(const ::uwb::UwbMacAddress &uwbMacAddress);
 
 /**
  * @brief Converts UwbRangingMeasurement to UWB_RANGING_MEASUREMENT.
- * 
- * @param uwbRangingMeasurement 
- * @return UWB_RANGING_MEASUREMENT 
+ *
+ * @param uwbRangingMeasurement
+ * @return UWB_RANGING_MEASUREMENT
  */
 UWB_RANGING_MEASUREMENT
-From(const ::uwb::protocol::fira::UwbRangingMeasurement& uwbRangingMeasurement);
+From(const ::uwb::protocol::fira::UwbRangingMeasurement &uwbRangingMeasurement);
 
 /**
  * @brief Converts UwbDeviceConfigurationParameterType to UWB_DEVICE_CONFIG_PARAM_TYPE.
@@ -286,9 +286,9 @@ To(const UWB_DEVICE_STATE &deviceState);
 
 /**
  * @brief Converts UWB_LINE_OF_SIGHT_INDICATOR to UwbLineOfSightIndicator.
- * 
- * @param lineOfSightIndicator 
- * @return ::uwb::protocol::fira::UwbLineOfSightIndicator 
+ *
+ * @param lineOfSightIndicator
+ * @return ::uwb::protocol::fira::UwbLineOfSightIndicator
  */
 ::uwb::protocol::fira::UwbLineOfSightIndicator
 To(const UWB_LINE_OF_SIGHT_INDICATOR &lineOfSightIndicator);
@@ -393,36 +393,36 @@ To(const UWB_APP_CONFIG_PARAM_TYPE &appConfigParameterType);
 
 /**
  * @brief Converts a UWB_MAC_ADDRESS_MODE_INDICATOR to UwbMacAddressType.
- * 
- * @param macAddressModeIndicator 
- * @return ::uwb::UwbMacAddressType 
+ *
+ * @param macAddressModeIndicator
+ * @return ::uwb::UwbMacAddressType
  */
 ::uwb::UwbMacAddressType
 To(const UWB_MAC_ADDRESS_MODE_INDICATOR &macAddressModeIndicator);
 
 /**
  * @brief Converts UWB_MAC_ADDRESS to UwbMacAddress.
- * 
- * @param macAddress 
- * @return ::uwb::UwbMacAddress 
+ *
+ * @param macAddress
+ * @return ::uwb::UwbMacAddress
  */
 ::uwb::UwbMacAddress
 To(const UWB_MAC_ADDRESS &macAddress);
 
 /**
  * @brief Converts UWB_RANGING_MEASUREMENT to UwbRangingMeasurement.
- * 
- * @param rangingMeasurement 
- * @return ::uwb::protocol::fira::UwbRangingMeasurement 
+ *
+ * @param rangingMeasurement
+ * @return ::uwb::protocol::fira::UwbRangingMeasurement
  */
 ::uwb::protocol::fira::UwbRangingMeasurement
 To(const UWB_RANGING_MEASUREMENT &rangingMeasurement);
 
 /**
  * @brief Converts UWB_RANGING_DATA to UwbRangingData.
- * 
- * @param rangingData 
- * @return ::uwb::protocol::fira::UwbRangingData 
+ *
+ * @param rangingData
+ * @return ::uwb::protocol::fira::UwbRangingData
  */
 ::uwb::protocol::fira::UwbRangingData
 To(const UWB_RANGING_DATA &rangingData);

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -41,6 +41,15 @@ UWB_DEVICE_STATE
 From(const ::uwb::protocol::fira::UwbDeviceState &uwbDeviceState);
 
 /**
+ * @brief Converts UwbLineOfSightIndicator to UWB_LINE_OF_SIGHT_INDICATOR.
+ * 
+ * @param uwbLineOfSightIndicator 
+ * @return UWB_LINE_OF_SIGHT_INDICATOR 
+ */
+UWB_LINE_OF_SIGHT_INDICATOR
+From(const ::uwb::protocol::fira::UwbLineOfSightIndicator &uwbLineOfSightIndicator);
+
+/**
  * @brief Converts UwbMulticastAction to UWB_MULTICAST_ACTION.
  *
  * @param uwbMulticastAction
@@ -175,6 +184,33 @@ UWB_DEVICE_STATUS
 From(const ::uwb::protocol::fira::UwbStatusDevice &uwbStatusDevice);
 
 /**
+ * @brief Converts UwbMacAddressType to UWB_MAC_ADDRESS_MODE_INDICATOR.
+ * 
+ * @param uwbMacAddressModeIndicator 
+ * @return UWB_MAC_ADDRESS_MODE_INDICATOR 
+ */
+UWB_MAC_ADDRESS_MODE_INDICATOR
+From(const ::uwb::UwbMacAddressType &uwbMacAddressModeIndicator);
+
+/**
+ * @brief Converts UwbMacAddress to UWB_MAC_ADDRESS.
+ * 
+ * @param uwbMacAddress 
+ * @return UWB_MAC_ADDRESS 
+ */
+UWB_MAC_ADDRESS
+From(const ::uwb::UwbMacAddress &uwbMacAddress);
+
+/**
+ * @brief Converts UwbRangingMeasurement to UWB_RANGING_MEASUREMENT.
+ * 
+ * @param uwbRangingMeasurement 
+ * @return UWB_RANGING_MEASUREMENT 
+ */
+UWB_RANGING_MEASUREMENT
+From(const ::uwb::protocol::fira::UwbRangingMeasurement& uwbRangingMeasurement);
+
+/**
  * @brief Converts UwbDeviceConfigurationParameterType to UWB_DEVICE_CONFIG_PARAM_TYPE.
  *
  * @param uwbDeviceConfigurationParameterType
@@ -247,6 +283,15 @@ To(const UWB_STATUS &status);
  */
 ::uwb::protocol::fira::UwbDeviceState
 To(const UWB_DEVICE_STATE &deviceState);
+
+/**
+ * @brief Converts UWB_LINE_OF_SIGHT_INDICATOR to UwbLineOfSightIndicator.
+ * 
+ * @param lineOfSightIndicator 
+ * @return ::uwb::protocol::fira::UwbLineOfSightIndicator 
+ */
+::uwb::protocol::fira::UwbLineOfSightIndicator
+To(const UWB_LINE_OF_SIGHT_INDICATOR &lineOfSightIndicator);
 
 /**
  * @brief Converts UWB_MULTICAST_ACTION to UwbMulticastAction.
@@ -345,6 +390,24 @@ To(const UWB_SESSION_REASON_CODE &sessionReasonCode);
  */
 ::uwb::protocol::fira::UwbApplicationConfigurationParameterType
 To(const UWB_APP_CONFIG_PARAM_TYPE &appConfigParameterType);
+
+/**
+ * @brief Converts a UWB_MAC_ADDRESS_MODE_INDICATOR to UwbMacAddressType.
+ * 
+ * @param macAddressModeIndicator 
+ * @return ::uwb::UwbMacAddressType 
+ */
+::uwb::UwbMacAddressType
+To(const UWB_MAC_ADDRESS_MODE_INDICATOR &macAddressModeIndicator);
+
+/**
+ * @brief Converts UWB_MAC_ADDRESS to UwbMacAddress.
+ * 
+ * @param macAddress 
+ * @return ::uwb::UwbMacAddress 
+ */
+::uwb::UwbMacAddress
+To(const UWB_MAC_ADDRESS &macAddress);
 
 /**
  * @brief Converts UWB_RANGING_MEASUREMENT to UwbRangingMeasurement.


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Allow neutral <-> ddi conversions to be performed for `UwbRangingData`.

### Technical Details

* Add conversion functions for all types in the chain originating from `UwbRangingData`.

### Test Results

* All unit tests pass on both Linux and Windows.

### Reviewer Focus

None

### Future Work

Unit tests need to be added for these conversion functions.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
