### PR TITLE
Add ETW tracing to UWB simulator DDI handler function entrypoints

### DIFF
--- a/lib/uwb/UwbVersion.cxx
+++ b/lib/uwb/UwbVersion.cxx
@@ -1,4 +1,6 @@
 
+#include <sstream>
+
 #include <uwb/UwbVersion.hxx>
 
 using namespace uwb;
@@ -6,6 +8,14 @@ using namespace uwb;
 UwbVersion::operator uint32_t() const noexcept
 {
     return Major << 24U | (Minor | Maintenance);
+}
+
+std::string
+UwbVersion::ToString() const
+{
+    std::ostringstream ss;
+    ss << Major << '.' << Minor << '.' << Maintenance;
+    return ss.str();
 }
 
 /* static */

--- a/lib/uwb/include/uwb/UwbVersion.hxx
+++ b/lib/uwb/include/uwb/UwbVersion.hxx
@@ -28,6 +28,14 @@ struct UwbVersion
     operator uint32_t() const noexcept;
 
     /**
+     * @brief Returns a string representation of the version number.
+     *
+     * @return std::string
+     */
+    std::string
+    ToString() const;
+
+    /**
      * @brief Parses the specified string and converts it to a UwbVersion
      * object, if valid.
      *

--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -376,6 +376,9 @@ struct UwbDeviceInformation
     UwbStatus Status;
     std::shared_ptr<UwbDeviceInfoVendor> VendorSpecificInfo;
 
+    std::string
+    ToString() const;
+
     auto
     operator<=>(const UwbDeviceInformation&) const noexcept = default;
 };

--- a/lib/uwb/include/uwb/protocols/fira/UwbCapability.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/UwbCapability.hxx
@@ -6,6 +6,7 @@
 #include <functional>
 #include <initializer_list>
 #include <memory>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -217,6 +218,14 @@ struct UwbCapability
     std::vector<Channel> Channels{ ChannelsDefault };
     std::vector<BprfParameter> BprfParameterSets{ BprfParameterSetsDefault };
     std::vector<HprfParameter> HprfParameterSets{ HprfParameterSetsDefault };
+
+    /**
+     * @brief Return a string representation of the object.
+     *
+     * @return std::string
+     */
+    std::string
+    ToString() const;
 
     /**
      * @brief Convert this object into a FiRa Data Object (DO).

--- a/lib/uwb/protocols/fira/FiraDevice.cxx
+++ b/lib/uwb/protocols/fira/FiraDevice.cxx
@@ -102,6 +102,23 @@ uwb::protocol::fira::StringToResultReportConfiguration(const std::string& input)
 }
 
 std::string
+UwbDeviceInformation::ToString() const
+{
+    std::ostringstream ss;
+    const auto* status = std::get_if<UwbStatusGeneric>(&Status);
+    if (*status == UwbStatusOk) {
+        ss << "FiRa Uci v" << VersionUci << ", "
+           << "FiRa Uci Test v" << VersionUciTest << ", "
+           << "FiRa MAC v" << VersionMac << ", "
+           << "FiRa PHY v" << VersionPhy;
+    } else {
+        ss << "(error=" << ::ToString(Status) << ")";
+    }
+
+    return ss.str();
+}
+
+std::string
 UwbStatusDevice::ToString() const
 {
     std::ostringstream ss;

--- a/lib/uwb/protocols/fira/UwbCapability.cxx
+++ b/lib/uwb/protocols/fira/UwbCapability.cxx
@@ -3,6 +3,7 @@
 #include <bit>
 #include <climits>
 #include <iterator>
+#include <sstream>
 #include <stdexcept>
 #include <type_traits>
 
@@ -133,11 +134,11 @@ const std::unordered_map<HprfParameter, std::size_t> UwbCapability::HprfParamete
 
 /**
  * @brief Get the Bytes Big Endian From std::size_t
- * 
+ *
  * @param value the bitmap to encode
- * @param desiredLength the desired number of bytes in the encoding, padding with zeros if necessary. 
+ * @param desiredLength the desired number of bytes in the encoding, padding with zeros if necessary.
  *                      If the value is too large, this will only encode the lowest desiredLength bytes
- * @return std::vector<uint8_t> 
+ * @return std::vector<uint8_t>
  */
 std::vector<uint8_t>
 GetBytesBigEndianFromBitMap(std::size_t value, std::size_t desiredLength)
@@ -167,13 +168,13 @@ GetBytesBigEndianFromBitMap(std::size_t value, std::size_t desiredLength)
 
 /**
  * @brief Parses a span of bytes as a std::size_t number encoded in big endian.
- * 
+ *
  * @tparam IntegerT The type of output integer.
  * @param bytes The buffer to parse.
  * @return
  */
 template <typename IntegerT = std::size_t>
-requires std::is_unsigned_v<IntegerT>
+    requires std::is_unsigned_v<IntegerT>
 IntegerT
 ReadSizeTFromBytesBigEndian(std::span<const uint8_t> bytes)
 {
@@ -193,9 +194,9 @@ ReadSizeTFromBytesBigEndian(std::span<const uint8_t> bytes)
 // TODO find a better place for this function
 /**
  * @brief Get the Bit Mask From Bit Index object
- * 
- * @param bitIndex 
- * @return std::size_t 
+ *
+ * @param bitIndex
+ * @return std::size_t
  */
 std::size_t
 GetBitMaskFromBitIndex(std::size_t bitIndex)
@@ -207,10 +208,10 @@ GetBitMaskFromBitIndex(std::size_t bitIndex)
 }
 
 /**
- * @brief Get the Bit Index From Bit Mask object. 
- * 
- * @param bitMask 
- * @return std::size_t 
+ * @brief Get the Bit Index From Bit Mask object.
+ *
+ * @param bitMask
+ * @return std::size_t
  */
 std::size_t
 GetBitIndexFromBitMask(std::size_t bitMask)
@@ -226,12 +227,12 @@ GetBitIndexFromBitMask(std::size_t bitMask)
 // TODO find a better place for this function
 /**
  * @brief helper function to encode a given valueSet into a bitset according to bitIndexMap, using desiredLength bytes
- * 
- * @tparam T 
- * @param valueSet 
- * @param bitIndexMap 
- * @param desiredLength 
- * @return std::vector<uint8_t> 
+ *
+ * @tparam T
+ * @param valueSet
+ * @param bitIndexMap
+ * @param desiredLength
+ * @return std::vector<uint8_t>
  */
 template <class T>
 std::vector<uint8_t>
@@ -248,11 +249,11 @@ EncodeValuesAsBytes(const std::vector<T>& valueSet, const std::unordered_map<T, 
 // TODO find a better place for this function
 /**
  * @brief helper function that writes the bitset for a given valueSet according to bitIndexMap, using desiredLength bytes
- * 
- * @tparam T 
+ *
+ * @tparam T
  * @param assignee the destination of the bitset
- * @param bitIndexMap 
- * @param bytes 
+ * @param bitIndexMap
+ * @param bytes
  */
 template <class T>
 std::vector<T>
@@ -279,6 +280,14 @@ ToOobDataObjectHelper(encoding::TlvBer::Builder& builder, encoding::TlvBer::Buil
                    .SetValue(bytes)
                    .Build();
     builder.AddTlv(tlv);
+}
+
+std::string
+UwbCapability::ToString() const
+{
+    std::ostringstream ss;
+    // TODO
+    return ss.str();
 }
 
 std::unique_ptr<encoding::TlvBer>
@@ -550,7 +559,7 @@ uwb::protocol::fira::operator==(const UwbCapability& lhs, const UwbCapability& r
         return ::detail::leftUnorderedEquals(v1, v2);
     };
 
-    const bool basicFieldsEqual = 
+    const bool basicFieldsEqual =
         std::tie(lhs.FiraPhyVersionRange, lhs.FiraMacVersionRange, lhs.ExtendedMacAddress, lhs.UwbInitiationTime, lhs.AngleOfArrivalFom, lhs.BlockStriding, lhs.HoppingMode) ==
         std::tie(rhs.FiraPhyVersionRange, rhs.FiraMacVersionRange, rhs.ExtendedMacAddress, rhs.UwbInitiationTime, rhs.AngleOfArrivalFom, rhs.BlockStriding, rhs.HoppingMode);
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
@@ -342,7 +342,7 @@ UwbSimulatorDdiCallbacks::SessionGetRangingCount(uint32_t sessionId, uint32_t &r
 
     TraceLoggingWrite(
         UwbSimulatorTraceloggingProvider,
-        "SessionStopRanging",
+        "SessionGetRangingCount",
         TraceLoggingLevel(TRACE_LEVEL_INFORMATION),
         TraceLoggingUInt32(sessionId, "Session Id"),
         TraceLoggingUInt32(rangingCount, "Session Ranging Count"));

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
@@ -76,6 +76,11 @@ UwbSimulatorDdiCallbacks::SessionUpdateState(UwbSimulatorSession &session, UwbSe
 UwbStatus
 UwbSimulatorDdiCallbacks::DeviceReset()
 {
+    TraceLoggingWrite(
+        UwbSimulatorTraceloggingProvider,
+        "DeviceReset",
+        TraceLoggingLevel(TRACE_LEVEL_INFORMATION));
+
     return UwbStatusOk;
 }
 
@@ -83,6 +88,13 @@ UwbStatus
 UwbSimulatorDdiCallbacks::DeviceGetInformation(UwbDeviceInformation &deviceInformation)
 {
     deviceInformation = m_deviceInformation;
+
+    TraceLoggingWrite(
+        UwbSimulatorTraceloggingProvider,
+        "DeviceGetInformation",
+        TraceLoggingLevel(TRACE_LEVEL_INFORMATION),
+        TraceLoggingString(deviceInformation.ToString().c_str(), "DeviceInformation"));
+
     return UwbStatusOk;
 }
 
@@ -90,6 +102,13 @@ UwbStatus
 UwbSimulatorDdiCallbacks::DeviceGetCapabilities(UwbCapability &deviceCapabilities)
 {
     deviceCapabilities = m_deviceCapabilities;
+
+    TraceLoggingWrite(
+        UwbSimulatorTraceloggingProvider,
+        "DeviceGetCapabilities",
+        TraceLoggingLevel(TRACE_LEVEL_INFORMATION),
+        TraceLoggingString(deviceCapabilities.ToString().c_str(), "DeviceCapabilities"));
+
     return UwbStatusOk;
 }
 
@@ -110,6 +129,13 @@ UwbSimulatorDdiCallbacks::DeviceSetConfigurationParameters(const std::vector<Uwb
 UwbStatus
 UwbSimulatorDdiCallbacks::SessionInitialize(uint32_t sessionId, UwbSessionType sessionType)
 {
+    TraceLoggingWrite(
+        UwbSimulatorTraceloggingProvider,
+        "SessionInitialize",
+        TraceLoggingLevel(TRACE_LEVEL_INFORMATION),
+        TraceLoggingUInt32(sessionId, "Session Id"),
+        TraceLoggingString(std::data(magic_enum::enum_name(sessionType)), "Session Type"));
+
     std::unique_lock sessionsWriteLock{ m_sessionsGate };
     auto [sessionIt, inserted] = m_sessions.try_emplace(sessionId, sessionId, sessionType);
     if (!inserted) {
@@ -125,6 +151,12 @@ UwbSimulatorDdiCallbacks::SessionInitialize(uint32_t sessionId, UwbSessionType s
 UwbStatus
 UwbSimulatorDdiCallbacks::SessionDeninitialize(uint32_t sessionId)
 {
+    TraceLoggingWrite(
+        UwbSimulatorTraceloggingProvider,
+        "SessionDeninitialize",
+        TraceLoggingLevel(TRACE_LEVEL_INFORMATION),
+        TraceLoggingUInt32(sessionId, "Session Id"));
+
     decltype(m_sessions)::node_type nodeHandle;
     {
         std::unique_lock sessionsWriteLock{ m_sessionsGate };
@@ -141,8 +173,14 @@ UwbSimulatorDdiCallbacks::SessionDeninitialize(uint32_t sessionId)
 }
 
 UwbStatus
-UwbSimulatorDdiCallbacks::SetApplicationConfigurationParameters(uint32_t /*sessionId*/, const std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> & /* applicationConfigurationParameters */, std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus, std::shared_ptr<IUwbAppConfigurationParameter>>> &applicationConfigurationParameterResults)
+UwbSimulatorDdiCallbacks::SetApplicationConfigurationParameters(uint32_t sessionId, const std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> & /* applicationConfigurationParameters */, std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus, std::shared_ptr<IUwbAppConfigurationParameter>>> &applicationConfigurationParameterResults)
 {
+    TraceLoggingWrite(
+        UwbSimulatorTraceloggingProvider,
+        "SetApplicationConfigurationParameters",
+        TraceLoggingLevel(TRACE_LEVEL_INFORMATION),
+        TraceLoggingUInt32(sessionId, "Session Id"));
+
     std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus, std::shared_ptr<IUwbAppConfigurationParameter>>> results{};
     applicationConfigurationParameterResults = std::move(results);
     return UwbStatusOk;
@@ -151,6 +189,12 @@ UwbSimulatorDdiCallbacks::SetApplicationConfigurationParameters(uint32_t /*sessi
 UwbStatus
 UwbSimulatorDdiCallbacks::GetApplicationConfigurationParameters(uint32_t sessionId, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> &applicationConfigurationParameters)
 {
+    TraceLoggingWrite(
+        UwbSimulatorTraceloggingProvider,
+        "GetApplicationConfigurationParameters",
+        TraceLoggingLevel(TRACE_LEVEL_INFORMATION),
+        TraceLoggingUInt32(sessionId, "Session Id"));
+
     std::shared_lock sessionsReadLock{ m_sessionsGate };
     auto sessionIt = m_sessions.find(sessionId);
     if (sessionIt == std::cend(m_sessions)) {
@@ -168,6 +212,13 @@ UwbSimulatorDdiCallbacks::GetSessionCount(uint32_t &sessionCount)
 {
     std::shared_lock sessionsReadLock{ m_sessionsGate };
     sessionCount = static_cast<uint32_t>(std::size(m_sessions));
+
+    TraceLoggingWrite(
+        UwbSimulatorTraceloggingProvider,
+        "GetSessionCount",
+        TraceLoggingLevel(TRACE_LEVEL_INFORMATION),
+        TraceLoggingUInt32(sessionCount, "Session Count"));
+
     return UwbStatusOk;
 }
 
@@ -182,12 +233,27 @@ UwbSimulatorDdiCallbacks::SessionGetState(uint32_t sessionId, UwbSessionState &s
 
     const auto &[_, session] = *sessionIt;
     sessionState = session.State;
+
+    TraceLoggingWrite(
+        UwbSimulatorTraceloggingProvider,
+        "SessionGetState",
+        TraceLoggingLevel(TRACE_LEVEL_INFORMATION),
+        TraceLoggingUInt32(sessionId, "Session Id"),
+        TraceLoggingString(std::data(magic_enum::enum_name(sessionState)), "Session State"));
+
     return UwbStatusOk;
 }
 
 UwbStatus
 UwbSimulatorDdiCallbacks::SessionUpdateControllerMulticastList(uint32_t sessionId, UwbMulticastAction action, std::vector<UwbSessionUpdateMulticastListEntry> updateMulticastListEntries)
 {
+    TraceLoggingWrite(
+        UwbSimulatorTraceloggingProvider,
+        "SessionUpdateControllerMulticastList",
+        TraceLoggingLevel(TRACE_LEVEL_INFORMATION),
+        TraceLoggingUInt32(sessionId, "Session Id"),
+        TraceLoggingString(std::data(magic_enum::enum_name(action)), "Multicast Action"));
+
     std::unique_lock sessionsWriteLock{ m_sessionsGate };
     auto sessionIt = m_sessions.find(sessionId);
     if (sessionIt == std::cend(m_sessions)) {
@@ -225,6 +291,12 @@ UwbSimulatorDdiCallbacks::SessionUpdateControllerMulticastList(uint32_t sessionI
 UwbStatus
 UwbSimulatorDdiCallbacks::SessionStartRanging(uint32_t sessionId)
 {
+    TraceLoggingWrite(
+        UwbSimulatorTraceloggingProvider,
+        "SessionStartRanging",
+        TraceLoggingLevel(TRACE_LEVEL_INFORMATION),
+        TraceLoggingUInt32(sessionId, "Session Id"));
+
     std::unique_lock sessionsWriteLock{ m_sessionsGate };
     auto sessionIt = m_sessions.find(sessionId);
     if (sessionIt == std::cend(m_sessions)) {
@@ -239,6 +311,12 @@ UwbSimulatorDdiCallbacks::SessionStartRanging(uint32_t sessionId)
 UwbStatus
 UwbSimulatorDdiCallbacks::SessionStopRanging(uint32_t sessionId)
 {
+    TraceLoggingWrite(
+        UwbSimulatorTraceloggingProvider,
+        "SessionStopRanging",
+        TraceLoggingLevel(TRACE_LEVEL_INFORMATION),
+        TraceLoggingUInt32(sessionId, "Session Id"));
+
     std::unique_lock sessionsWriteLock{ m_sessionsGate };
     auto sessionIt = m_sessions.find(sessionId);
     if (sessionIt == std::cend(m_sessions)) {
@@ -261,6 +339,13 @@ UwbSimulatorDdiCallbacks::SessionGetRangingCount(uint32_t sessionId, uint32_t &r
 
     auto &[_, session] = *sessionIt;
     rangingCount = session.RangingCount;
+
+    TraceLoggingWrite(
+        UwbSimulatorTraceloggingProvider,
+        "SessionStopRanging",
+        TraceLoggingLevel(TRACE_LEVEL_INFORMATION),
+        TraceLoggingUInt32(sessionId, "Session Id"),
+        TraceLoggingUInt32(rangingCount, "Session Ranging Count"));
 
     return UwbStatusOk;
 }
@@ -308,12 +393,23 @@ UwbSimulatorDdiCallbacks::UwbNotification(UwbNotificationData &notificationData)
 UwbSimulatorCapabilities
 UwbSimulatorDdiCallbacks::GetSimulatorCapabilities()
 {
+    TraceLoggingWrite(
+        UwbSimulatorTraceloggingProvider,
+        "GetSimulatorCapabilities",
+        TraceLoggingLevel(TRACE_LEVEL_INFORMATION));
     return m_simulatorCapabilities;
 }
 
 void
 UwbSimulatorDdiCallbacks::TriggerSessionEvent(const UwbSimulatorTriggerSessionEventArgs &triggerSessionEventArgs)
 {
+    TraceLoggingWrite(
+        UwbSimulatorTraceloggingProvider,
+        "TriggerSessionEvent",
+        TraceLoggingLevel(TRACE_LEVEL_INFORMATION),
+        TraceLoggingUInt32(triggerSessionEventArgs.SessionId, "Session Id"),
+        TraceLoggingString(std::data(magic_enum::enum_name(triggerSessionEventArgs.Action)), "Action"));
+
     switch (triggerSessionEventArgs.Action) {
     case UwbSimulatorSessionEventAction::RandomRangingMeasurementGenerationStart: {
         SessionRandomMeasurementGenerationConfigure(triggerSessionEventArgs.SessionId, RandomMeasurementGeneration::Enable);

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
@@ -396,7 +396,8 @@ UwbSimulatorDdiCallbacks::GetSimulatorCapabilities()
     TraceLoggingWrite(
         UwbSimulatorTraceloggingProvider,
         "GetSimulatorCapabilities",
-        TraceLoggingLevel(TRACE_LEVEL_INFORMATION));
+        TraceLoggingLevel(TRACE_LEVEL_INFORMATION),
+        TraceLoggingHexUInt32(m_simulatorCapabilities.Version, "Version"));
     return m_simulatorCapabilities;
 }
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorSession.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorSession.cxx
@@ -1,5 +1,6 @@
 
 #include "UwbSimulatorSession.hxx"
+#include "UwbSimulatorTracelogging.hxx"
 
 using namespace windows::devices::uwb::simulator;
 using namespace uwb::protocol::fira;
@@ -84,6 +85,12 @@ UwbSimulatorSession::GenerateNextRangingData()
 void
 UwbSimulatorSession::RandomRangingMeasurementGenerator(std::function<void(UwbRangingData)> onMeasurementEvent, std::stop_token stopToken)
 {
+    TraceLoggingWrite(
+        UwbSimulatorTraceloggingProvider,
+        "RandomRangingMeasurementGenerationThreadStarted",
+        TraceLoggingLevel(TRACE_LEVEL_INFORMATION),
+        TraceLoggingUInt32(Id, "Session Id"));
+
     while (!stopToken.stop_requested()) {
         std::this_thread::sleep_for(m_randomRangingMeasurementsDuration);
         auto rangingData = GenerateNextRangingData();
@@ -91,4 +98,10 @@ UwbSimulatorSession::RandomRangingMeasurementGenerator(std::function<void(UwbRan
     }
 
     m_sequenceNumber = 0;
+
+    TraceLoggingWrite(
+        UwbSimulatorTraceloggingProvider,
+        "RandomRangingMeasurementGenerationThreadStopped",
+        TraceLoggingLevel(TRACE_LEVEL_INFORMATION),
+        TraceLoggingUInt32(Id, "Session Id"));
 }


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Allow tracing UWB simulator DDI handling execution.

### Technical Details

* Add `TraceLogging` prints for most DDI handler function entrypoints.
* Add several `ToString()` methods to neutral types that needed them.

### Test Results

None

### Reviewer Focus

None

### Future Work

* Add more TraceLogging prints as necessary for testing purposes. 

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
