### PR TITLE
OnSessionRangingData

### DIFF
--- a/lib/uwb/UwbDevice.cxx
+++ b/lib/uwb/UwbDevice.cxx
@@ -84,6 +84,7 @@ UwbDevice::OnSessionMulticastListStatus(UwbSessionUpdateMulicastListStatus statu
         return;
     }
 
+    PLOG_VERBOSE << "Adding peer to session " << statusMulticastList.SessionId;
     for (const auto& peerAddStatus : statusMulticastList.Status) {
         if (peerAddStatus.Status == UwbStatusMulticast::OkUpdate) {
             session->InsertPeer(peerAddStatus.ControleeMacAddress);
@@ -100,7 +101,8 @@ UwbDevice::OnSessionRangingData(UwbRangingData rangingData)
         return;
     }
 
-    // TODO: implement this
+    PLOG_VERBOSE << "Adding ranging data to session " << rangingData.SessionId;
+    session->AddRangingData(rangingData);
 }
 
 void

--- a/lib/uwb/UwbSession.cxx
+++ b/lib/uwb/UwbSession.cxx
@@ -87,7 +87,8 @@ UwbSession::InsertPeer(const uwb::UwbMacAddress& peerAddress)
 }
 
 void
-UwbSession::AddRangingData(const uwb::protocol::fira::UwbRangingData& data){
+UwbSession::AddRangingData(const uwb::protocol::fira::UwbRangingData& data)
+{
     m_rangingData.emplace_back(data);
     PLOG_VERBOSE << "Added ranging data " << data.ToString();
 }

--- a/lib/uwb/UwbSession.cxx
+++ b/lib/uwb/UwbSession.cxx
@@ -85,3 +85,9 @@ UwbSession::InsertPeer(const uwb::UwbMacAddress& peerAddress)
     m_peers.insert(peerAddress);
     PLOG_VERBOSE << "Added peer " << peerAddress.ToString();
 }
+
+void
+UwbSession::AddRangingData(const uwb::protocol::fira::UwbRangingData& data){
+    m_rangingData.emplace_back(data);
+    PLOG_VERBOSE << "Added ranging data " << data.ToString();
+}

--- a/lib/uwb/include/uwb/UwbSession.hxx
+++ b/lib/uwb/include/uwb/UwbSession.hxx
@@ -127,8 +127,8 @@ public:
 
     /**
      * @brief Add some ranging data to this session
-     * 
-     * @param data 
+     *
+     * @param data
      */
     void
     AddRangingData(const uwb::protocol::fira::UwbRangingData& data);

--- a/lib/uwb/include/uwb/UwbSession.hxx
+++ b/lib/uwb/include/uwb/UwbSession.hxx
@@ -125,6 +125,14 @@ public:
     void
     InsertPeer(const uwb::UwbMacAddress& peerAddress);
 
+    /**
+     * @brief Add some ranging data to this session
+     * 
+     * @param data 
+     */
+    void
+    AddRangingData(const uwb::protocol::fira::UwbRangingData& data);
+
 private:
     virtual void
     ConfigureImpl(const protocol::fira::UwbSessionData& uwbSessionData) = 0;
@@ -141,6 +149,7 @@ private:
 protected:
     uint32_t m_sessionId{ 0 };
     uwb::protocol::fira::UwbSessionStatus m_sessionStatus{};
+    std::vector<uwb::protocol::fira::UwbRangingData> m_rangingData{};
     UwbMacAddressType m_uwbMacAddressType{ UwbMacAddressType::Extended };
     UwbMacAddress m_uwbMacAddressSelf;
     std::atomic<bool> m_rangingActive{ false };


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Implement the handler for ranging data

### Technical Details

* Added another private variable UwbSessionData::m_rangingData that is just a vector of all observed ranging data.

### Reviewer Focus

Do we need a mutex for this handler?

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
