### PR TITLE
Use joinable thread for service runtime

### DIFF
--- a/lib/nearobject/include/nearobject/service/ServiceRuntime.hxx
+++ b/lib/nearobject/include/nearobject/service/ServiceRuntime.hxx
@@ -16,26 +16,58 @@ struct NearObjectService;
 class ServiceRuntime
 {
 public:
+    ServiceRuntime() = default;
     ~ServiceRuntime();
 
     ServiceRuntime&
+    operator=(const ServiceRuntime&) = default;
+    ServiceRuntime&
+    operator=(ServiceRuntime&&) = default;
+    ServiceRuntime(ServiceRuntime&) = default;
+    ServiceRuntime(ServiceRuntime&&) = default;
+
+    /**
+     * @brief Set the Service instance object.
+     *
+     * @param service The near object service to run.
+     * @return ServiceRuntime& A reference to this object.
+     */
+    ServiceRuntime&
     SetServiceInstance(std::shared_ptr<NearObjectService> service);
 
+    /**
+     * @brief Start the service main event loop.
+     */
     void
     Start();
 
+    /**
+     * @brief Stop the service main event loop.
+     *
+     * This sends a request to stop the event loop and returns immediately. The
+     * service will complete handling on any in-flight requests and then exit.
+     */
     void
     Stop();
 
+private:
+    /**
+     * @brief Handle a service event that has occurred.
+     */
     void
     HandleEvent();
 
+    /**
+     * @brief Main event loop function. This runs, processing events and
+     * requests until requested to stop, either explicitly through the Stop()
+     * function, or upon destruction of this object.
+     */
     void
     Run();
 
 private:
     std::atomic<bool> m_running = false;
-    std::thread m_threadMain;
+    std::jthread m_threadMain;
     std::mutex m_runEventGate;
     std::condition_variable m_runEvent;
     std::shared_ptr<NearObjectService> m_service;

--- a/lib/nearobject/service/ServiceRuntime.cxx
+++ b/lib/nearobject/service/ServiceRuntime.cxx
@@ -7,10 +7,6 @@ using namespace nearobject::service;
 ServiceRuntime::~ServiceRuntime()
 {
     Stop();
-
-    if (m_threadMain.joinable()) {
-        m_threadMain.join();
-    }
 }
 
 ServiceRuntime&
@@ -31,7 +27,7 @@ ServiceRuntime::Start()
         }
     }
 
-    m_threadMain = std::thread([&]() {
+    m_threadMain = std::jthread([&]() {
         Run();
     });
 }


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [X] Documentation
- [ ] Infrastructure

### Goals

Allow service runtime thread to be joined on stop request.

### Technical Details

* Replace use of `std::thread` with `std::jthread`.
* Remove explicit join on destruction (`std::thread` does this automatically).
* Add documentation to functions.

### Test Results

All unit tests pass on both Linux and Windows.

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
