### PR TITLE
Enforce UWB simulator driver DDI buffer size checks

### DIFF
--- a/windows/drivers/uwb/simulator/IUwbSimulatorDdiCallbacksLrp.hxx
+++ b/windows/drivers/uwb/simulator/IUwbSimulatorDdiCallbacksLrp.hxx
@@ -137,11 +137,13 @@ struct IUwbSimulatorDdiCallbacksLrp
     /**
      * @brief
      *
-     * @param controlees
+     * @param sessionId
+     * @param action
+     * @param updateMulticastListEntries
      * @return UwbStatus
      */
     virtual UwbStatus
-    SessionUpdateControllerMulticastList(uint32_t sessionId, std::vector<UwbMacAddress> controlees) = 0;
+    SessionUpdateControllerMulticastList(uint32_t sessionId, UwbMulticastAction action, std::vector<UwbSessionUpdateMulticastListEntry> updateMulticastListEntries) = 0;
 
     /**
      * @brief

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
@@ -198,7 +198,7 @@ UwbSimulatorDdiCallbacks::SessionUpdateControllerMulticastList(uint32_t sessionI
 
     const auto getControlee = [](const UwbSessionUpdateMulticastListEntry &entry) {
         return entry.ControleeMacAddress;
-    };   
+    };
 
     switch (action) {
     case UwbMulticastAction::AddShortAddress: {
@@ -207,7 +207,7 @@ UwbSimulatorDdiCallbacks::SessionUpdateControllerMulticastList(uint32_t sessionI
         break;
     }
     case UwbMulticastAction::DeleteShortAddress: {
-        // TODO: updateMulticastListEntry.SubSessionId needs to be handled in future. 
+        // TODO: updateMulticastListEntry.SubSessionId needs to be handled in future.
         std::erase_if(session.Controlees, [&](const auto &controleeToRemove) {
             return std::ranges::any_of(updateMulticastListEntries | std::views::transform(getControlee), [&](const auto &controlee) {
                 return controleeToRemove == controlee;
@@ -218,7 +218,7 @@ UwbSimulatorDdiCallbacks::SessionUpdateControllerMulticastList(uint32_t sessionI
     default:
         return UwbStatusGeneric::InvalidParameter;
     }
-    
+
     return UwbStatusOk;
 }
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
@@ -1,6 +1,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <ranges>
 
 #include <magic_enum.hpp>
 
@@ -185,7 +186,7 @@ UwbSimulatorDdiCallbacks::SessionGetState(uint32_t sessionId, UwbSessionState &s
 }
 
 UwbStatus
-UwbSimulatorDdiCallbacks::SessionUpdateControllerMulticastList(uint32_t sessionId, std::vector<UwbMacAddress> controlees)
+UwbSimulatorDdiCallbacks::SessionUpdateControllerMulticastList(uint32_t sessionId, UwbMulticastAction action, std::vector<UwbSessionUpdateMulticastListEntry> updateMulticastListEntries)
 {
     std::unique_lock sessionsWriteLock{ m_sessionsGate };
     auto sessionIt = m_sessions.find(sessionId);
@@ -194,7 +195,30 @@ UwbSimulatorDdiCallbacks::SessionUpdateControllerMulticastList(uint32_t sessionI
     }
 
     auto &[_, session] = *sessionIt;
-    std::move(std::begin(controlees), std::end(controlees), std::inserter(session.Controlees, std::end(session.Controlees)));
+
+    const auto getControlee = [](const UwbSessionUpdateMulticastListEntry &entry) {
+        return entry.ControleeMacAddress;
+    };   
+
+    switch (action) {
+    case UwbMulticastAction::AddShortAddress: {
+        // TODO: updateMulticastListEntry.SubSessionId needs to be handled in future.
+        std::ranges::move(updateMulticastListEntries | std::views::transform(getControlee), std::inserter(session.Controlees, std::end(session.Controlees)));
+        break;
+    }
+    case UwbMulticastAction::DeleteShortAddress: {
+        // TODO: updateMulticastListEntry.SubSessionId needs to be handled in future. 
+        std::erase_if(session.Controlees, [&](const auto &controleeToRemove) {
+            return std::ranges::any_of(updateMulticastListEntries | std::views::transform(getControlee), [&](const auto &controlee) {
+                return controleeToRemove == controlee;
+            });
+        });
+        break;
+    }
+    default:
+        return UwbStatusGeneric::InvalidParameter;
+    }
+    
     return UwbStatusOk;
 }
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
@@ -69,7 +69,7 @@ struct UwbSimulatorDdiCallbacks :
     SessionGetState(uint32_t sessionId, UwbSessionState &sessionState) override;
 
     virtual UwbStatus
-    SessionUpdateControllerMulticastList(uint32_t sessionId, std::vector<UwbMacAddress> controlees) override;
+    SessionUpdateControllerMulticastList(uint32_t sessionId, UwbMulticastAction action, std::vector<UwbSessionUpdateMulticastListEntry> updateMulticastListEntries) override;
 
     virtual UwbStatus
     SessionStartRanging(uint32_t sessionId) override;

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.cxx
@@ -104,8 +104,7 @@ UwbSimulatorDdiHandler::OnUwbGetDeviceInformation(WDFREQUEST request, std::span<
     // Update output buffer if sufficiently sized.
     if (std::size(outputBuffer) >= outputSize) {
         std::memcpy(std::data(outputBuffer), std::data(std::data(uwbDeviceInformation)), outputSize);
-    }
-    else {
+    } else {
         status = STATUS_BUFFER_TOO_SMALL;
     }
 
@@ -136,7 +135,7 @@ UwbSimulatorDdiHandler::OnUwbGetDeviceCapabilities(WDFREQUEST request, std::span
     } else {
         status = STATUS_BUFFER_TOO_SMALL;
     }
- 
+
     // Complete the request.
     WdfRequestCompleteWithInformation(request, status, outputSize);
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.cxx
@@ -59,7 +59,13 @@ UwbSimulatorDeviceFile::OnRequest(WDFREQUEST request, ULONG ioControlCode, size_
     // Use the handler to validate the request.
     auto &ddiHandler = *ddiHandlerIt;
     auto status = ddiHandler->ValidateRequest(request, ioControlCode, inputBufferLength, outputBufferLength);
-    if (status != STATUS_SUCCESS) {
+    switch (status) {
+    case STATUS_SUCCESS:
+        break;
+    case STATUS_BUFFER_TOO_SMALL:
+        WdfRequestCompleteWithInformation(request, status, outputBufferLength);
+        // intentional fall-through
+    default:
         return status;
     }
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDispatchEntry.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDispatchEntry.hxx
@@ -63,10 +63,15 @@ struct UwbSimulatorDispatchEntry
      * @return NTSTATUS
      */
     NTSTATUS
-    GetRequestValidityStatus(std::size_t inputBufferSize, std::size_t outputBufferSize, std::size_t inputBufferVariableSize = 0, std::size_t outputBufferVariableSize = 0) const noexcept
+    GetRequestValidityStatus(std::size_t inputBufferSize, std::size_t &outputBufferSize, std::size_t inputBufferVariableSize = 0, std::size_t outputBufferVariableSize = 0) const noexcept
     {
-        return (inputBufferSize >= (InputSizeMinimum + inputBufferVariableSize)) &&
-            (outputBufferSize >= (OutputSizeMinimum + outputBufferVariableSize));
+        if (inputBufferSize < (InputSizeMinimum + inputBufferVariableSize)) {
+            return STATUS_INVALID_PARAMETER;
+        } else if (outputBufferSize < (OutputSizeMinimum + outputBufferVariableSize)) {
+            return STATUS_BUFFER_TOO_SMALL;
+        } else {
+            return STATUS_SUCCESS;
+        } 
     }
 };
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDispatchEntry.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDispatchEntry.hxx
@@ -71,7 +71,7 @@ struct UwbSimulatorDispatchEntry
             return STATUS_BUFFER_TOO_SMALL;
         } else {
             return STATUS_SUCCESS;
-        } 
+        }
     }
 };
 

--- a/windows/tools/uwb/simulator/Main.cxx
+++ b/windows/tools/uwb/simulator/Main.cxx
@@ -30,7 +30,7 @@ main(int argc, char* argv[])
 
     CLI::App app{};
     app.name("uwbsim");
-    app.description("control and interact uwb simulator devices");
+    app.description("control and interact with uwb simulator devices");
 
     std::string deviceName{};
     app.add_option("--deviceName, -d", deviceName, "The uwb simulator device name (path)");


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Ensure the UWB simulator DDI handlers don't crash when improperly sized output buffers are specified.

### Technical Details

* Implement checks for the required size of the output buffers.
* Copy complete output data for DDIs whose output type uses a flex-array wrapper (previously data was being truncated).

### Test Results

Ad-hoc only.

### Reviewer Focus

None

### Future Work

* Some of the DDI implementations we don't need right now need are partially implemented and need to be completed.
* Update `flextype_wrapper` to confirm to STL iterator `data()` function properly.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
