### PR TITLE
Expose UWB simulator DDI driver functionality through C++ abstraction

### DIFF
--- a/lib/uwb/include/uwb/UwbSession.hxx
+++ b/lib/uwb/include/uwb/UwbSession.hxx
@@ -72,13 +72,13 @@ public:
     AddPeer(UwbMacAddress peerMacAddress);
 
     /**
-     * @brief
+     * @brief Start ranging.
      */
     void
     StartRanging();
 
     /**
-     * @brief
+     * @brief Stop ranging.
      */
     void
     StopRanging();
@@ -119,9 +119,9 @@ public:
     }
 
     /**
-     * @brief Temporarily public function to call the UwbSessionEventCallbacks callback for new ranging data 
-     * 
-     * @param peerRangingData 
+     * @brief Temporarily public function to call the UwbSessionEventCallbacks callback for new ranging data
+     *
+     * @param peerRangingData
      */
     void
     ProcessRangingData(const std::vector<uwb::UwbPeer>& peerRangingData);
@@ -135,15 +135,31 @@ private:
     void
     InsertPeerImpl(const uwb::UwbMacAddress& peerAddress);
 
+    /**
+     * @brief Configures the session for use.
+     *
+     * @param uwbSessionData The session data to configure the session with.
+     */
     virtual void
     ConfigureImpl(const protocol::fira::UwbSessionData& uwbSessionData) = 0;
 
+    /**
+     * @brief Start ranging.
+     */
     virtual void
     StartRangingImpl() = 0;
 
+    /**
+     * @brief Stop ranging.
+     */
     virtual void
     StopRangingImpl() = 0;
 
+    /**
+     * @brief Add a new peer to the session.
+     *
+     * @param peerMacAddress
+     */
     virtual void
     AddPeerImpl(UwbMacAddress peerMacAddress) = 0;
 

--- a/windows/devices/uwb/UwbDevice.cxx
+++ b/windows/devices/uwb/UwbDevice.cxx
@@ -24,6 +24,18 @@ UwbDevice::UwbDevice(std::string deviceName) :
     m_deviceName(std::move(deviceName))
 {}
 
+wil::shared_hfile
+UwbDevice::DriverHandle() noexcept
+{
+    return m_handleDriver;
+}
+
+wil::shared_hfile
+UwbDevice::DriverHandleNotifications() noexcept
+{
+    return m_handleDriverNotifications;
+}
+
 const std::string&
 UwbDevice::DeviceName() const noexcept
 {
@@ -33,7 +45,7 @@ UwbDevice::DeviceName() const noexcept
 void
 UwbDevice::Initialize()
 {
-    wil::unique_hfile handleDriver(CreateFileA(
+    wil::shared_hfile handleDriver(CreateFileA(
         m_deviceName.c_str(),
         GENERIC_READ | GENERIC_WRITE,
         FILE_SHARE_READ | FILE_SHARE_WRITE,
@@ -42,7 +54,7 @@ UwbDevice::Initialize()
         FILE_FLAG_OVERLAPPED,
         nullptr));
 
-    wil::unique_hfile handleDriverNotifications(CreateFileA(
+    wil::shared_hfile handleDriverNotifications(CreateFileA(
         m_deviceName.c_str(),
         GENERIC_READ | GENERIC_WRITE,
         FILE_SHARE_READ | FILE_SHARE_WRITE,

--- a/windows/devices/uwb/UwbDevice.cxx
+++ b/windows/devices/uwb/UwbDevice.cxx
@@ -116,13 +116,7 @@ UwbDevice::HandleNotifications()
 std::shared_ptr<uwb::UwbSession>
 UwbDevice::CreateSessionImpl(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks)
 {
-    // Create a duplicate handle to the driver for use by the session.
-    wil::shared_hfile handleDriverForSession;
-    if (!DuplicateHandle(GetCurrentProcess(), m_handleDriver.get(), GetCurrentProcess(), &handleDriverForSession, 0, FALSE, DUPLICATE_SAME_ACCESS)) {
-        return nullptr;
-    }
-
-    return std::make_shared<UwbSession>(std::move(callbacks), std::move(handleDriverForSession));
+    return CreateSessionImpl<UwbSession>(std::move(callbacks));
 }
 
 UwbCapability

--- a/windows/devices/uwb/UwbDevice.cxx
+++ b/windows/devices/uwb/UwbDevice.cxx
@@ -117,7 +117,7 @@ std::shared_ptr<uwb::UwbSession>
 UwbDevice::CreateSessionImpl(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks)
 {
     // Create a duplicate handle to the driver for use by the session.
-    wil::unique_hfile handleDriverForSession;
+    wil::shared_hfile handleDriverForSession;
     if (!DuplicateHandle(GetCurrentProcess(), m_handleDriver.get(), GetCurrentProcess(), &handleDriverForSession, 0, FALSE, DUPLICATE_SAME_ACCESS)) {
         return nullptr;
     }

--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -18,6 +18,12 @@ UwbSession::UwbSession(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks,
     m_handleDriver(std::move(handleDriver))
 {}
 
+wil::shared_hfile
+UwbSession::HandleDriver() noexcept
+{
+    return m_handleDriver;
+}
+
 void
 UwbSession::ConfigureImpl(const ::uwb::protocol::fira::UwbSessionData &uwbSessionData)
 {

--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -13,7 +13,7 @@
 
 using namespace windows::devices::uwb;
 
-UwbSession::UwbSession(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, wil::unique_hfile handleDriver) :
+UwbSession::UwbSession(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, wil::shared_hfile handleDriver) :
     ::uwb::UwbSession(std::move(callbacks)),
     m_handleDriver(std::move(handleDriver))
 {}

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
@@ -71,7 +71,7 @@ private:
      * @param callbacks The event callback instance.
      * @return std::shared_ptr<uwb::UwbSession>
      */
-    std::shared_ptr<::uwb::UwbSession>
+    virtual std::shared_ptr<::uwb::UwbSession>
     CreateSessionImpl(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks) override;
 
     /**
@@ -79,7 +79,7 @@ private:
      *
      * @return uwb::protocol::fira::UwbCapability
      */
-    ::uwb::protocol::fira::UwbCapability
+    virtual ::uwb::protocol::fira::UwbCapability
     GetCapabilitiesImpl() override;
 
 private:
@@ -92,7 +92,6 @@ private:
 private:
     const std::string m_deviceName;
 
-    unique_hcmnotification m_hcmNotificationHandle;
     wil::unique_hfile m_handleDriver;
     wil::unique_hfile m_handleDriverNotifications;
     std::jthread m_notificationThread;

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
@@ -89,11 +89,28 @@ private:
     void
     HandleNotifications();
 
+protected:
+    /**
+     * @brief Obtain a shared instance of the primary driver handle.
+     *
+     * @return wil::shared_hfile
+     */
+    wil::shared_hfile
+    DriverHandle() noexcept;
+
+    /**
+     * @brief Obtain a shared instance of the notification driver handle.
+     *
+     * @return wil::shared_hfile
+     */
+    wil::shared_hfile
+    DriverHandleNotifications() noexcept;
+
 private:
     const std::string m_deviceName;
 
-    wil::unique_hfile m_handleDriver;
-    wil::unique_hfile m_handleDriverNotifications;
+    wil::shared_hfile m_handleDriver;
+    wil::shared_hfile m_handleDriverNotifications;
     std::jthread m_notificationThread;
 };
 } // namespace windows::devices::uwb

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
@@ -29,7 +29,7 @@ public:
      * @param callbacks The event callback instance.
      * @param handleDriver File handle for a UWB-CX driver instance.
      */
-    UwbSession(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, wil::unique_hfile handleDriver);
+    UwbSession(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, wil::shared_hfile handleDriver);
 
 private:
     /**
@@ -57,7 +57,7 @@ private:
     AddPeerImpl(::uwb::UwbMacAddress peerMacAddress) override;
 
 private:
-    wil::unique_hfile m_handleDriver;
+    wil::shared_hfile m_handleDriver;
 };
 
 } // namespace windows::devices::uwb

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
@@ -33,28 +33,39 @@ public:
 
 private:
     /**
-     * @brief TODO
+     * @brief Configure the session for use.
+     *
+     * @param uwbSessionData The session data to configure the session with.
      */
-    void
+    virtual void
     ConfigureImpl(const ::uwb::protocol::fira::UwbSessionData& uwbSessionData) override;
 
     /**
-     * @brief TODO
+     * @brief Start ranging.
      */
-    void
+    virtual void
     StartRangingImpl() override;
 
     /**
-     * @brief TODO
+     * @brief Stop ranging.
      */
-    void
+    virtual void
     StopRangingImpl() override;
 
     /**
-     * @brief TODO
+     * @brief Add a new peer to the session.
      */
-    void
+    virtual void
     AddPeerImpl(::uwb::UwbMacAddress peerMacAddress) override;
+
+protected:
+    /**
+     * @brief Obtain a shared instance of the primary driver handle.
+     *
+     * @return wil::shared_hfile
+     */
+    wil::shared_hfile
+    HandleDriver() noexcept;
 
 private:
     wil::shared_hfile m_handleDriver;

--- a/windows/devices/uwbsimulator/CMakeLists.txt
+++ b/windows/devices/uwbsimulator/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(windev-uwb-simulator
         ${CMAKE_CURRENT_LIST_DIR}/UwbDeviceSimulator.cxx
     PUBLIC
         ${WINDEVUWBSIM_DIR_PUBLIC_INCLUDE_PREFIX}/UwbDeviceSimulator.hxx
+        ${WINDEVUWBSIM_DIR_PUBLIC_INCLUDE_PREFIX}/UwbSessionSimulator.hxx
 )
 
 target_include_directories(windev-uwb-simulator
@@ -28,6 +29,7 @@ target_link_libraries(windev-uwb-simulator
 
 list(APPEND WINDEVUWBSIM_PUBLIC_HEADERS
     ${WINDEVUWBSIM_DIR_PUBLIC_INCLUDE_PREFIX}/UwbDeviceSimulator.hxx
+    ${WINDEVUWBSIM_DIR_PUBLIC_INCLUDE_PREFIX}/UwbSessionSimulator.hxx
 )
 
 set_target_properties(windev-uwb-simulator PROPERTIES FOLDER windows/devices/uwb)

--- a/windows/devices/uwbsimulator/CMakeLists.txt
+++ b/windows/devices/uwbsimulator/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(windev-uwb-simulator
         uwb-proto-fira
         uwbsim-driver
         WIL::WIL
+        windev-uwb
 )
 
 list(APPEND WINDEVUWBSIM_PUBLIC_HEADERS

--- a/windows/devices/uwbsimulator/UwbDeviceSimulator.cxx
+++ b/windows/devices/uwbsimulator/UwbDeviceSimulator.cxx
@@ -6,8 +6,15 @@
 using namespace windows::devices::uwb::simulator;
 
 UwbDeviceSimulator::UwbDeviceSimulator(std::string deviceName) :
+    UwbDevice(deviceName),
     m_deviceName(std::move(deviceName))
-{}
+{
+    // The simulator driver publishes device interfaces for both itself
+    // (GUID_DEVINTERFACE_UWB_SIMULATOR) and UWB (GUID_UWB_DEVICE_INTERFACE). It
+    // will respond to requests for both interfaces on each device instance, so
+    // we simply push the deviceName to the underlying UWB device.
+    // eg. with 'UwbDevice(deviceName)' above.
+}
 
 const std::string&
 UwbDeviceSimulator::DeviceName() const noexcept

--- a/windows/devices/uwbsimulator/UwbDeviceSimulator.cxx
+++ b/windows/devices/uwbsimulator/UwbDeviceSimulator.cxx
@@ -25,18 +25,7 @@ UwbDeviceSimulator::DeviceName() const noexcept
 bool
 UwbDeviceSimulator::Initialize()
 {
-    wil::unique_hfile handleDriver(CreateFileA(
-        m_deviceName.c_str(),
-        GENERIC_READ | GENERIC_WRITE,
-        FILE_SHARE_READ | FILE_SHARE_WRITE,
-        nullptr,
-        OPEN_EXISTING,
-        FILE_FLAG_OVERLAPPED,
-        nullptr));
-    if (!handleDriver.is_valid()) {
-        return false;
-    }
-
-    m_handleDriver = std::move(handleDriver);
+    UwbDevice::Initialize();
+    m_handleDriver = UwbDevice::DriverHandle();
     return true;
 }

--- a/windows/devices/uwbsimulator/UwbDeviceSimulator.cxx
+++ b/windows/devices/uwbsimulator/UwbDeviceSimulator.cxx
@@ -1,8 +1,6 @@
 
 #include <windows/devices/uwb/simulator/UwbDeviceSimulator.hxx>
 
-#include <UwbSimulatorDdiGlue.h>
-
 using namespace windows::devices::uwb::simulator;
 
 UwbDeviceSimulator::UwbDeviceSimulator(std::string deviceName) :
@@ -28,4 +26,12 @@ UwbDeviceSimulator::Initialize()
     UwbDevice::Initialize();
     m_handleDriver = UwbDevice::DriverHandle();
     return true;
+}
+
+UwbSimulatorCapabilities
+UwbDeviceSimulator::GetSimulatorCapabilities()
+{
+    UwbSimulatorCapabilities uwbSimulatorCapabilities{};
+    // TODO: invoke IOCTL_UWB_DEVICE_SIM_GET_CAPABILITIES IOCTL
+    return uwbSimulatorCapabilities;
 }

--- a/windows/devices/uwbsimulator/UwbDeviceSimulator.cxx
+++ b/windows/devices/uwbsimulator/UwbDeviceSimulator.cxx
@@ -1,5 +1,6 @@
 
 #include <windows/devices/uwb/simulator/UwbDeviceSimulator.hxx>
+#include <windows/devices/uwb/simulator/UwbSessionSimulator.hxx>
 
 using namespace windows::devices::uwb::simulator;
 
@@ -26,6 +27,12 @@ UwbDeviceSimulator::Initialize()
     UwbDevice::Initialize();
     m_handleDriver = UwbDevice::DriverHandle();
     return true;
+}
+
+std::shared_ptr<::uwb::UwbSession>
+UwbDeviceSimulator::CreateSessionImpl(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks)
+{
+    return UwbDevice::CreateSessionImpl<UwbSessionSimulator>(std::move(callbacks));
 }
 
 UwbSimulatorCapabilities

--- a/windows/devices/uwbsimulator/UwbSessionSimulator.cxx
+++ b/windows/devices/uwbsimulator/UwbSessionSimulator.cxx
@@ -1,0 +1,2 @@
+
+#include <windows/devices/uwb/simulator/UwbSessionSimulator.hxx>

--- a/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbDeviceSimulator.hxx
+++ b/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbDeviceSimulator.hxx
@@ -11,10 +11,12 @@
 #include <cfgmgr32.h>
 #include <wil/resource.h>
 #include <windows/devices/DeviceResource.hxx>
+#include <windows/devices/uwb/UwbDevice.hxx>
 
 namespace windows::devices::uwb::simulator
 {
-class UwbDeviceSimulator
+class UwbDeviceSimulator :
+    public windows::devices::uwb::UwbDevice
 {
 public:
     /**
@@ -41,7 +43,6 @@ public:
 private:
     const std::string m_deviceName;
 
-    unique_hcmnotification m_hcmNotificationHandle;
     wil::unique_hfile m_handleDriver;
 };
 

--- a/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbDeviceSimulator.hxx
+++ b/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbDeviceSimulator.hxx
@@ -42,8 +42,7 @@ public:
 
 private:
     const std::string m_deviceName;
-
-    wil::unique_hfile m_handleDriver;
+    wil::shared_hfile m_handleDriver;
 };
 
 } // namespace windows::devices::uwb::simulator

--- a/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbDeviceSimulator.hxx
+++ b/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbDeviceSimulator.hxx
@@ -8,6 +8,8 @@
 // NB: This must come before any other Windows include
 #include <windows.h>
 
+#include <UwbSimulatorDdiGlue.h>
+
 #include <cfgmgr32.h>
 #include <wil/resource.h>
 #include <windows/devices/DeviceResource.hxx>
@@ -39,6 +41,17 @@ public:
      */
     bool
     Initialize();
+
+    /**
+     * @brief Obtain the capabilities of the simulator driver.
+     * 
+     * Internally, this invokes IOCTL_UWB_DEVICE_SIM_GET_CAPABILITIES on the
+     * primary driver handle.
+     * 
+     * @return UwbSimulatorCapabilities
+     */
+    UwbSimulatorCapabilities
+    GetSimulatorCapabilities();
 
 private:
     const std::string m_deviceName;

--- a/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbDeviceSimulator.hxx
+++ b/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbDeviceSimulator.hxx
@@ -37,21 +37,28 @@ public:
     DeviceName() const noexcept;
 
     /**
-     * @brief Initialize the device.
+     * @brief Initialize the simulator device.
+     *
+     * @return true
+     * @return false
      */
     bool
     Initialize();
 
     /**
      * @brief Obtain the capabilities of the simulator driver.
-     * 
+     *
      * Internally, this invokes IOCTL_UWB_DEVICE_SIM_GET_CAPABILITIES on the
      * primary driver handle.
-     * 
+     *
      * @return UwbSimulatorCapabilities
      */
     UwbSimulatorCapabilities
     GetSimulatorCapabilities();
+
+private:
+    virtual std::shared_ptr<::uwb::UwbSession>
+    CreateSessionImpl(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks) override;
 
 private:
     const std::string m_deviceName;

--- a/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbSessionSimulator.hxx
+++ b/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbSessionSimulator.hxx
@@ -1,0 +1,27 @@
+
+#ifndef UWB_SESSION_SIMULATOR_HXX
+#define UWB_SESSION_SIMULATOR_HXX
+
+#include <memory>
+
+#include <windows.h>
+
+#include <wil/resource.h>
+
+#include <uwb/UwbSessionEventCallbacks.hxx>
+#include <windows/devices/uwb/UwbSession.hxx>
+
+namespace windows::devices::uwb::simulator
+{
+class UwbSessionSimulator :
+    public windows::devices::uwb::UwbSession
+{
+public:
+    // Inherit constructor for base class as nothing in for construction is different.
+    using windows::devices::uwb::UwbSession::UwbSession;
+
+    virtual ~UwbSessionSimulator() = default;
+};
+} // namespace windows::devices::uwb::simulator
+
+#endif // UWB_SESSION_SIMULATOR_HXX

--- a/windows/tools/uwb/simulator/CMakeLists.txt
+++ b/windows/tools/uwb/simulator/CMakeLists.txt
@@ -17,4 +17,3 @@ target_link_libraries(uwbsim-win
 
 set_target_properties(uwbsim-win PROPERTIES OUTPUT_NAME uwbsim)
 set_target_properties(uwbsim-win PROPERTIES FOLDER windows/tools)
-

--- a/windows/tools/uwb/simulator/Main.cxx
+++ b/windows/tools/uwb/simulator/Main.cxx
@@ -19,7 +19,8 @@
 
 #include <logging/LogUtils.hxx>
 
-using namespace windows::devices;
+using windows::devices::DeviceEnumerator;
+using namespace windows::devices::uwb::simulator;
 
 int
 main(int argc, char* argv[])
@@ -56,7 +57,7 @@ main(int argc, char* argv[])
 
     std::cout << "creating uwb simulator device " << deviceName << std::endl;
 
-    auto uwbDeviceSimulator = std::make_unique<uwb::simulator::UwbDeviceSimulator>(deviceName);
+    auto uwbDeviceSimulator = std::make_unique<UwbDeviceSimulator>(deviceName);
     if (!uwbDeviceSimulator) {
         std::cerr << "failed to create uwb simulator device instance" << std::endl;
         return -2;


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Expose UWB simulator driver functionality through an easy to use abstraction.

### Technical Details

* Modify `UwbSimulatorDevice` to sub-class from `UwbDevice`, allowing it to use existing code for UWB device functionality.
* Change existing Windows `UwbDevice` and `UwbSession` concrete implementations to use shared driver handles instead of unique ones to allow sharing sub-classes (like the simulator ones) to use them.
* Add `UwbSessionSimulator` sub-class of Windows `UwbSession`.
* Add basic documentation for top-level `UwbSession` interface.

### Test Results

All unit tests pass on both Linux and Windows.

### Reviewer Focus

None

### Future Work

The simulator driver DDI functionality as wrapped by `UwbDeviceSimulator` and `UwbSessionSimulator` needs to be implemented.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
