### PR TITLE
Implement remaining UWB DDIs in UWB simulator driver

### DIFF
--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -140,6 +140,13 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
         }
     }
 
+    SECTION("UwbSessionType is stable")
+    {
+        for (const auto& uwbSessionType : magic_enum::enum_values<UwbSessionType>()) {
+            test::ValidateRoundtrip(uwbSessionType);
+        }
+    }
+
     SECTION("UwbLineOfSightIndicator is stable")
     {
         for (const auto& uwbLineOfSightIndicator : magic_enum::enum_values<UwbLineOfSightIndicator>()) {

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -90,6 +90,17 @@ windows::devices::uwb::ddi::lrp::From(const UwbDeviceState &uwbDeviceState)
     return DeviceStateMap.at(uwbDeviceState);
 }
 
+UWB_SESSION_TYPE
+windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbSessionType &uwbSessionType)
+{
+    static const std::unordered_map<UwbSessionType, UWB_SESSION_TYPE> SessionTypeMap{
+        { UwbSessionType::RangingSession, UWB_SESSION_TYPE_RANGING_SESSION },
+        { UwbSessionType::TestMode, UWB_SESSION_TYPE_DEVICE_TEST_MODE },
+    };
+
+    return SessionTypeMap.at(uwbSessionType);
+}
+
 UWB_LINE_OF_SIGHT_INDICATOR
 windows::devices::uwb::ddi::lrp::From(const UwbLineOfSightIndicator &uwbLineOfSightIndicator)
 {
@@ -744,6 +755,17 @@ windows::devices::uwb::ddi::lrp::To(const UWB_DEVICE_STATUS &deviceStatus)
     return UwbStatusDevice{
         .State = DeviceStateToMap.at(deviceStatus.deviceState)
     };
+}
+
+UwbSessionType
+windows::devices::uwb::ddi::lrp::To(const UWB_SESSION_TYPE &sessionType)
+{
+    static const std::unordered_map<UWB_SESSION_TYPE, UwbSessionType> SessionTypeMap{
+        { UWB_SESSION_TYPE_RANGING_SESSION, UwbSessionType::RangingSession },
+        { UWB_SESSION_TYPE_DEVICE_TEST_MODE, UwbSessionType::TestMode },
+    };
+
+    return SessionTypeMap.at(sessionType);
 }
 
 UwbDeviceConfigurationParameterType

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -41,6 +41,15 @@ UWB_DEVICE_STATE
 From(const ::uwb::protocol::fira::UwbDeviceState &uwbDeviceState);
 
 /**
+ * @brief Converts UwbSessionType to UWB_SESSION_TYPE.
+ * 
+ * @param uwbSessionType 
+ * @return UWB_SESSION_TYPE 
+ */
+UWB_SESSION_TYPE
+From(const ::uwb::protocol::fira::UwbSessionType &uwbSessionType);
+
+/**
  * @brief Converts UwbLineOfSightIndicator to UWB_LINE_OF_SIGHT_INDICATOR.
  *
  * @param uwbLineOfSightIndicator
@@ -285,6 +294,16 @@ To(const UWB_STATUS &status);
  */
 ::uwb::protocol::fira::UwbDeviceState
 To(const UWB_DEVICE_STATE &deviceState);
+
+
+/**
+ * @brief Converts UWB_SESSION_TYPE to UwbSessionType. 
+ * 
+ * @param sessionType 
+ * @return ::uwb::protocol::fira::UwbSessionType 
+ */
+::uwb::protocol::fira::UwbSessionType
+To(const UWB_SESSION_TYPE &sessionType);
 
 /**
  * @brief Converts UWB_LINE_OF_SIGHT_INDICATOR to UwbLineOfSightIndicator.

--- a/windows/drivers/uwb/simulator/IUwbSimulatorSession.hxx
+++ b/windows/drivers/uwb/simulator/IUwbSimulatorSession.hxx
@@ -21,6 +21,7 @@ struct IUwbSimulatorSession
     UwbSessionType Type{ UwbSessionType::RangingSession };
     UwbSessionState State{ UwbSessionState::Deinitialized };
     uint32_t Sequence{ 0 };
+    uint32_t RangingCount{ 0 };
     std::unordered_set<::uwb::UwbMacAddress> Controlees;
     std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> ApplicationConfigurationParameters;
 };

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
@@ -136,8 +136,6 @@ UwbSimulatorDdiCallbacks::SessionDeninitialize(uint32_t sessionId)
     auto &session = nodeHandle.mapped();
     SessionUpdateState(session, UwbSessionState::Deinitialized);
 
-    // TODO: do whatever else is needed for deinitialization
-
     return UwbStatusOk;
 }
 
@@ -210,7 +208,7 @@ UwbSimulatorDdiCallbacks::SessionStartRanging(uint32_t sessionId)
     }
 
     auto &[_, session] = *sessionIt;
-    session.Sequence++;
+    session.RangingCount++;
     return UwbStatusOk;
 }
 
@@ -229,8 +227,17 @@ UwbSimulatorDdiCallbacks::SessionStopRanging(uint32_t sessionId)
 }
 
 UwbStatus
-UwbSimulatorDdiCallbacks::SessionGetRangingCount(uint32_t /* sessionId */, uint32_t & /* rangingCount */)
+UwbSimulatorDdiCallbacks::SessionGetRangingCount(uint32_t sessionId, uint32_t &rangingCount)
 {
+    std::unique_lock sessionsWriteLock{ m_sessionsGate };
+    auto sessionIt = m_sessions.find(sessionId);
+    if (sessionIt == std::cend(m_sessions)) {
+        return UwbStatusSession::NotExist;
+    }
+
+    auto &[_, session] = *sessionIt;
+    rangingCount = session.RangingCount;
+
     return UwbStatusOk;
 }
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
@@ -320,5 +320,6 @@ UwbSimulatorDdiCallbacks::SessionRandomMeasurementGenerationConfigure(uint32_t s
         session.RandomRangingMeasurementGenerationStart([&](UwbRangingData rangingData) {
             RaiseUwbNotification(std::move(rangingData));
         });
+        break;
     }
 }

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.cxx
@@ -292,16 +292,48 @@ UwbSimulatorDdiHandler::OnUwbSessionUpdateControllerMulticastList(WDFREQUEST /*r
 
 // IOCTL_UWB_START_RANGING_SESSION
 NTSTATUS
-UwbSimulatorDdiHandler::OnUwbSessionStartRanging(WDFREQUEST /*request*/, std::span<uint8_t> /*inputBuffer*/, std::span<uint8_t> /*outputBuffer*/)
+UwbSimulatorDdiHandler::OnUwbSessionStartRanging(WDFREQUEST request, std::span<uint8_t> inputBuffer, std::span<uint8_t> outputBuffer)
 {
-    return STATUS_NOT_IMPLEMENTED;
+    NTSTATUS status = STATUS_SUCCESS;
+
+    // Convert DDI input type to neutral type.
+    auto &startRangingSessionIn = *reinterpret_cast<UWB_START_RANGING_SESSION *>(std::data(inputBuffer));
+    auto sessionId = startRangingSessionIn.sessionId;
+
+    // Invoke callback.
+    auto statusUwb = m_callbacks->SessionStartRanging(sessionId);
+
+    // Convert neutral types to DDI types.
+    auto &outputValue = *reinterpret_cast<UWB_STATUS *>(std::data(outputBuffer));
+    outputValue = UwbCxDdi::From(statusUwb);
+
+    // Complete the request.
+    WdfRequestCompleteWithInformation(request, status, sizeof outputValue);
+
+    return status;
 }
 
 // IOCTL_UWB_STOP_RANGING_SESSION
 NTSTATUS
-UwbSimulatorDdiHandler::OnUwbSessionStopRanging(WDFREQUEST /*request*/, std::span<uint8_t> /*inputBuffer*/, std::span<uint8_t> /*outputBuffer*/)
+UwbSimulatorDdiHandler::OnUwbSessionStopRanging(WDFREQUEST request, std::span<uint8_t> inputBuffer, std::span<uint8_t> outputBuffer)
 {
-    return STATUS_NOT_IMPLEMENTED;
+    NTSTATUS status = STATUS_SUCCESS;
+
+    // Convert DDI input type to neutral type.
+    auto &stopRangingSessionIn = *reinterpret_cast<UWB_STOP_RANGING_SESSION *>(std::data(inputBuffer));
+    auto sessionId = stopRangingSessionIn.sessionId;
+
+    // Invoke callback.
+    auto statusUwb = m_callbacks->SessionStopRanging(sessionId);
+
+    // Convert neutral types to DDI types.
+    auto &outputValue = *reinterpret_cast<UWB_STATUS *>(std::data(outputBuffer));
+    outputValue = UwbCxDdi::From(statusUwb);
+
+    // Complete the request.
+    WdfRequestCompleteWithInformation(request, status, sizeof outputValue);
+
+    return status;
 }
 
 // IOCTL_UWB_GET_RANGING_COUNT

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.cxx
@@ -198,7 +198,7 @@ UwbSimulatorDdiHandler::OnUwbGetSessionCount(WDFREQUEST request, std::span<uint8
     // Invoke callback.
     uint32_t sessionCount = 0;
     auto statusUwb = m_callbacks->GetSessionCount(sessionCount);
-    
+
     // Convert neutral type to DDI output type.
     auto &outputValue = *reinterpret_cast<UWB_GET_SESSION_COUNT *>(std::data(outputBuffer));
     outputValue.size = sizeof outputValue;
@@ -313,7 +313,7 @@ UwbSimulatorDdiHandler::OnUwbSessionGetRangingCount(WDFREQUEST request, std::spa
     // Convert DDI input type to neutral type.
     auto &getRangingCountIn = *reinterpret_cast<UWB_GET_RANGING_COUNT *>(std::data(inputBuffer));
     auto sessionId = getRangingCountIn.sessionId;
-    
+
     // Invoke callback.
     uint32_t rangingCount = 0;
     auto statusUwb = m_callbacks->SessionGetRangingCount(sessionId, rangingCount);

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.cxx
@@ -146,7 +146,7 @@ UwbSimulatorDdiHandler::OnUwbGetApplicationConfigurationParameters(WDFREQUEST re
     NTSTATUS status = STATUS_SUCCESS;
 
     // Convert DDI input type to neutral type.
-    auto &applicationConfigurationParametersIn [[maybe_unused]] = *reinterpret_cast<UWB_SET_APP_CONFIG_PARAMS *>(std::data(inputBuffer));
+    auto &applicationConfigurationParametersIn = *reinterpret_cast<UWB_SET_APP_CONFIG_PARAMS *>(std::data(inputBuffer));
     std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> applicationConfigurationParameters{};
     std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus, std::shared_ptr<IUwbAppConfigurationParameter>>> applicationConfigurationParameterResults;
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Allow the simulator driver to be used as if it was a proper UWB device.

### Technical Details

* Implement remaining UWB DDI IOCTLs, including:
    - `IOCTL_UWB_GET_SESSION_COUNT`
    - `IOCTL_UWB_SESSION_INIT`
    - `IOCTL_UWB_SESSION_DEINIT`
    - `IOCTL_UWB_GET_RANGING_COUNT`

### Test Results

None. This will be tested with the `nocli` tool independently.

### Reviewer Focus

None

### Future Work

* The callback implementations for `IOCTL_UWB_[GET|SET]_APP_CONFIG_PARAMS` and `IOCTL_UWB_[GET|SET]_DEVICE_CONFIG_PARAMS` return empty data since they're not technically required for what needs to be tested right now. Eventually, these will have to be implemented properly.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
