### PR TITLE
Fix neutral <-> ddi type conversions for UwbSessionUpdateMulicastListStatus and UwbRangingData

### DIFF
--- a/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
+++ b/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
@@ -216,6 +216,16 @@ struct flextype_wrapper
     }
 
     /**
+     * @brief Return a reference to the wrapped value. 
+     * 
+     * @return value_type& 
+     */
+    value_type& value()
+    {
+        return m_value;
+    }
+
+    /**
      * @brief The total size of the value. Note, the buffer may be larger than
      * this value since it has enough space to guarantee correct alignment.
      *

--- a/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
+++ b/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
@@ -51,14 +51,12 @@ enum class flex_array_type : std::size_t {
  */
 template <
     typename ValueT,
-    typename FlexElementT,
     flex_array_type FlexElementAdjuster = flex_array_type::anysize>
     requires std::is_standard_layout_v<ValueT>
 struct flextype_wrapper
 {
     using value_type = ValueT;
     using wrapped_type = ValueT;
-    using element_type = FlexElementT;
     static constexpr flex_array_type array_adjuster = FlexElementAdjuster;
 
     virtual ~flextype_wrapper() = default;
@@ -96,6 +94,7 @@ struct flextype_wrapper
      * @param num_flex_elements Desired number of flex-array elements to store.
      * @return constexpr auto
      */
+    template <typename element_type>
     static inline constexpr auto
     required_buffer_size(std::size_t num_flex_elements)
     {
@@ -119,10 +118,11 @@ struct flextype_wrapper
      * @param num_flex_elements Desired number of flex-array elements to store.
      * @return flextype_wrapper
      */
+    template <typename element_type>
     static flextype_wrapper
     from_num_elements(std::size_t num_flex_elements)
     {
-        return flextype_wrapper{ required_buffer_size(num_flex_elements) };
+        return flextype_wrapper{ required_buffer_size<element_type>(num_flex_elements) };
     }
 
     /**

--- a/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
+++ b/lib/shared/notstd/include/notstd/flextype_wrapper.hxx
@@ -91,6 +91,7 @@ struct flextype_wrapper
      * a template argument. Thus, the calculation method described above is used
      * instead as a compromise.
      *
+     * @tparam element_type The type of the flex-array elements.
      * @param num_flex_elements Desired number of flex-array elements to store.
      * @return constexpr auto
      */
@@ -115,6 +116,7 @@ struct flextype_wrapper
      * size of the wrapped type and pass this to the constructor accepting the
      * total size instead.
      *
+     * @tparam element_type The type of the flex-array elements.
      * @param num_flex_elements Desired number of flex-array elements to store.
      * @return flextype_wrapper
      */

--- a/tests/unit/notstd/TestNotStdFlextypeWrapper.cxx
+++ b/tests/unit/notstd/TestNotStdFlextypeWrapper.cxx
@@ -74,10 +74,10 @@ template <
     typename ElementT,
     flex_array_type FlexElementAdjuster = flex_array_type::anysize>
 struct test_flex_wrapper :
-    public notstd::flextype_wrapper<test_flex_type<ElementT, FlexElementAdjuster>, ElementT, FlexElementAdjuster>
+    public notstd::flextype_wrapper<test_flex_type<ElementT, FlexElementAdjuster>, FlexElementAdjuster>
 {
     using value_type = test_flex_type<ElementT, FlexElementAdjuster>;
-    using flex_wrapper_type = flextype_wrapper<value_type, ElementT, FlexElementAdjuster>;
+    using flex_wrapper_type = flextype_wrapper<value_type, FlexElementAdjuster>;
 
     test_flex_wrapper(std::size_t numElements) :
         flex_wrapper_type(numElements)
@@ -117,7 +117,7 @@ TEST_CASE("flextype_wrapper can be used as a value container with element-based 
     {
         using flex_wrapper_type = test_flex_wrapper<test_flex_type_element_byte>;
 
-        auto wrapper = flex_wrapper_type::from_num_elements(num_elements);
+        auto wrapper = flex_wrapper_type::from_num_elements<test_flex_type_element_byte>(num_elements);
 
         // Ensure there's enough room to store the complete type including flex array elements.
         REQUIRE(wrapper.size() >= flex_wrapper_type::value_type::total_size<num_elements>());
@@ -138,7 +138,7 @@ TEST_CASE("flextype_wrapper can be used as a value container with element-based 
     {
         using flex_wrapper_type = test_flex_wrapper<test_flex_type_element_compound>;
 
-        auto wrapper = flex_wrapper_type::from_num_elements(num_elements);
+        auto wrapper = flex_wrapper_type::from_num_elements<test_flex_type_element_compound>(num_elements);
 
         // Ensure there's enough room to store the complete type including flex array elements.
         REQUIRE(wrapper.size() >= flex_wrapper_type::value_type::total_size<num_elements>());
@@ -161,7 +161,7 @@ TEST_CASE("flextype_wrapper can be used as a value container with element-based 
     {
         using flex_wrapper_type = test_flex_wrapper<test_flex_type_element_compound>;
 
-        auto wrapper = flex_wrapper_type::from_num_elements(num_elements);
+        auto wrapper = flex_wrapper_type::from_num_elements<test_flex_type_element_compound>(num_elements);
         flex_wrapper_type::value_type& value = wrapper;
         value.value = 0xFEEDF00DU;
         value.num_elements = num_elements;
@@ -184,7 +184,7 @@ TEST_CASE("flextype_wrapper can be used as a value container with element-based 
     {
         using flex_wrapper_type = test_flex_wrapper<test_flex_type_element_compound>;
 
-        auto wrapper = flex_wrapper_type::from_num_elements(num_elements);
+        auto wrapper = flex_wrapper_type::from_num_elements<test_flex_type_element_compound>(num_elements);
         flex_wrapper_type::value_type& value = wrapper;
         value.value = 0xFEEDF00DU;
         value.num_elements = num_elements;

--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -1,8 +1,8 @@
 
 #include <concepts>
 #include <iterator>
-#include <ranges>
 #include <random>
+#include <ranges>
 #include <type_traits>
 
 #include <catch2/catch_test_macros.hpp>
@@ -51,13 +51,13 @@ ValidateRoundtrip(const NeutralT& instance)
 
 /**
  * @brief Generate a random integral value.
- * 
- * @tparam ReturnT 
+ *
+ * @tparam ReturnT
  */
 template <typename ReturnT = uint32_t>
-requires (std::is_same_v<ReturnT, uint8_t> || std::is_same_v<ReturnT, uint16_t> || std::is_same_v<ReturnT, uint32_t>)
+    requires(std::is_same_v<ReturnT, uint8_t> || std::is_same_v<ReturnT, uint16_t> || std::is_same_v<ReturnT, uint32_t>)
 ReturnT
-GetRandom()
+    GetRandom()
 {
     static std::mt19937 engine{ std::random_device{}() };
     static std::uniform_int_distribution<uint32_t> distribution{};
@@ -67,13 +67,13 @@ GetRandom()
 
 /**
  * @brief Generate a random uwb ranging measurement.
- * 
- * @return ::uwb::protocol::fira::UwbRangingMeasurementData 
+ *
+ * @return ::uwb::protocol::fira::UwbRangingMeasurementData
  */
-::uwb::protocol::fira::UwbRangingMeasurementData 
+::uwb::protocol::fira::UwbRangingMeasurementData
 GetRandomUwbMeasurementData()
 {
-    ::uwb::protocol::fira::UwbRangingMeasurementData uwbRangingMeasurementData {
+    ::uwb::protocol::fira::UwbRangingMeasurementData uwbRangingMeasurementData{
         .Result = GetRandom<uint16_t>(),
         .FigureOfMerit = GetRandom<uint8_t>(),
     };
@@ -87,9 +87,9 @@ GetRandomUwbMeasurementData()
 }
 
 /**
- * @brief Returns a vector of all possible UwbStatus values. 
- * 
- * @return const std::vector<::uwb::protocol::fira::UwbStatus>& 
+ * @brief Returns a vector of all possible UwbStatus values.
+ *
+ * @return const std::vector<::uwb::protocol::fira::UwbStatus>&
  */
 const std::vector<::uwb::protocol::fira::UwbStatus>&
 AllUwbStatusValues()
@@ -347,7 +347,7 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
                 .CurrentRangingInterval = test::GetRandom<uint32_t>(),
                 .RangingMeasurementType = uwbRangingMeasurementType,
                 .RangingMeasurements = {
-                    UwbRangingMeasurement {
+                    UwbRangingMeasurement{
                         .SlotIndex = test::GetRandom<uint8_t>(),
                         .Distance = test::GetRandom<uint16_t>(),
                         .Status = UwbStatusGeneric::Rejected,
@@ -358,7 +358,7 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
                         .AoaDestinationAzimuth = test::GetRandomUwbMeasurementData(),
                         .AoaDestinationElevation = test::GetRandomUwbMeasurementData(),
                     },
-                    UwbRangingMeasurement {
+                    UwbRangingMeasurement{
                         .SlotIndex = test::GetRandom<uint8_t>(),
                         .Distance = test::GetRandom<uint16_t>(),
                         .Status = UwbStatusGeneric::Rejected,
@@ -369,7 +369,7 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
                         .AoaDestinationAzimuth = test::GetRandomUwbMeasurementData(),
                         .AoaDestinationElevation = test::GetRandomUwbMeasurementData(),
                     },
-                    UwbRangingMeasurement {
+                    UwbRangingMeasurement{
                         .SlotIndex = test::GetRandom<uint8_t>(),
                         .Distance = test::GetRandom<uint16_t>(),
                         .Status = UwbStatusGeneric::Rejected,
@@ -385,7 +385,6 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
 
             test::ValidateRoundtrip(uwbRangingData);
         }
-
     }
 
     SECTION("UwbNotificationData UwbStatus variant is stable")
@@ -451,7 +450,7 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
             .CurrentRangingInterval = test::GetRandom<uint32_t>(),
             .RangingMeasurementType = UwbRangingMeasurementType::TwoWay,
             .RangingMeasurements = {
-                UwbRangingMeasurement {
+                UwbRangingMeasurement{
                     .SlotIndex = test::GetRandom<uint8_t>(),
                     .Distance = test::GetRandom<uint16_t>(),
                     .Status = UwbStatusGeneric::Rejected,
@@ -462,7 +461,7 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
                     .AoaDestinationAzimuth = test::GetRandomUwbMeasurementData(),
                     .AoaDestinationElevation = test::GetRandomUwbMeasurementData(),
                 },
-                UwbRangingMeasurement {
+                UwbRangingMeasurement{
                     .SlotIndex = test::GetRandom<uint8_t>(),
                     .Distance = test::GetRandom<uint16_t>(),
                     .Status = UwbStatusGeneric::Rejected,

--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -440,7 +440,7 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
             .Status = std::move(uwbMulticastListStatus)
         };
         const UwbNotificationData uwbNotificationDataSessionUpdateMulicastListStatus{ uwbSessionUpdateMulicastListStatus };
-        // test::ValidateRoundtrip(uwbNotificationDataSessionUpdateMulicastListStatus);
+        test::ValidateRoundtrip(uwbNotificationDataSessionUpdateMulicastListStatus);
     }
 
     SECTION("UwbNotificationData UwbRangingData variant is stable")
@@ -476,6 +476,6 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
             },
         };
         const UwbNotificationData uwbNotificationDataRangingData{ uwbRangingData };
-        // test::ValidateRoundtrip(uwbNotificationDataRangingData);
+        test::ValidateRoundtrip(uwbNotificationDataRangingData);
     }
 }

--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -55,9 +55,11 @@ ValidateRoundtrip(const NeutralT& instance)
  * @tparam ReturnT
  */
 template <typename ReturnT = uint32_t>
-    requires(std::is_same_v<ReturnT, uint8_t> || std::is_same_v<ReturnT, uint16_t> || std::is_same_v<ReturnT, uint32_t>)
+// clang-format off
+requires std::is_convertible_v<uint32_t, ReturnT>
 ReturnT
-    GetRandom()
+GetRandom()
+// clang-format on
 {
     static std::mt19937 engine{ std::random_device{}() };
     static std::uniform_int_distribution<uint32_t> distribution{};

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -702,41 +702,14 @@ windows::devices::uwb::ddi::lrp::To(const UWB_STATUS &status)
         { UWB_STATUS_ERROR_ADDRESS_ALREADY_PRESENT, UwbStatusSession::AddressAlreadyPresent },
     };
 
-    switch (status) {
-    case UWB_STATUS_OK:
-    case UWB_STATUS_REJECTED:
-    case UWB_STATUS_FAILED:
-    case UWB_STATUS_SYNTAX_ERROR:
-    case UWB_STATUS_INVALID_PARAM:
-    case UWB_STATUS_INVALID_RANGE:
-    case UWB_STATUS_INVALID_MESSAGE_SIZE:
-    case UWB_STATUS_UNKNOWN_GID:
-    case UWB_STATUS_UNKNOWN_OID:
-    case UWB_STATUS_READ_ONLY:
-    case UWB_STATUS_COMMAND_RETRY:
+    auto enumId = notstd::to_underlying(status);
+    if (enumId < notstd::to_underlying(UWB_STATUS_ERROR_SESSION_NOT_EXIST)) {
         return StatusToMapGeneric.at(status);
-    case UWB_STATUS_ERROR_SESSION_NOT_EXIST:
-    case UWB_STATUS_ERROR_SESSION_DUPLICATE:
-    case UWB_STATUS_ERROR_SESSION_ACTIVE:
-    case UWB_STATUS_ERROR_MAX_SESSIONS_EXCEEDED:
-    case UWB_STATUS_ERROR_SESSION_NOT_CONFIGURED:
-    case UWB_STATUS_ERROR_ACTIVE_SESSIONS_ONGOING:
-    case UWB_STATUS_ERROR_MULTICAST_LIST_FULL:
-    case UWB_STATUS_ERROR_ADDRESS_NOT_FOUND:
-    case UWB_STATUS_ERROR_ADDRESS_ALREADY_PRESENT:
-        return StatusToMapSession.at(status);
-    case UWB_STATUS_RANGING_TX_FAILED:
-    case UWB_STATUS_RANGING_RX_TIMEOUT:
-    case UWB_STATUS_RANGING_RX_PHY_DEC_FAILED:
-    case UWB_STATUS_RANGING_RX_PHY_TOA_FAILED:
-    case UWB_STATUS_RANGING_RX_PHY_STS_FAILED:
-    case UWB_STATUS_RANGING_RX_MAC_DEC_FAILED:
-    case UWB_STATUS_RANGING_RX_MAC_IE_DEC_FAILED:
-    case UWB_STATUS_RANGING_RX_MAC_IE_MISSING:
-        return StatusToMapRanging.at(status);
     }
-
-    throw std::runtime_error("unknown UwbStatus value");
+    if (enumId < notstd::to_underlying(UWB_STATUS_RANGING_TX_FAILED)) {
+        return StatusToMapSession.at(status);
+    }
+    return StatusToMapRanging.at(status);
 }
 
 UwbStatusDevice

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -485,7 +485,7 @@ windows::devices::uwb::ddi::lrp::From(const UwbNotificationData &uwbNotification
     // structure here, which will include the size of the largest union member,
     // resulting in an overestimate. While this wastes some memory, it provides
     // a strong guarantee that enough memory will be allocated, avoiding the
-    // possibility of buffer overrun and heap corruption.  
+    // possibility of buffer overrun and heap corruption.
     std::size_t totalSize = sizeof(UWB_NOTIFICATION_DATA);
     std::unique_ptr<UwbNotificationDataWrapper> notificationDataWrapper;
 

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -702,14 +702,41 @@ windows::devices::uwb::ddi::lrp::To(const UWB_STATUS &status)
         { UWB_STATUS_ERROR_ADDRESS_ALREADY_PRESENT, UwbStatusSession::AddressAlreadyPresent },
     };
 
-    auto enumId = notstd::to_underlying(status);
-    if (enumId < notstd::to_underlying(UWB_STATUS_ERROR_SESSION_NOT_EXIST)) {
+    switch (status) {
+    case UWB_STATUS_OK:
+    case UWB_STATUS_REJECTED:
+    case UWB_STATUS_FAILED:
+    case UWB_STATUS_SYNTAX_ERROR:
+    case UWB_STATUS_INVALID_PARAM:
+    case UWB_STATUS_INVALID_RANGE:
+    case UWB_STATUS_INVALID_MESSAGE_SIZE:
+    case UWB_STATUS_UNKNOWN_GID:
+    case UWB_STATUS_UNKNOWN_OID:
+    case UWB_STATUS_READ_ONLY:
+    case UWB_STATUS_COMMAND_RETRY:
         return StatusToMapGeneric.at(status);
-    }
-    if (enumId < notstd::to_underlying(UWB_STATUS_RANGING_TX_FAILED)) {
+    case UWB_STATUS_ERROR_SESSION_NOT_EXIST:
+    case UWB_STATUS_ERROR_SESSION_DUPLICATE:
+    case UWB_STATUS_ERROR_SESSION_ACTIVE:
+    case UWB_STATUS_ERROR_MAX_SESSIONS_EXCEEDED:
+    case UWB_STATUS_ERROR_SESSION_NOT_CONFIGURED:
+    case UWB_STATUS_ERROR_ACTIVE_SESSIONS_ONGOING:
+    case UWB_STATUS_ERROR_MULTICAST_LIST_FULL:
+    case UWB_STATUS_ERROR_ADDRESS_NOT_FOUND:
+    case UWB_STATUS_ERROR_ADDRESS_ALREADY_PRESENT:
         return StatusToMapSession.at(status);
+    case UWB_STATUS_RANGING_TX_FAILED:
+    case UWB_STATUS_RANGING_RX_TIMEOUT:
+    case UWB_STATUS_RANGING_RX_PHY_DEC_FAILED:
+    case UWB_STATUS_RANGING_RX_PHY_TOA_FAILED:
+    case UWB_STATUS_RANGING_RX_PHY_STS_FAILED:
+    case UWB_STATUS_RANGING_RX_MAC_DEC_FAILED:
+    case UWB_STATUS_RANGING_RX_MAC_IE_DEC_FAILED:
+    case UWB_STATUS_RANGING_RX_MAC_IE_MISSING:
+        return StatusToMapRanging.at(status);
     }
-    return StatusToMapRanging.at(status);
+
+    throw std::runtime_error("unknown UwbStatus value");
 }
 
 UwbStatusDevice

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -415,6 +415,7 @@ windows::devices::uwb::ddi::lrp::From(const ::uwb::UwbMacAddress &uwbMacAddress)
 UWB_RANGING_MEASUREMENT
 windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbRangingMeasurement &uwbRangingMeasurement)
 {
+    // clang-format off
     UWB_RANGING_MEASUREMENT rangingMeasurement{
         .size = sizeof rangingMeasurement,
         .macAddrPeer = From(uwbRangingMeasurement.PeerMacAddress),
@@ -425,7 +426,7 @@ windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbRangingMea
             (uwbRangingMeasurement.AoAAzimuth.Result & 0x00FFU),
             (uwbRangingMeasurement.AoAAzimuth.Result & 0xFF00U) >> 8U },
         .aoaAzimuthFigureOfMerit = uwbRangingMeasurement.AoAAzimuth.FigureOfMerit.value_or(0),
-        .aoaElevation = { 
+        .aoaElevation = {
             (uwbRangingMeasurement.AoAElevation.Result & 0x00FFU),
             (uwbRangingMeasurement.AoAElevation.Result & 0xFF00U) >> 8U },
         .aoaElevationFigureOfMerit = uwbRangingMeasurement.AoAElevation.FigureOfMerit.value_or(0),
@@ -439,6 +440,7 @@ windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbRangingMea
         .aoaDestinationElevationFigureOfMerit = uwbRangingMeasurement.AoaDestinationElevation.FigureOfMerit.value_or(0),
         .slotIndex = uwbRangingMeasurement.SlotIndex
     };
+    // clang-format on
 
     return rangingMeasurement;
 }
@@ -483,21 +485,21 @@ windows::devices::uwb::ddi::lrp::From(const UwbNotificationData &uwbNotification
         if constexpr (std::is_same_v<ValueType, UwbStatus>) {
             totalSize += sizeof(UWB_NOTIFICATION_DATA::genericError);
             notificationDataWrapper = std::make_unique<UwbNotificationDataWrapper>(totalSize);
-            UWB_NOTIFICATION_DATA& notificationData = notificationDataWrapper->value();
+            UWB_NOTIFICATION_DATA &notificationData = notificationDataWrapper->value();
             notificationData.size = totalSize;
             notificationData.notificationType = NotificationTypeMap.at(typeid(arg));
             notificationData.genericError = From(arg);
         } else if constexpr (std::is_same_v<ValueType, UwbStatusDevice>) {
             totalSize += sizeof(UWB_NOTIFICATION_DATA::deviceStatus);
             notificationDataWrapper = std::make_unique<UwbNotificationDataWrapper>(totalSize);
-            UWB_NOTIFICATION_DATA& notificationData = notificationDataWrapper->value();
+            UWB_NOTIFICATION_DATA &notificationData = notificationDataWrapper->value();
             notificationData.size = totalSize;
             notificationData.notificationType = NotificationTypeMap.at(typeid(arg));
             notificationData.deviceStatus = From(arg);
         } else if constexpr (std::is_same_v<ValueType, UwbSessionStatus>) {
             totalSize += sizeof(UWB_NOTIFICATION_DATA::sessionStatus);
             notificationDataWrapper = std::make_unique<UwbNotificationDataWrapper>(totalSize);
-            UWB_NOTIFICATION_DATA& notificationData = notificationDataWrapper->value();
+            UWB_NOTIFICATION_DATA &notificationData = notificationDataWrapper->value();
             notificationData.size = totalSize;
             notificationData.notificationType = NotificationTypeMap.at(typeid(arg));
             notificationData.sessionStatus = From(arg);
@@ -505,7 +507,7 @@ windows::devices::uwb::ddi::lrp::From(const UwbNotificationData &uwbNotification
             // notificationData.sessionUpdateControllerMulticastList = From(arg);
         } else if constexpr (std::is_same_v<ValueType, UwbRangingData>) {
             // notificationData.rangingData = From(arg);
-        } 
+        }
         // Note: no else clause is needed here since if the type is not
         // supported, the at() call above will throw std::out_of_range, ensuring
         // this code will never be reached.

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -504,9 +504,23 @@ windows::devices::uwb::ddi::lrp::From(const UwbNotificationData &uwbNotification
             notificationData.notificationType = NotificationTypeMap.at(typeid(arg));
             notificationData.sessionStatus = From(arg);
         } else if constexpr (std::is_same_v<ValueType, UwbSessionUpdateMulicastListStatus>) {
-            // notificationData.sessionUpdateControllerMulticastList = From(arg);
+            auto uwbSessionUpdateMulicastListStatusWrapper = From(arg);
+            totalSize += std::size(uwbSessionUpdateMulicastListStatusWrapper);
+            notificationDataWrapper = std::make_unique<UwbNotificationDataWrapper>(totalSize);
+            UWB_NOTIFICATION_DATA &notificationData = notificationDataWrapper->value();
+            notificationData.size = totalSize;
+            notificationData.notificationType = NotificationTypeMap.at(typeid(arg));
+            auto data = uwbSessionUpdateMulicastListStatusWrapper.data();
+            std::memcpy(&notificationData.sessionUpdateControllerMulticastList, std::data(data), std::size(data));
         } else if constexpr (std::is_same_v<ValueType, UwbRangingData>) {
-            // notificationData.rangingData = From(arg);
+            auto uwbRangingDataWrapper = From(arg);
+            totalSize += std::size(uwbRangingDataWrapper);
+            notificationDataWrapper = std::make_unique<UwbNotificationDataWrapper>(totalSize);
+            UWB_NOTIFICATION_DATA &notificationData = notificationDataWrapper->value();
+            notificationData.size = totalSize;
+            notificationData.notificationType = NotificationTypeMap.at(typeid(arg));
+            auto data = uwbRangingDataWrapper.data();
+            std::memcpy(&notificationData.rangingData, std::data(data), std::size(data));
         }
         // Note: no else clause is needed here since if the type is not
         // supported, the at() call above will throw std::out_of_range, ensuring

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -85,7 +85,7 @@ From(const ::uwb::protocol::fira::UwbMulticastListStatus &uwbStatusMulticastList
 UWB_MULTICAST_CONTROLEE_LIST_ENTRY
 From(const ::uwb::protocol::fira::UwbSessionUpdateMulticastListEntry &uwbSessionUpdateMulticastListEntry);
 
-using UwbSessionUpdateMulicastListWrapper = notstd::flextype_wrapper<UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST, decltype(UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST::controleeList)>;
+using UwbSessionUpdateMulicastListWrapper = notstd::flextype_wrapper<UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST>;
 
 /**
  * @brief Converts UwbSessionUpdateMulicastList to UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST.
@@ -96,7 +96,7 @@ using UwbSessionUpdateMulicastListWrapper = notstd::flextype_wrapper<UWB_SESSION
 UwbSessionUpdateMulicastListWrapper
 From(const ::uwb::protocol::fira::UwbSessionUpdateMulicastList &uwbSessionUpdateMulicastList);
 
-using UwbSessionUpdateMulicastListStatusWrapper = notstd::flextype_wrapper<UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF, decltype(UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF::statusList)>;
+using UwbSessionUpdateMulicastListStatusWrapper = notstd::flextype_wrapper<UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF>;
 
 /**
  * @brief Converts UwbSessionUpdateMulicastListStatus to UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF.
@@ -152,7 +152,7 @@ From(const ::uwb::protocol::fira::UwbSessionState uwbSessionState);
 UWB_SESSION_STATUS
 From(const ::uwb::protocol::fira::UwbSessionStatus &uwbSessionStatus);
 
-using UwbDeviceInformationWrapper = notstd::flextype_wrapper<UWB_DEVICE_INFO, decltype(UWB_DEVICE_INFO::vendorSpecificInfo)>;
+using UwbDeviceInformationWrapper = notstd::flextype_wrapper<UWB_DEVICE_INFO>;
 
 /**
  * @brief Converts UwbDeviceInformation to UWB_DEVICE_INFO.
@@ -163,7 +163,7 @@ using UwbDeviceInformationWrapper = notstd::flextype_wrapper<UWB_DEVICE_INFO, de
 UwbDeviceInformationWrapper
 From(const ::uwb::protocol::fira::UwbDeviceInformation &uwbDeviceInfo);
 
-using UwbDeviceCapabilitiesWrapper = notstd::flextype_wrapper<UWB_DEVICE_CAPABILITIES, decltype(UWB_DEVICE_CAPABILITIES::capabilityParams)>;
+using UwbDeviceCapabilitiesWrapper = notstd::flextype_wrapper<UWB_DEVICE_CAPABILITIES>;
 
 /**
  * @brief Converts UwbCapability to UWB_DEVICE_CAPABILITIES.
@@ -219,7 +219,7 @@ From(const ::uwb::protocol::fira::UwbRangingMeasurement &uwbRangingMeasurement);
 UWB_DEVICE_CONFIG_PARAM_TYPE
 From(const ::uwb::protocol::fira::UwbDeviceConfigurationParameterType &uwbDeviceConfigurationParameterType);
 
-using UwbRangingDataWrapper = notstd::flextype_wrapper<UWB_RANGING_DATA, decltype(UWB_RANGING_DATA::rangingMeasurements)>;
+using UwbRangingDataWrapper = notstd::flextype_wrapper<UWB_RANGING_DATA>;
 
 /**
  * @brief Converts UwbRangingData to UWB_RANGING_DATA.
@@ -230,13 +230,15 @@ using UwbRangingDataWrapper = notstd::flextype_wrapper<UWB_RANGING_DATA, decltyp
 UwbRangingDataWrapper
 From(const ::uwb::protocol::fira::UwbRangingData &uwbRangingData);
 
+using UwbNotificationDataWrapper = notstd::flextype_wrapper<UWB_NOTIFICATION_DATA>;
+
 /**
  * @brief Converts UwbNotificationData to UWB_NOTIFICATION_DATA.
  *
  * @param uwbNotificationData
  * @return UWB_NOTIFICATION_DATA
  */
-UWB_NOTIFICATION_DATA
+UwbNotificationDataWrapper
 From(const ::uwb::protocol::fira::UwbNotificationData &uwbNotificationData);
 
 /**


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Ensure neutral <-> ddi type conversions work for `UwbSessionUpdateMulicastListStatus` and `UwbRangingData` type.

### Technical Details

* Remove explicit flex-array element type from `flexarray_wrapper`.
* Add value type reference accessor to `flexarray_wrapper`.
* Account for size of members in `UWB_NOTIFICATION_DATA`'s union which contain flex-arrays.

### Test Results

* All unit tests are now re-enabled and pass on both Linux and Windows.

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
