### PR TITLE
Add multi-device support to DevicePresenceMonitor

### DIFF
--- a/windows/devices/util/DevicePresenceMonitor.cxx
+++ b/windows/devices/util/DevicePresenceMonitor.cxx
@@ -1,5 +1,6 @@
 
 #include <filesystem>
+#include <sstream>
 
 #include <windows/devices/DevicePresenceMonitor.hxx>
 
@@ -98,4 +99,31 @@ void
 DevicePresenceMonitor::Stop()
 {
     UnregisterForDeviceClassNotifications();
+}
+
+DevicePresenceMonitor::StartException::StartException(const GUID &deviceGuid, CONFIGRET configurationManagerResult) :
+    m_deviceGuid(deviceGuid),
+    m_configurationManagerResult(configurationManagerResult)
+{
+    std::ostringstream ss;
+    ss << "configuration manager registration failed for device guid " << notstd::GuidToString<std::string>(deviceGuid) << " with CONFIGRET=" << std::hex << configurationManagerResult;
+    m_what = ss.str();
+}
+
+GUID
+DevicePresenceMonitor::StartException::Guid() const noexcept
+{
+    return m_deviceGuid;
+}
+
+CONFIGRET
+DevicePresenceMonitor::StartException::ConfigurationManagerResult() const noexcept
+{
+    return m_configurationManagerResult;
+}
+
+const char *
+DevicePresenceMonitor::StartException::what() const noexcept
+{
+    return m_what.c_str();
 }

--- a/windows/devices/util/include/windows/devices/DevicePresenceMonitor.hxx
+++ b/windows/devices/util/include/windows/devices/DevicePresenceMonitor.hxx
@@ -4,7 +4,6 @@
 
 #include <functional>
 #include <ios>
-#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
@@ -44,11 +43,11 @@ public:
      * @param callback The callback function to invoke when a device presence
      * change event occurs.
      */
-    explicit DevicePresenceMonitor(const GUID &deviceGuid, std::function<void(const GUID& deviceGuid, DevicePresenceEvent presenceEvent, std::string deviceName)> callback) noexcept;
+    explicit DevicePresenceMonitor(const GUID& deviceGuid, std::function<void(const GUID& deviceGuid, DevicePresenceEvent presenceEvent, std::string deviceName)> callback) noexcept;
 
     /**
      * @brief Construct a new Device Presence Monitor object
-     * 
+     *
      * @param deviceGuids A list of deveice guids to monitor for presence changes.
      * @param callback The callback function to invoke when a device presence change event occurs.
      */
@@ -57,51 +56,36 @@ public:
     /**
      * @brief Exception thrown when there is an error starting the monitor.
      */
-    class StartException : public std::exception
+    class StartException :
+        public std::exception
     {
     public:
-        StartException(const GUID& deviceGuid, CONFIGRET configurationManagerResult) :
-            m_deviceGuid(deviceGuid),
-            m_configurationManagerResult(configurationManagerResult)
-        {
-            std::ostringstream ss;
-            ss << "configuration manager registration failed for device guid " << notstd::GuidToString<std::string>(deviceGuid) << " with CONFIGRET=" << std::hex << configurationManagerResult;
-            m_what = ss.str();
-        }
+        StartException(const GUID& deviceGuid, CONFIGRET configurationManagerResult);
 
         /**
          * @brief The device guid associated with the error.
-         * 
-         * @return GUID 
+         *
+         * @return GUID
          */
         GUID
-        Guid() const noexcept
-        {
-            return m_deviceGuid;
-        }
+        Guid() const noexcept;
 
         /**
          * @brief The Windows Configuration Manager (CM) return value from the
-         * failed operation. 
-         * 
-         * @return CONFIGRET 
+         * failed operation.
+         *
+         * @return CONFIGRET
          */
         CONFIGRET
-        ConfigurationManagerResult() const noexcept
-        {
-            return m_configurationManagerResult;
-        }
+        ConfigurationManagerResult() const noexcept;
 
         /**
          * @brief A description of what caused the failure.
-         * 
-         * @return const char* 
+         *
+         * @return const char*
          */
-        const char *
-        what() const noexcept override
-        {
-            return m_what.c_str();
-        }
+        const char*
+        what() const noexcept override;
 
     private:
         GUID m_deviceGuid;
@@ -143,7 +127,7 @@ private:
      * @param eventDataSize
      */
     void
-    OnDeviceInterfaceNotification(HCMNOTIFICATION hcmNotificationHandle, CM_NOTIFY_ACTION action, CM_NOTIFY_EVENT_DATA *eventData, DWORD eventDataSize);
+    OnDeviceInterfaceNotification(HCMNOTIFICATION hcmNotificationHandle, CM_NOTIFY_ACTION action, CM_NOTIFY_EVENT_DATA* eventData, DWORD eventDataSize);
 
     /**
      * @brief Unbound callback function for when a class driver event occurs.
@@ -156,7 +140,7 @@ private:
      * @return DWORD
      */
     static DWORD CALLBACK
-    OnDeviceInterfaceNotificationCallback(HCMNOTIFICATION hcmNotificationHandle, void *context, CM_NOTIFY_ACTION action, CM_NOTIFY_EVENT_DATA *eventData, DWORD eventDataSize);
+    OnDeviceInterfaceNotificationCallback(HCMNOTIFICATION hcmNotificationHandle, void* context, CM_NOTIFY_ACTION action, CM_NOTIFY_EVENT_DATA* eventData, DWORD eventDataSize);
 
 private:
     std::function<void(const GUID& deviceGuid, DevicePresenceEvent presenceEvent, std::string deviceName)> m_callback;

--- a/windows/shared/notstd/guid.hxx
+++ b/windows/shared/notstd/guid.hxx
@@ -1,4 +1,7 @@
 
+#ifndef NOTSTD_GUID_HXX
+#define NOTSTD_GUID_HXX
+
 #include <algorithm>
 #include <cstring>
 #include <iterator>
@@ -201,3 +204,5 @@ struct hash<GUID>
     }
 };
 } // namespace std
+
+#endif // NOTSTD_GUID_HXX

--- a/windows/tools/devicemon/Main.cxx
+++ b/windows/tools/devicemon/Main.cxx
@@ -68,7 +68,7 @@ main(int argc, char* argv[])
         }
     }
 
-    windows::devices::DevicePresenceMonitor monitor{deviceGuid.value(), [](auto&& deviceGuid, auto&& presenceEvent, auto&& deviceName) {
+    windows::devices::DevicePresenceMonitor monitor(deviceGuid.value(), [](auto&& deviceGuid, auto&& presenceEvent, auto&& deviceName) {
         const auto presenceEventName = magic_enum::enum_name(presenceEvent);
         std::cout << deviceName << " " << presenceEventName << std::endl;
     });

--- a/windows/tools/devicemon/Main.cxx
+++ b/windows/tools/devicemon/Main.cxx
@@ -68,7 +68,7 @@ main(int argc, char* argv[])
         }
     }
 
-    windows::devices::DevicePresenceMonitor monitor(deviceGuid.value(), [](auto&& presenceEvent, auto&& deviceName) {
+    windows::devices::DevicePresenceMonitor monitor{deviceGuid.value(), [](auto&& deviceGuid, auto&& presenceEvent, auto&& deviceName) {
         const auto presenceEventName = magic_enum::enum_name(presenceEvent);
         std::cout << deviceName << " " << presenceEventName << std::endl;
     });

--- a/windows/tools/nocli/NearObjectCliHandlerWindows.cxx
+++ b/windows/tools/nocli/NearObjectCliHandlerWindows.cxx
@@ -111,7 +111,7 @@ try {
     // Keep a container of known devices. Once initialized,
     std::vector<std::unique_ptr<windows::devices::uwb::UwbDevice>> uwbDevices{};
 
-    DevicePresenceMonitor presenceMonitor(windows::devices::uwb::InterfaceClassUwb, [&](auto&& presenceEvent, auto&& deviceName) {
+    DevicePresenceMonitor presenceMonitor(windows::devices::uwb::InterfaceClassUwb, [&](auto&& deviceGuid, auto&& presenceEvent, auto&& deviceName) {
         const auto presenceEventName = magic_enum::enum_name(presenceEvent);
         PLOG_INFO << deviceName << " " << presenceEventName << std::endl;
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Allow detecting presence changes of multiple distinct devices using a single abstraction.

### Technical Details

* Extend `DevicePresenceMonitor` to support multiple device GUIDs.
* Move `StartException` code from header to source file.
* Add missing `#include` guard for `guid.hxx`.

### Test Results

All unit tests pass on both Linux and windows.

### Reviewer Focus

None

### Future Work

Replace manually rolled presence detection in `NearObjectDeviceDiscoveryAgentUwb` with this.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
