### PR TITLE
Isolate driver interaction code from high-level abstractions

### DIFF
--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -293,7 +293,7 @@ constexpr auto UwbStatusOk = UwbStatusGeneric::Ok;
 using UwbStatus = std::variant<UwbStatusGeneric, UwbStatusSession, UwbStatusRanging>;
 
 /**
- * @brief Determines if the specified UWB status describes a successfuly result.
+ * @brief Determines if the specified UWB status describes a successful result.
  *
  * @param uwbStatus The status to check.
  * @return true

--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -292,6 +292,16 @@ constexpr auto UwbStatusOk = UwbStatusGeneric::Ok;
 
 using UwbStatus = std::variant<UwbStatusGeneric, UwbStatusSession, UwbStatusRanging>;
 
+/**
+ * @brief Determines if the specified UWB status describes a successfuly result.
+ *
+ * @param uwbStatus The status to check.
+ * @return true
+ * @return false
+ */
+bool
+IsUwbStatusOk(const UwbStatus& uwbStatus) noexcept;
+
 enum class UwbStatusMulticast {
     OkUpdate,
     ErrorListFull,

--- a/lib/uwb/protocols/fira/FiraDevice.cxx
+++ b/lib/uwb/protocols/fira/FiraDevice.cxx
@@ -105,8 +105,7 @@ std::string
 UwbDeviceInformation::ToString() const
 {
     std::ostringstream ss;
-    const auto* status = std::get_if<UwbStatusGeneric>(&Status);
-    if (*status == UwbStatusOk) {
+    if (IsUwbStatusOk(Status)) {
         ss << "FiRa Uci v" << VersionUci << ", "
            << "FiRa Uci Test v" << VersionUciTest << ", "
            << "FiRa MAC v" << VersionMac << ", "
@@ -244,4 +243,11 @@ uwb::protocol::fira::ToString(const UwbNotificationData& uwbNotificationData)
         uwbNotificationData);
 
     return ss.str();
+}
+
+bool
+uwb::protocol::fira::IsUwbStatusOk(const UwbStatus& uwbStatus) noexcept
+{
+    const auto* status = std::get_if<UwbStatusGeneric>(&uwbStatus);
+    return (status != nullptr) && (*status == UwbStatusGeneric::Ok);
 }

--- a/windows/devices/uwb/CMakeLists.txt
+++ b/windows/devices/uwb/CMakeLists.txt
@@ -5,13 +5,16 @@ set(UWBCXADAPTER_DIR_PUBLIC_INCLUDE_PREFIX ${UWBCXADAPTER_DIR_PUBLIC_INCLUDE}/wi
 
 target_sources(uwbcxadapter
     PRIVATE
-        ${CMAKE_CURRENT_LIST_DIR}/UwbCxAdapter.cxx
         ${CMAKE_CURRENT_LIST_DIR}/UwbAppConfiguration.cxx
+        ${CMAKE_CURRENT_LIST_DIR}/UwbCxAdapter.cxx
         ${CMAKE_CURRENT_LIST_DIR}/UwbCxAdapterDdiLrp.cxx
+        ${CMAKE_CURRENT_LIST_DIR}/UwbDeviceConnector.cxx
     PUBLIC
+        ${UWBCXADAPTER_DIR_PUBLIC_INCLUDE_PREFIX}/IUwbDeviceDdi.hxx
         ${UWBCXADAPTER_DIR_PUBLIC_INCLUDE_PREFIX}/UwbAppConfiguration.hxx
         ${UWBCXADAPTER_DIR_PUBLIC_INCLUDE_PREFIX}/UwbCxAdapter.hxx
         ${UWBCXADAPTER_DIR_PUBLIC_INCLUDE_PREFIX}/UwbCxAdapterDdiLrp.hxx
+        ${UWBCXADAPTER_DIR_PUBLIC_INCLUDE_PREFIX}/UwbDeviceConnector.hxx
 )
 
 target_include_directories(uwbcxadapter
@@ -32,9 +35,11 @@ target_link_libraries(uwbcxadapter
 )
 
 list(APPEND UWBCXADAPTER_PUBLIC_HEADERS
+    ${UWBCXADAPTER_DIR_PUBLIC_INCLUDE_PREFIX}/IUwbDeviceDdi.hxx
     ${UWBCXADAPTER_DIR_PUBLIC_INCLUDE_PREFIX}/UwbAppConfiguration.hxx
     ${UWBCXADAPTER_DIR_PUBLIC_INCLUDE_PREFIX}/UwbCxAdapter.hxx
     ${UWBCXADAPTER_DIR_PUBLIC_INCLUDE_PREFIX}/UwbCxAdapterDdiLrp.hxx
+    ${UWBCXADAPTER_DIR_PUBLIC_INCLUDE_PREFIX}/UwbDeviceConnector.hxx
 )
 
 set_target_properties(uwbcxadapter PROPERTIES FOLDER windows/devices/uwb)

--- a/windows/devices/uwb/UwbDevice.cxx
+++ b/windows/devices/uwb/UwbDevice.cxx
@@ -45,6 +45,8 @@ UwbDevice::DeviceName() const noexcept
 void
 UwbDevice::Initialize()
 {
+    m_uwbDeviceConnector = std::make_shared<UwbDeviceConnector>(m_deviceName);
+
     wil::shared_hfile handleDriver(CreateFileA(
         m_deviceName.c_str(),
         GENERIC_READ | GENERIC_WRITE,

--- a/windows/devices/uwb/UwbDevice.cxx
+++ b/windows/devices/uwb/UwbDevice.cxx
@@ -24,18 +24,6 @@ UwbDevice::UwbDevice(std::string deviceName) :
     m_deviceName(std::move(deviceName))
 {}
 
-wil::shared_hfile
-UwbDevice::DriverHandle() noexcept
-{
-    return m_handleDriver;
-}
-
-wil::shared_hfile
-UwbDevice::DriverHandleNotifications() noexcept
-{
-    return m_handleDriverNotifications;
-}
-
 const std::string&
 UwbDevice::DeviceName() const noexcept
 {
@@ -46,84 +34,16 @@ void
 UwbDevice::Initialize()
 {
     m_uwbDeviceConnector = std::make_shared<UwbDeviceConnector>(m_deviceName);
-    m_uwbDeviceConnector->NotificationListenerStart([this](auto&& uwbNotificationData)
-    {
+    m_uwbDeviceConnector->NotificationListenerStart([this](auto&& uwbNotificationData) {
         // Invoke base class notification handler which takes care of threading.
         ::UwbDevice::OnUwbNotification(std::move(uwbNotificationData));
     });
-
-    wil::shared_hfile handleDriver(CreateFileA(
-        m_deviceName.c_str(),
-        GENERIC_READ | GENERIC_WRITE,
-        FILE_SHARE_READ | FILE_SHARE_WRITE,
-        nullptr,
-        OPEN_EXISTING,
-        FILE_FLAG_OVERLAPPED,
-        nullptr));
-
-    wil::shared_hfile handleDriverNotifications(CreateFileA(
-        m_deviceName.c_str(),
-        GENERIC_READ | GENERIC_WRITE,
-        FILE_SHARE_READ | FILE_SHARE_WRITE,
-        nullptr,
-        OPEN_EXISTING,
-        FILE_ATTRIBUTE_NORMAL,
-        nullptr));
-
-    // TODO: call CM_Register_Notification(handleDriver, filterType=CM_NOTIFY_FILTER_TYPE_DEVICEHANDLE)
-    //   - handle CM_NOTIFY_ACTION_DEVICEQUERYREMOVE -> close handleDriver since device removal is requested
-    //   - handle CM_NOTIFY_ACTION_DEVICEQUERYREMOVEFAILED -> query removal failed
-
-    m_handleDriver = std::move(handleDriver);
-    m_handleDriverNotifications = std::move(handleDriverNotifications);
-    m_notificationThread = std::jthread([this] {
-        HandleNotifications();
-    });
-}
-
-void
-UwbDevice::HandleNotifications()
-{
-    for (;;) {
-        // TODO: check exit condition
-
-        // Determine the amount of memory required for the UWB_NOTIFICATION_DATA from the driver.
-        DWORD bytesRequired = 0;
-        BOOL ioResult = DeviceIoControl(m_handleDriverNotifications.get(), IOCTL_UWB_NOTIFICATION, nullptr, 0, nullptr, 0, &bytesRequired, nullptr);
-        if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
-            HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
-            PLOG_ERROR << "error determining output buffer size for UWB notification, hr=" << std::showbase << std::hex << hr;
-            continue;
-        }
-
-        // Allocate memory for the UWB_NOTIFICATION_DATA structure, and pass this to the driver request.
-        DWORD uwbNotificationDataSize = bytesRequired;
-        std::vector<uint8_t> uwbNotificationDataBuffer(uwbNotificationDataSize);
-        ioResult = DeviceIoControl(m_handleDriverNotifications.get(), IOCTL_UWB_NOTIFICATION, nullptr, 0, std::data(uwbNotificationDataBuffer), uwbNotificationDataSize, &bytesRequired, nullptr);
-        if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
-            HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
-            PLOG_ERROR << "error obtaining UWB notification buffer, hr=" << std::showbase << std::hex << hr;
-            continue;
-        }
-
-        // Log a message if the output buffer is not aligned to UWB_NOTIFICATION_DATA. Ignore it for now as this should not occur often.
-        if (reinterpret_cast<uintptr_t>(std::data(uwbNotificationDataBuffer)) % alignof(UWB_NOTIFICATION_DATA) != 0) {
-            PLOG_ERROR << "driver output buffer is unaligned! undefined behavior may result";
-        }
-
-        // Convert to neutral type and process the notification.
-        const UWB_NOTIFICATION_DATA& notificationData = *reinterpret_cast<UWB_NOTIFICATION_DATA*>(std::data(uwbNotificationDataBuffer));
-        auto uwbNotificationData = UwbCxDdi::To(notificationData);
-
-        // Invoke base class notification handler which takes care of threading.
-        ::UwbDevice::OnUwbNotification(std::move(uwbNotificationData));
-    }
 }
 
 std::shared_ptr<uwb::UwbSession>
 UwbDevice::CreateSessionImpl(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks)
 {
-    return CreateSessionImpl<UwbSession>(std::move(callbacks));
+    return std::make_shared<UwbSession>(std::move(callbacks), m_uwbDeviceConnector);
 }
 
 UwbCapability

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -189,6 +189,16 @@ UwbDeviceConnector::SessionUpdateControllerMulticastList(uint32_t sessionId, Uwb
     return resultFuture;
 }
 
+std::future<std::tuple<UwbStatus, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>>>>
+UwbDeviceConnector::GetApplicationConfigurationParameters(uint32_t sessionId, std::vector<UwbApplicationConfigurationParameterType> applicationConfigurationParameterTypes)
+{
+    std::promise<std::tuple<UwbStatus, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>>>> promiseResult;
+    auto resultFuture = promiseResult.get_future();
+    // TODO: invoke IOCTL_UWB_GET_APP_CONFIG_PARAMS
+
+    return resultFuture;
+}
+
 std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>>>
 UwbDeviceConnector::SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> applicationConfigurationParameters)
 {

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -23,7 +23,7 @@ UwbDeviceConnector::UwbDeviceConnector(std::string deviceName) :
 {}
 
 HRESULT
-UwbDeviceConnector::OpenDriverHandle(wil::shared_hfile &driverHandle, bool isOverlapped = false) noexcept
+UwbDeviceConnector::OpenDriverHandle(wil::shared_hfile& driverHandle, bool isOverlapped = false) noexcept
 {
     driverHandle.reset(CreateFileA(
         m_deviceName.c_str(),
@@ -262,7 +262,7 @@ UwbDeviceConnector::NotificationListenerStart(std::function<void(::uwb::protocol
         PLOG_ERROR << "failed to obtain driver handle for " << m_deviceName << ", hr=" << hr;
         return false;
     }
-    
+
     m_notificationThread = std::jthread([this, handleDriver = std::move(handleDriver), onNotification = std::move(onNotification)](std::stop_token stopToken) {
         HandleNotifications(std::move(handleDriver), stopToken, std::move(onNotification));
     });

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -189,10 +189,10 @@ UwbDeviceConnector::SessionUpdateControllerMulticastList(uint32_t sessionId, Uwb
     return resultFuture;
 }
 
-std::future<std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus, std::shared_ptr<IUwbAppConfigurationParameter>>>>
+std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>>>
 UwbDeviceConnector::SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> applicationConfigurationParameters)
 {
-    std::promise<std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus, std::shared_ptr<IUwbAppConfigurationParameter>>>> resultPromise;
+    std::promise<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>>> resultPromise;
     auto resultFuture = resultPromise.get_future();
     // TODO: invoke IOCTL_UWB_SET_APP_CONFIG_PARAMS
 

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -1,0 +1,253 @@
+
+#include <ios>
+#include <stdexcept>
+
+#include <plog/Log.h>
+#include <wil/result.h>
+
+#include <windows/devices/uwb/UwbCxAdapterDdiLrp.hxx>
+#include <windows/devices/uwb/UwbCxDdiLrp.hxx>
+#include <windows/devices/uwb/UwbDeviceConnector.hxx>
+
+using namespace windows::devices::uwb;
+using namespace ::uwb::protocol::fira;
+
+/**
+ * @brief Namespace alias to reduce typing but preserve clarity regarding DDI
+ * conversion.
+ */
+namespace UwbCxDdi = windows::devices::uwb::ddi::lrp;
+
+UwbDeviceConnector::UwbDeviceConnector(std::string deviceName) :
+    m_deviceName(std::move(deviceName))
+{}
+
+wil::shared_hfile
+UwbDeviceConnector::DriverHandle() noexcept
+{
+    return m_handleDriver;
+}
+
+wil::shared_hfile
+UwbDeviceConnector::DriverHandleNotifications() noexcept
+{
+    return m_handleDriverNotifications;
+}
+
+const std::string&
+UwbDeviceConnector::DeviceName() const noexcept
+{
+    return m_deviceName;
+}
+
+void
+UwbDeviceConnector::Initialize()
+{
+    wil::shared_hfile handleDriver(CreateFileA(
+        m_deviceName.c_str(),
+        GENERIC_READ | GENERIC_WRITE,
+        FILE_SHARE_READ | FILE_SHARE_WRITE,
+        nullptr,
+        OPEN_EXISTING,
+        FILE_FLAG_OVERLAPPED,
+        nullptr));
+
+    wil::shared_hfile handleDriverNotifications(CreateFileA(
+        m_deviceName.c_str(),
+        GENERIC_READ | GENERIC_WRITE,
+        FILE_SHARE_READ | FILE_SHARE_WRITE,
+        nullptr,
+        OPEN_EXISTING,
+        FILE_ATTRIBUTE_NORMAL,
+        nullptr));
+
+    // TODO: call CM_Register_Notification(handleDriver, filterType=CM_NOTIFY_FILTER_TYPE_DEVICEHANDLE)
+    //   - handle CM_NOTIFY_ACTION_DEVICEQUERYREMOVE -> close handleDriver since device removal is requested
+    //   - handle CM_NOTIFY_ACTION_DEVICEQUERYREMOVEFAILED -> query removal failed
+
+    m_handleDriver = std::move(handleDriver);
+    m_handleDriverNotifications = std::move(handleDriverNotifications);
+    m_notificationThread = std::jthread([this] {
+        HandleNotifications();
+    });
+}
+
+std::future<UwbStatus>
+UwbDeviceConnector::Reset()
+{
+    std::promise<UwbStatus> resultPromise{};
+    auto resultFuture = resultPromise.get_future();
+    // TODO: invoke IOCTL_UWB_DEVICE_RESET
+
+    UwbStatus uwbStatus{}; // TODO: set this to value obtained from IOCTL
+    resultPromise.set_value(uwbStatus);
+
+    return resultFuture;
+}
+
+std::future<::uwb::protocol::fira::UwbDeviceInformation>
+UwbDeviceConnector::GetDeviceInformation()
+{
+    std::promise<UwbDeviceInformation> resultPromise;
+    auto resultFuture = resultPromise.get_future();
+    // TODO: invoke IOCTL_UWB_GET_DEVICE_INFO
+
+    return resultFuture;
+}
+
+std::future<std::tuple<::uwb::protocol::fira::UwbStatus, ::uwb::protocol::fira::UwbCapability>>
+UwbDeviceConnector::GetCapabilities()
+{
+    std::promise<std::tuple<::uwb::protocol::fira::UwbStatus, ::uwb::protocol::fira::UwbCapability>> resultPromise{};
+    auto resultFuture = resultPromise.get_future();
+
+    // Determine the amount of memory required for the UWB_DEVICE_CAPABILITIES from the driver.
+    DWORD bytesRequired = 0;
+    BOOL ioResult = DeviceIoControl(m_handleDriver.get(), IOCTL_UWB_GET_DEVICE_CAPABILITIES, nullptr, 0, nullptr, 0, &bytesRequired, nullptr);
+    if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
+        // TODO: need to do something different here
+        HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
+        PLOG_ERROR << "error when sending IOCTL_UWB_GET_DEVICE_CAPABILITIES, hr=" << std::showbase << std::hex << hr;
+        return resultFuture;
+    }
+
+    // Allocate memory for the UWB_DEVICE_CAPABILITIES structure, and pass this to the driver request.
+    DWORD uwbCapabilitiesSize = bytesRequired;
+    auto uwbDeviceCapabilitiesBuffer = std::make_unique<uint8_t[]>(uwbCapabilitiesSize);
+    ioResult = DeviceIoControl(m_handleDriver.get(), IOCTL_UWB_GET_DEVICE_CAPABILITIES, nullptr, 0, uwbDeviceCapabilitiesBuffer.get(), uwbCapabilitiesSize, &bytesRequired, nullptr);
+    if (!ioResult) {
+        // TODO: need to do something different here
+        HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
+        PLOG_ERROR << "error when sending IOCTL_UWB_GET_DEVICE_CAPABILITIES, hr=" << std::showbase << std::hex << hr;
+        return resultFuture;
+    }
+
+    const UWB_DEVICE_CAPABILITIES& uwbDeviceCapabilities = *reinterpret_cast<UWB_DEVICE_CAPABILITIES*>(uwbDeviceCapabilitiesBuffer.get());
+    auto deviceCapabilities = UwbCxDdi::To(uwbDeviceCapabilities);
+    auto uwbStatus = UwbCxDdi::To(uwbDeviceCapabilities.status);
+    auto result = std::make_tuple(uwbStatus, std::move(deviceCapabilities));
+    resultPromise.set_value(std::move(result));
+
+    return resultFuture;
+}
+
+std::future<UwbStatus>
+UwbDeviceConnector::GetSessionCount(uint32_t& sessionCount)
+{
+    std::promise<UwbStatus> resultPromise;
+    auto resultFuture = resultPromise.get_future();
+    // TODO: invoke IOCTL_UWB_GET_SESSION_COUNT
+
+    return resultFuture;
+}
+
+std::future<UwbStatus>
+UwbDeviceConnector::SessionIntitialize(uint32_t sessionId, UwbSessionType sessionType)
+{
+    std::promise<UwbStatus> resultPromise;
+    auto resultFuture = resultPromise.get_future();
+    // TODO: invoke IOCTL_UWB_SESSION_INIT
+
+    return resultFuture;
+}
+
+std::future<UwbStatus>
+UwbDeviceConnector::SessionDeinitialize(uint32_t sessionId)
+{
+    std::promise<UwbStatus> resultPromise;
+    auto resultFuture = resultPromise.get_future();
+    // TODO: invoke IOCTL_UWB_SESSION_DEINIT
+
+    return resultFuture;
+}
+
+std::future<std::tuple<UwbStatus, std::optional<UwbSessionState>>>
+UwbDeviceConnector::SessionGetState(uint32_t sessionId)
+{
+    std::promise<std::tuple<UwbStatus, std::optional<UwbSessionState>>> resultPromise;
+    auto resultFuture = resultPromise.get_future();
+    // TODO: invoke IOCTL_UWB_GET_SESSION_STATE
+
+    return resultFuture;
+}
+
+std::future<UwbStatus>
+UwbDeviceConnector::SessionRangingStart(uint32_t sessionId)
+{
+    std::promise<UwbStatus> resultPromise;
+    auto resultFuture = resultPromise.get_future();
+    // TODO: invoke IOCTL_UWB_START_RANGING_SESSION
+
+    return resultFuture;
+}
+
+std::future<UwbStatus>
+UwbDeviceConnector::SessionRangingStop(uint32_t sessionId)
+{
+    std::promise<UwbStatus> resultPromise;
+    auto resultFuture = resultPromise.get_future();
+    // TODO: invoke IOCTL_UWB_STOP_RANGING_SESSION
+
+    return resultFuture;
+}
+
+std::future<std::tuple<UwbStatus, std::optional<uint32_t>>>
+UwbDeviceConnector::SessionGetRangingCount(uint32_t sessionId)
+{
+    std::promise<std::tuple<UwbStatus, std::optional<uint32_t>>> resultPromise;
+    auto resultFuture = resultPromise.get_future();
+    // TODO: invoke IOCTL_UWB_GET_RANGING_COUNT
+
+    return resultFuture;
+}
+
+std::future<UwbSessionUpdateMulicastListStatus>
+UwbDeviceConnector::SessionUpdateControllerMulticastList(uint32_t sessionId, UwbMulticastAction multicastAction, std::vector<::uwb::UwbMacAddress> controlees)
+{
+    std::promise<UwbSessionUpdateMulicastListStatus> resultPromise;
+    auto resultFuture = resultPromise.get_future();
+    // TODO: invoke IOCTL_UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST
+
+    return resultFuture;
+}
+
+void
+UwbDeviceConnector::HandleNotifications()
+{
+    for (;;) {
+        // TODO: check exit condition
+
+        // Determine the amount of memory required for the UWB_NOTIFICATION_DATA from the driver.
+        DWORD bytesRequired = 0;
+        BOOL ioResult = DeviceIoControl(m_handleDriverNotifications.get(), IOCTL_UWB_NOTIFICATION, nullptr, 0, nullptr, 0, &bytesRequired, nullptr);
+        if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
+            HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
+            PLOG_ERROR << "error determining output buffer size for UWB notification, hr=" << std::showbase << std::hex << hr;
+            continue;
+        }
+
+        // Allocate memory for the UWB_NOTIFICATION_DATA structure, and pass this to the driver request.
+        DWORD uwbNotificationDataSize = bytesRequired;
+        std::vector<uint8_t> uwbNotificationDataBuffer(uwbNotificationDataSize);
+        ioResult = DeviceIoControl(m_handleDriverNotifications.get(), IOCTL_UWB_NOTIFICATION, nullptr, 0, std::data(uwbNotificationDataBuffer), uwbNotificationDataSize, &bytesRequired, nullptr);
+        if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
+            HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
+            PLOG_ERROR << "error obtaining UWB notification buffer, hr=" << std::showbase << std::hex << hr;
+            continue;
+        }
+
+        // Log a message if the output buffer is not aligned to UWB_NOTIFICATION_DATA. Ignore it for now as this should not occur often.
+        if (reinterpret_cast<uintptr_t>(std::data(uwbNotificationDataBuffer)) % alignof(UWB_NOTIFICATION_DATA) != 0) {
+            PLOG_ERROR << "driver output buffer is unaligned! undefined behavior may result";
+        }
+
+        // Convert to neutral type and process the notification.
+        const UWB_NOTIFICATION_DATA& notificationData = *reinterpret_cast<UWB_NOTIFICATION_DATA*>(std::data(uwbNotificationDataBuffer));
+        auto uwbNotificationData = UwbCxDdi::To(notificationData);
+
+        // TODO: push this outside the class somewhere. This is where the pub/sub model comes into play.
+        // OLD code below:
+        // Invoke base class notification handler which takes care of threading.
+        // ::UwbDevice::OnUwbNotification(std::move(uwbNotificationData));
+    }
+}

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -131,10 +131,10 @@ UwbDeviceConnector::GetCapabilities()
     return resultFuture;
 }
 
-std::future<UwbStatus>
-UwbDeviceConnector::GetSessionCount(uint32_t& sessionCount)
+std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::optional<uint32_t>>>
+UwbDeviceConnector::GetSessionCount()
 {
-    std::promise<UwbStatus> resultPromise;
+    std::promise<std::tuple<::uwb::protocol::fira::UwbStatus, std::optional<uint32_t>>> resultPromise;
     auto resultFuture = resultPromise.get_future();
     // TODO: invoke IOCTL_UWB_GET_SESSION_COUNT
 

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -189,8 +189,18 @@ UwbDeviceConnector::SessionUpdateControllerMulticastList(uint32_t sessionId, Uwb
     return resultFuture;
 }
 
+std::future<std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus, std::shared_ptr<IUwbAppConfigurationParameter>>>>
+UwbDeviceConnector::SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> applicationConfigurationParameters)
+{
+    std::promise<std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus, std::shared_ptr<IUwbAppConfigurationParameter>>>> resultPromise;
+    auto resultFuture = resultPromise.get_future();
+    // TODO: invoke IOCTL_UWB_SET_APP_CONFIG_PARAMS
+
+    return resultFuture;
+}
+
 void
-UwbDeviceConnector::HandleNotifications(wil::shared_hfile handleDriver, std::stop_token stopToken, std::function<void(::uwb::protocol::fira::UwbNotificationData)> onNotification)
+UwbDeviceConnector::HandleNotifications(wil::shared_hfile handleDriver, std::stop_token stopToken, std::function<void(UwbNotificationData)> onNotification)
 {
     // TODO: the below loop invokes the IOCTL synchronously, blocking on a
     // result. There is no known way to cancel the blocking call on the client

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -22,54 +22,25 @@ UwbDeviceConnector::UwbDeviceConnector(std::string deviceName) :
     m_deviceName(std::move(deviceName))
 {}
 
-wil::shared_hfile
-UwbDeviceConnector::DriverHandle() noexcept
+HRESULT
+UwbDeviceConnector::OpenDriverHandle(wil::shared_hfile &driverHandle, bool isOverlapped = false) noexcept
 {
-    return m_handleDriver;
-}
-
-wil::shared_hfile
-UwbDeviceConnector::DriverHandleNotifications() noexcept
-{
-    return m_handleDriverNotifications;
+    driverHandle.reset(CreateFileA(
+        m_deviceName.c_str(),
+        GENERIC_READ | GENERIC_WRITE,
+        FILE_SHARE_READ | FILE_SHARE_WRITE,
+        nullptr,
+        OPEN_EXISTING,
+        isOverlapped ? FILE_FLAG_OVERLAPPED : FILE_ATTRIBUTE_NORMAL,
+        nullptr));
+    RETURN_LAST_ERROR_IF(driverHandle.get() == INVALID_HANDLE_VALUE);
+    return S_OK;
 }
 
 const std::string&
 UwbDeviceConnector::DeviceName() const noexcept
 {
     return m_deviceName;
-}
-
-void
-UwbDeviceConnector::Initialize()
-{
-    wil::shared_hfile handleDriver(CreateFileA(
-        m_deviceName.c_str(),
-        GENERIC_READ | GENERIC_WRITE,
-        FILE_SHARE_READ | FILE_SHARE_WRITE,
-        nullptr,
-        OPEN_EXISTING,
-        FILE_FLAG_OVERLAPPED,
-        nullptr));
-
-    wil::shared_hfile handleDriverNotifications(CreateFileA(
-        m_deviceName.c_str(),
-        GENERIC_READ | GENERIC_WRITE,
-        FILE_SHARE_READ | FILE_SHARE_WRITE,
-        nullptr,
-        OPEN_EXISTING,
-        FILE_ATTRIBUTE_NORMAL,
-        nullptr));
-
-    // TODO: call CM_Register_Notification(handleDriver, filterType=CM_NOTIFY_FILTER_TYPE_DEVICEHANDLE)
-    //   - handle CM_NOTIFY_ACTION_DEVICEQUERYREMOVE -> close handleDriver since device removal is requested
-    //   - handle CM_NOTIFY_ACTION_DEVICEQUERYREMOVEFAILED -> query removal failed
-
-    m_handleDriver = std::move(handleDriver);
-    m_handleDriverNotifications = std::move(handleDriverNotifications);
-    m_notificationThread = std::jthread([this] {
-        HandleNotifications();
-    });
 }
 
 std::future<UwbStatus>
@@ -101,9 +72,16 @@ UwbDeviceConnector::GetCapabilities()
     std::promise<std::tuple<::uwb::protocol::fira::UwbStatus, ::uwb::protocol::fira::UwbCapability>> resultPromise{};
     auto resultFuture = resultPromise.get_future();
 
+    wil::shared_hfile handleDriver;
+    auto hr = OpenDriverHandle(handleDriver);
+    if (FAILED(hr)) {
+        PLOG_ERROR << "failed to obtain driver handle for " << m_deviceName << ", hr=" << hr;
+        return resultFuture;
+    }
+
     // Determine the amount of memory required for the UWB_DEVICE_CAPABILITIES from the driver.
     DWORD bytesRequired = 0;
-    BOOL ioResult = DeviceIoControl(m_handleDriver.get(), IOCTL_UWB_GET_DEVICE_CAPABILITIES, nullptr, 0, nullptr, 0, &bytesRequired, nullptr);
+    BOOL ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_GET_DEVICE_CAPABILITIES, nullptr, 0, nullptr, 0, &bytesRequired, nullptr);
     if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
         // TODO: need to do something different here
         HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
@@ -114,7 +92,7 @@ UwbDeviceConnector::GetCapabilities()
     // Allocate memory for the UWB_DEVICE_CAPABILITIES structure, and pass this to the driver request.
     DWORD uwbCapabilitiesSize = bytesRequired;
     auto uwbDeviceCapabilitiesBuffer = std::make_unique<uint8_t[]>(uwbCapabilitiesSize);
-    ioResult = DeviceIoControl(m_handleDriver.get(), IOCTL_UWB_GET_DEVICE_CAPABILITIES, nullptr, 0, uwbDeviceCapabilitiesBuffer.get(), uwbCapabilitiesSize, &bytesRequired, nullptr);
+    ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_GET_DEVICE_CAPABILITIES, nullptr, 0, uwbDeviceCapabilitiesBuffer.get(), uwbCapabilitiesSize, &bytesRequired, nullptr);
     if (!ioResult) {
         // TODO: need to do something different here
         HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
@@ -212,14 +190,19 @@ UwbDeviceConnector::SessionUpdateControllerMulticastList(uint32_t sessionId, Uwb
 }
 
 void
-UwbDeviceConnector::HandleNotifications()
+UwbDeviceConnector::HandleNotifications(wil::shared_hfile handleDriver, std::stop_token stopToken, std::function<void(::uwb::protocol::fira::UwbNotificationData)> onNotification)
 {
-    for (;;) {
-        // TODO: check exit condition
-
+    // TODO: the below loop invokes the IOCTL synchronously, blocking on a
+    // result. There is no known way to cancel the blocking call on the client
+    // side; as such, even when stop is requested on the stop token, it cannot
+    // be evaluated since the blocking call won't be interrupted.
+    //
+    // The correct solution here is to open the handle in overlapped mode, and
+    // make a non-blocking call. This is not trivial, so will be done later.
+    while (!stopToken.stop_requested()) {
         // Determine the amount of memory required for the UWB_NOTIFICATION_DATA from the driver.
         DWORD bytesRequired = 0;
-        BOOL ioResult = DeviceIoControl(m_handleDriverNotifications.get(), IOCTL_UWB_NOTIFICATION, nullptr, 0, nullptr, 0, &bytesRequired, nullptr);
+        BOOL ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_NOTIFICATION, nullptr, 0, nullptr, 0, &bytesRequired, nullptr);
         if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
             HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
             PLOG_ERROR << "error determining output buffer size for UWB notification, hr=" << std::showbase << std::hex << hr;
@@ -229,7 +212,7 @@ UwbDeviceConnector::HandleNotifications()
         // Allocate memory for the UWB_NOTIFICATION_DATA structure, and pass this to the driver request.
         DWORD uwbNotificationDataSize = bytesRequired;
         std::vector<uint8_t> uwbNotificationDataBuffer(uwbNotificationDataSize);
-        ioResult = DeviceIoControl(m_handleDriverNotifications.get(), IOCTL_UWB_NOTIFICATION, nullptr, 0, std::data(uwbNotificationDataBuffer), uwbNotificationDataSize, &bytesRequired, nullptr);
+        ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_NOTIFICATION, nullptr, 0, std::data(uwbNotificationDataBuffer), uwbNotificationDataSize, &bytesRequired, nullptr);
         if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
             HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
             PLOG_ERROR << "error obtaining UWB notification buffer, hr=" << std::showbase << std::hex << hr;
@@ -245,9 +228,6 @@ UwbDeviceConnector::HandleNotifications()
         const UWB_NOTIFICATION_DATA& notificationData = *reinterpret_cast<UWB_NOTIFICATION_DATA*>(std::data(uwbNotificationDataBuffer));
         auto uwbNotificationData = UwbCxDdi::To(notificationData);
 
-        // TODO: push this outside the class somewhere. This is where the pub/sub model comes into play.
-        // OLD code below:
-        // Invoke base class notification handler which takes care of threading.
-        // ::UwbDevice::OnUwbNotification(std::move(uwbNotificationData));
+        onNotification(std::move(uwbNotificationData));
     }
 }

--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -12,135 +12,159 @@
 #include <windows/devices/uwb/UwbSession.hxx>
 
 using namespace windows::devices::uwb;
+using namespace ::uwb::protocol::fira;
 
-UwbSession::UwbSession(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, wil::shared_hfile handleDriver) :
+UwbSession::UwbSession(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, std::shared_ptr<UwbDeviceConnector> uwbDeviceConnector) :
     ::uwb::UwbSession(std::move(callbacks)),
-    m_handleDriver(std::move(handleDriver))
+    m_uwbDeviceConnector(std::move(uwbDeviceConnector))
 {}
 
-wil::shared_hfile
-UwbSession::HandleDriver() noexcept
+std::shared_ptr<UwbDeviceConnector>
+UwbSession::GetUwbDeviceConnector() noexcept
 {
-    return m_handleDriver;
+    return m_uwbDeviceConnector;
 }
 
 void
-UwbSession::ConfigureImpl(const ::uwb::protocol::fira::UwbSessionData &uwbSessionData)
+UwbSession::ConfigureImpl(const ::uwb::protocol::fira::UwbSessionData& uwbSessionData)
 {
     PLOG_VERBOSE << "ConfigureImpl";
 
-    // Populate the session initialization command argument.
-    UWB_SESSION_INIT sessionInit;
-    sessionInit.sessionId = uwbSessionData.sessionId;
-    sessionInit.sessionType = UWB_SESSION_TYPE_RANGING_SESSION;
+    uint32_t sessionId = uwbSessionData.sessionId;
+    UwbSessionType sessionType = UwbSessionType::RangingSession;
 
     // Request a new session from the driver.
-    BOOL ioResult = DeviceIoControl(m_handleDriver.get(), IOCTL_UWB_SESSION_INIT, &sessionInit, sizeof sessionInit, nullptr, 0, nullptr, nullptr);
-    if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
-        // TODO: handle this
-        HRESULT hr = GetLastError();
-        PLOG_ERROR << "could not request a new session from the driver, hr=" << std::showbase << std::hex << hr;
+    auto sessionInitResultFuture = m_uwbDeviceConnector->SessionIntitialize(sessionId, sessionType);
+    if (!sessionInitResultFuture.valid()) {
+        // TODO: need to signal to upper layer that this failed instead of just returning
+        PLOG_ERROR << "failed to initialize session";
+        return;
     }
 
-    m_sessionId = uwbSessionData.sessionId;
+    m_sessionId = sessionId;
 
-    // Populate the PUWB_SET_APP_CONFIG_PARAMS
-    auto setParamsAdaptor = GenerateUwbSetAppConfigParameterDdi(uwbSessionData);
-    auto &setParamsBuffer = setParamsAdaptor.DdiBuffer();
-    auto &setParams = setParamsAdaptor.DdiParameters();
+    // TODO: convert code below to invoke IOCTL_UWB_SET_APP_CONFIG_PARAMS to use connector
 
-    // Allocate memory for the PUWB_SET_APP_CONFIG_PARAMS_STATUS
-    auto statusSize = offsetof(UWB_SET_APP_CONFIG_PARAMS_STATUS, appConfigParamsStatus[setParams.appConfigParamsCount]);
-    auto statusBuffer = std::make_unique<uint8_t[]>(statusSize);
-    auto &statusHolder = *reinterpret_cast<UWB_SET_APP_CONFIG_PARAMS_STATUS *>(statusBuffer.get());
-    statusHolder.size = statusSize;
-    statusHolder.appConfigParamsCount = setParams.appConfigParamsCount;
+    // // Populate the PUWB_SET_APP_CONFIG_PARAMS
+    // auto setParamsAdaptor = GenerateUwbSetAppConfigParameterDdi(uwbSessionData);
+    // auto &setParamsBuffer = setParamsAdaptor.DdiBuffer();
+    // auto &setParams = setParamsAdaptor.DdiParameters();
 
-    ioResult = DeviceIoControl(m_handleDriver.get(), IOCTL_UWB_SET_APP_CONFIG_PARAMS, std::data(setParamsBuffer), std::size(setParamsBuffer), statusBuffer.get(), statusSize, nullptr, nullptr);
-    if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
-        // TODO: handle this
-        HRESULT hr = GetLastError();
-        PLOG_ERROR << "could not send params to driver, hr=" << std::showbase << std::hex << hr;
-    }
+    // // Allocate memory for the PUWB_SET_APP_CONFIG_PARAMS_STATUS
+    // auto statusSize = offsetof(UWB_SET_APP_CONFIG_PARAMS_STATUS, appConfigParamsStatus[setParams.appConfigParamsCount]);
+    // auto statusBuffer = std::make_unique<uint8_t[]>(statusSize);
+    // auto &statusHolder = *reinterpret_cast<UWB_SET_APP_CONFIG_PARAMS_STATUS *>(statusBuffer.get());
+    // statusHolder.size = statusSize;
+    // statusHolder.appConfigParamsCount = setParams.appConfigParamsCount;
+
+    // ioResult = DeviceIoControl(m_handleDriver.get(), IOCTL_UWB_SET_APP_CONFIG_PARAMS, std::data(setParamsBuffer), std::size(setParamsBuffer), statusBuffer.get(), statusSize, nullptr, nullptr);
+    // if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
+    //     // TODO: handle this
+    //     HRESULT hr = GetLastError();
+    //     PLOG_ERROR << "could not send params to driver, hr=" << std::showbase << std::hex << hr;
+    // }
 }
 
 void
 UwbSession::StartRangingImpl()
 {
-    UWB_START_RANGING_SESSION startRangingSession;
-    startRangingSession.sessionId = GetId();
-    BOOL ioResult = DeviceIoControl(m_handleDriver.get(), IOCTL_UWB_START_RANGING_SESSION, &startRangingSession, sizeof startRangingSession, nullptr, 0, nullptr, nullptr);
-    if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
-        // TODO: determine error signaling strategy, and signal error
-        HRESULT hr = GetLastError();
-        PLOG_ERROR << "could not send start ranging command to driver, hr=" << std::showbase << std::hex << hr;
+    // TODO: interface function should be modified to return a UwbStatus, and this value will be returned.
+    UwbStatus status;
+    uint32_t sessionId = GetId();
+    auto resultFuture = m_uwbDeviceConnector->SessionRangingStart(sessionId);
+    if (!resultFuture.valid()) {
+        PLOG_ERROR << "failed to start ranging for session id " << sessionId;
+        status = UwbStatusGeneric::Failed;
+        return; /* TODO: uwbStatus */
     }
+
+    try {
+        status = resultFuture.get();
+    } catch (std::exception& e) {
+        PLOG_ERROR << "caught exception attempting to start ranging for session id " << sessionId << "(" << e.what() << ")";
+        status = UwbStatusGeneric::Failed;
+    }
+
+    // TODO: return uwbStatus;
 }
 
 void
 UwbSession::StopRangingImpl()
 {
-    UWB_STOP_RANGING_SESSION stopRangingSession;
-    stopRangingSession.sessionId = GetId();
-    BOOL ioResult = DeviceIoControl(m_handleDriver.get(), IOCTL_UWB_STOP_RANGING_SESSION, &stopRangingSession, sizeof stopRangingSession, nullptr, 0, nullptr, nullptr);
-    if (LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
-        // TODO
-        HRESULT hr = GetLastError();
-        PLOG_ERROR << "could not send stop ranging command to driver, hr=" << std::showbase << std::hex << hr;
+    // TODO: interface function should be modified to return a UwbStatus, and this value will be returned.
+    UwbStatus status;
+    uint32_t sessionId = GetId();
+    auto resultFuture = m_uwbDeviceConnector->SessionRangingStop(sessionId);
+    if (!resultFuture.valid()) {
+        PLOG_ERROR << "failed to stop ranging for session id " << sessionId;
+        status = UwbStatusGeneric::Failed;
+        return; /* TODO: uwbStatus */
     }
+
+    try {
+        status = resultFuture.get();
+    } catch (std::exception& e) {
+        PLOG_ERROR << "caught exception attempting to stop ranging for session id " << sessionId << "(" << e.what() << ")";
+        status = UwbStatusGeneric::Failed;
+    }
+
+    // TODO: return uwbStatus;
 }
 
 void
-    UwbSession::AddPeerImpl(::uwb::UwbMacAddress /* peerMacAddress */)
+UwbSession::AddPeerImpl([[maybe_unused]] ::uwb::UwbMacAddress peerMacAddress)
 {
     PLOG_VERBOSE << "AddPeerImpl";
-    // TODO: two main options for updating the UWB-CLX peer list:
-    //  1) Every time a peer is added (on-demand)
-    //  2) Only when StartRanging() is called.
-    // Below sample code exemplifies 1) for simplicity but this is not necessarily the way to go.
-    //
-    // TODO: request UWB-CLX to update controlee list per below pseudo-code,
-    // which is *very* rough and some parts probably plain wrong:
-    //
-    const auto macAddressLength = m_uwbMacAddressSelf.GetLength();
-    const auto macAddressessLength = macAddressLength * m_peers.size();
 
-    std::size_t appConfigParamsSize = 0;
-    appConfigParamsSize += macAddressessLength;
-    // TODO: all other memory required for this structure must be accounted for, the above calculation was left incomplete.
-    // Also, proper memory alignment of trailing structures in the allocated buffer has not been taken into account.
-    auto appConfigParamsBuffer = std::make_unique<uint8_t[]>(appConfigParamsSize);
-    auto *appConfigParams = reinterpret_cast<UWB_SET_APP_CONFIG_PARAMS *>(appConfigParamsBuffer.get());
-    appConfigParams->sessionId = GetId();
-    appConfigParams->appConfigParamsCount = 2;
-    UWB_APP_CONFIG_PARAM *appConfigParamList = reinterpret_cast<UWB_APP_CONFIG_PARAM *>(appConfigParams + 1);
-    UWB_APP_CONFIG_PARAM *appConfigParamNumberOfControlees = appConfigParamList + 0;
-    UWB_APP_CONFIG_PARAM *appConfigParamDstMacAddress = appConfigParamList + 1;
+    // TODO: convert code below to invoke IOCTL_UWB_SET_APP_CONFIG_PARAMS to use connector
 
-    // Populate NUMBER_OF_CONTROLEES app configuration parameter.
-    auto &numberOfControleesPayload = *reinterpret_cast<uint8_t *>(appConfigParamNumberOfControlees + 1);
-    appConfigParamNumberOfControlees->paramType = UWB_APP_CONFIG_PARAM_TYPE_NUMBER_OF_CONTROLEES;
-    appConfigParamNumberOfControlees->paramLength = 1;
-    numberOfControleesPayload = static_cast<uint8_t>(m_peers.size());
+    // // TODO: two main options for updating the UWB-CLX peer list:
+    // //  1) Every time a peer is added (on-demand)
+    // //  2) Only when StartRanging() is called.
+    // // Below sample code exemplifies 1) for simplicity but this is not necessarily the way to go.
+    // //
+    // // TODO: request UWB-CLX to update controlee list per below pseudo-code,
+    // // which is *very* rough and some parts probably plain wrong:
+    // //
+    // const auto macAddressLength = m_uwbMacAddressSelf.GetLength();
+    // const auto macAddressessLength = macAddressLength * m_peers.size();
 
-    // Populate DST_MAC_ADDRESS app configuration parameter.
-    auto dstMacAddressPayload = reinterpret_cast<uint8_t *>(appConfigParamDstMacAddress + 1);
-    appConfigParamDstMacAddress->paramType = UWB_APP_CONFIG_PARAM_TYPE_DST_MAC_ADDRESS;
-    appConfigParamDstMacAddress->paramLength = static_cast<uint32_t>(macAddressessLength);
-    auto dstMacAddress = dstMacAddressPayload;
-    for (const auto &peer : m_peers) {
-        const auto value = peer.GetValue();
-        std::copy(std::cbegin(value), std::cend(value), dstMacAddress);
-        std::advance(dstMacAddress, std::size(value));
-    }
+    // std::size_t appConfigParamsSize = 0;
+    // appConfigParamsSize += macAddressessLength;
+    // // TODO: all other memory required for this structure must be accounted for, the above calculation was left incomplete.
+    // // Also, proper memory alignment of trailing structures in the allocated buffer has not been taken into account.
+    // auto appConfigParamsBuffer = std::make_unique<uint8_t[]>(appConfigParamsSize);
+    // auto *appConfigParams = reinterpret_cast<UWB_SET_APP_CONFIG_PARAMS *>(appConfigParamsBuffer.get());
+    // appConfigParams->sessionId = GetId();
+    // appConfigParams->appConfigParamsCount = 2;
+    // UWB_APP_CONFIG_PARAM *appConfigParamList = reinterpret_cast<UWB_APP_CONFIG_PARAM *>(appConfigParams + 1);
+    // UWB_APP_CONFIG_PARAM *appConfigParamNumberOfControlees = appConfigParamList + 0;
+    // UWB_APP_CONFIG_PARAM *appConfigParamDstMacAddress = appConfigParamList + 1;
 
-    // Attempt to set all new parameters.
-    DWORD bytesReturned = 0;
-    UWB_SET_APP_CONFIG_PARAMS_STATUS appConfigParamsStatus; // TODO: this needs to be dynamically allocated to fit returned content
-    BOOL ioResult = DeviceIoControl(m_handleDriver.get(), IOCTL_UWB_SET_APP_CONFIG_PARAMS, &appConfigParams, static_cast<DWORD>(appConfigParamsSize), &appConfigParamsStatus, sizeof appConfigParamsStatus, &bytesReturned, nullptr);
-    if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
-        // TODO
-        HRESULT hr = GetLastError();
-        PLOG_ERROR << "could not send params to driver, hr=" << std::showbase << std::hex << hr;
-    }
+    // // Populate NUMBER_OF_CONTROLEES app configuration parameter.
+    // auto &numberOfControleesPayload = *reinterpret_cast<uint8_t *>(appConfigParamNumberOfControlees + 1);
+    // appConfigParamNumberOfControlees->paramType = UWB_APP_CONFIG_PARAM_TYPE_NUMBER_OF_CONTROLEES;
+    // appConfigParamNumberOfControlees->paramLength = 1;
+    // numberOfControleesPayload = static_cast<uint8_t>(m_peers.size());
+
+    // // Populate DST_MAC_ADDRESS app configuration parameter.
+    // auto dstMacAddressPayload = reinterpret_cast<uint8_t *>(appConfigParamDstMacAddress + 1);
+    // appConfigParamDstMacAddress->paramType = UWB_APP_CONFIG_PARAM_TYPE_DST_MAC_ADDRESS;
+    // appConfigParamDstMacAddress->paramLength = static_cast<uint32_t>(macAddressessLength);
+    // auto dstMacAddress = dstMacAddressPayload;
+    // for (const auto &peer : m_peers) {
+    //     const auto value = peer.GetValue();
+    //     std::copy(std::cbegin(value), std::cend(value), dstMacAddress);
+    //     std::advance(dstMacAddress, std::size(value));
+    // }
+
+    // // Attempt to set all new parameters.
+    // DWORD bytesReturned = 0;
+    // UWB_SET_APP_CONFIG_PARAMS_STATUS appConfigParamsStatus; // TODO: this needs to be dynamically allocated to fit returned content
+    // BOOL ioResult = DeviceIoControl(m_handleDriver.get(), IOCTL_UWB_SET_APP_CONFIG_PARAMS, &appConfigParams, static_cast<DWORD>(appConfigParamsSize), &appConfigParamsStatus, sizeof appConfigParamsStatus, &bytesReturned, nullptr);
+    // if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
+    //     // TODO
+    //     HRESULT hr = GetLastError();
+    //     PLOG_ERROR << "could not send params to driver, hr=" << std::showbase << std::hex << hr;
+    // }
 }

--- a/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
@@ -34,7 +34,7 @@ struct IUwbDeviceDdi
     // IOCTL_UWB_SESSION_INIT
     virtual std::future<::uwb::protocol::fira::UwbStatus>
     SessionIntitialize(uint32_t sessionId, ::uwb::protocol::fira::UwbSessionType sessionType) = 0;
-    
+
     // IOCTL_UWB_SESSION_DEINIT
     virtual std::future<::uwb::protocol::fira::UwbStatus>
     SessionDeinitialize(uint32_t sessionId) = 0;

--- a/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
@@ -4,12 +4,15 @@
 
 #include <cstdint>
 #include <future>
+#include <memory>
 #include <optional>
 #include <tuple>
 #include <vector>
 
 #include <uwb/protocols/fira/FiraDevice.hxx>
+#include <uwb/protocols/fira/UwbApplicationConfiguration.hxx>
 #include <uwb/protocols/fira/UwbCapability.hxx>
+#include <windows/devices/uwb/UwbAppConfiguration.hxx>
 
 namespace windows::devices::uwb
 {
@@ -62,7 +65,11 @@ struct IUwbDeviceDdi
     // TODO: unspecified IOCTLs below
     // IOCTL_UWB_SET_DEVICE_CONFIG_PARAMS
     // IOCTL_UWB_GET_DEVICE_CONFIG_PARAMS
+
     // IOCTL_UWB_SET_APP_CONFIG_PARAMS
+    virtual std::future<std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus, std::shared_ptr<IUwbAppConfigurationParameter>>>>
+    SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> applicationConfigurationParameters) = 0;
+
     // IOCTL_UWB_GET_APP_CONFIG_PARAMS
 };
 } // namespace windows::devices::uwb

--- a/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
@@ -1,0 +1,70 @@
+
+#ifndef I_UWB_DEVICE_DDI_HXX
+#define I_UWB_DEVICE_DDI_HXX
+
+#include <cstdint>
+#include <future>
+#include <optional>
+#include <tuple>
+#include <vector>
+
+#include <uwb/protocols/fira/FiraDevice.hxx>
+#include <uwb/protocols/fira/UwbCapability.hxx>
+
+namespace windows::devices::uwb
+{
+struct IUwbDeviceDdi
+{
+    // IOCTL_UWB_DEVICE_RESET
+    virtual std::future<::uwb::protocol::fira::UwbStatus>
+    Reset() = 0;
+
+    // IOCTL_UWB_GET_DEVICE_INFO
+    virtual std::future<::uwb::protocol::fira::UwbDeviceInformation>
+    GetDeviceInformation() = 0;
+
+    // IOCTL_UWB_GET_DEVICE_CAPABILITIES
+    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, ::uwb::protocol::fira::UwbCapability>>
+    GetCapabilities() = 0;
+
+    // IOCTL_UWB_GET_SESSION_COUNT
+    virtual std::future<::uwb::protocol::fira::UwbStatus>
+    GetSessionCount(uint32_t &sessionCount) = 0;
+
+    // IOCTL_UWB_SESSION_INIT
+    virtual std::future<::uwb::protocol::fira::UwbStatus>
+    SessionIntitialize(uint32_t sessionId, ::uwb::protocol::fira::UwbSessionType sessionType) = 0;
+    
+    // IOCTL_UWB_SESSION_DEINIT
+    virtual std::future<::uwb::protocol::fira::UwbStatus>
+    SessionDeinitialize(uint32_t sessionId) = 0;
+
+    // IOCTL_UWB_GET_SESSION_STATE
+    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::optional<::uwb::protocol::fira::UwbSessionState>>>
+    SessionGetState(uint32_t sessionId) = 0;
+
+    // IOCTL_UWB_START_RANGING_SESSION
+    virtual std::future<::uwb::protocol::fira::UwbStatus>
+    SessionRangingStart(uint32_t sessionId) = 0;
+
+    // IOCTL_UWB_STOP_RANGING_SESSION
+    virtual std::future<::uwb::protocol::fira::UwbStatus>
+    SessionRangingStop(uint32_t sessionId) = 0;
+
+    // IOCTL_UWB_GET_RANGING_COUNT
+    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::optional<uint32_t>>>
+    SessionGetRangingCount(uint32_t sessionId) = 0;
+
+    // IOCTL_UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST
+    virtual std::future<::uwb::protocol::fira::UwbSessionUpdateMulicastListStatus>
+    SessionUpdateControllerMulticastList(uint32_t sessionId, ::uwb::protocol::fira::UwbMulticastAction multicastAction, std::vector<::uwb::UwbMacAddress> controlees) = 0;
+
+    // TODO: unspecified IOCTLs below
+    // IOCTL_UWB_SET_DEVICE_CONFIG_PARAMS
+    // IOCTL_UWB_GET_DEVICE_CONFIG_PARAMS
+    // IOCTL_UWB_SET_APP_CONFIG_PARAMS
+    // IOCTL_UWB_GET_APP_CONFIG_PARAMS
+};
+} // namespace windows::devices::uwb
+
+#endif // I_UWB_DEVICE_DDI_HXX

--- a/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
@@ -62,15 +62,17 @@ struct IUwbDeviceDdi
     virtual std::future<::uwb::protocol::fira::UwbSessionUpdateMulicastListStatus>
     SessionUpdateControllerMulticastList(uint32_t sessionId, ::uwb::protocol::fira::UwbMulticastAction multicastAction, std::vector<::uwb::UwbMacAddress> controlees) = 0;
 
-    // TODO: unspecified IOCTLs below
-    // IOCTL_UWB_SET_DEVICE_CONFIG_PARAMS
-    // IOCTL_UWB_GET_DEVICE_CONFIG_PARAMS
+    // IOCTL_UWB_GET_APP_CONFIG_PARAMS
+    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>>>>
+    GetApplicationConfigurationParameters(uint32_t sessionId, std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameterType> applicationConfigurationParameterTypes) = 0;
 
     // IOCTL_UWB_SET_APP_CONFIG_PARAMS
     virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>>>
     SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> applicationConfigurationParameters) = 0;
 
-    // IOCTL_UWB_GET_APP_CONFIG_PARAMS
+    // TODO: unspecified IOCTLs below
+    // IOCTL_UWB_SET_DEVICE_CONFIG_PARAMS
+    // IOCTL_UWB_GET_DEVICE_CONFIG_PARAMS
 };
 } // namespace windows::devices::uwb
 

--- a/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
@@ -67,7 +67,7 @@ struct IUwbDeviceDdi
     // IOCTL_UWB_GET_DEVICE_CONFIG_PARAMS
 
     // IOCTL_UWB_SET_APP_CONFIG_PARAMS
-    virtual std::future<std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus, std::shared_ptr<IUwbAppConfigurationParameter>>>>
+    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>>>
     SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> applicationConfigurationParameters) = 0;
 
     // IOCTL_UWB_GET_APP_CONFIG_PARAMS

--- a/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
@@ -28,8 +28,8 @@ struct IUwbDeviceDdi
     GetCapabilities() = 0;
 
     // IOCTL_UWB_GET_SESSION_COUNT
-    virtual std::future<::uwb::protocol::fira::UwbStatus>
-    GetSessionCount(uint32_t &sessionCount) = 0;
+    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::optional<uint32_t>>>
+    GetSessionCount() = 0;
 
     // IOCTL_UWB_SESSION_INIT
     virtual std::future<::uwb::protocol::fira::UwbStatus>

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
@@ -67,31 +67,6 @@ public:
     bool
     IsEqual(const ::uwb::UwbDevice& other) const noexcept override;
 
-protected:
-    /**
-     * @brief Helper function to create a typed (derived) UwbSession object,
-     * capturing the common code that is required in all sub-classes.
-     *
-     * @tparam UwbSessionT The type of session to create.
-     * @param callbacks The session callbacks.
-     * @return requires
-     */
-    template <typename UwbSessionT>
-    // clang-format off
-    requires std::is_base_of_v<::uwb::UwbSession, UwbSessionT>
-    // clang-format on
-    std::shared_ptr<::uwb::UwbSession>
-    CreateSessionImpl(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks)
-    {
-        // Create a duplicate handle to the driver for use by the session.
-        wil::shared_hfile handleDriverForSession;
-        if (!DuplicateHandle(GetCurrentProcess(), m_handleDriver.get(), GetCurrentProcess(), &handleDriverForSession, 0, FALSE, DUPLICATE_SAME_ACCESS)) {
-            return nullptr;
-        }
-
-        return std::make_shared<UwbSessionT>(std::move(callbacks), std::move(handleDriverForSession));
-    }
-
 private:
     /**
      * @brief Create a new UWB session.
@@ -111,35 +86,7 @@ private:
     GetCapabilitiesImpl() override;
 
 private:
-    /**
-     * @brief Thread function for handling UWB notifications from the driver.
-     */
-    void
-    HandleNotifications();
-
-protected:
-    /**
-     * @brief Obtain a shared instance of the primary driver handle.
-     *
-     * @return wil::shared_hfile
-     */
-    wil::shared_hfile
-    DriverHandle() noexcept;
-
-    /**
-     * @brief Obtain a shared instance of the notification driver handle.
-     *
-     * @return wil::shared_hfile
-     */
-    wil::shared_hfile
-    DriverHandleNotifications() noexcept;
-
-private:
     const std::string m_deviceName;
-
-    wil::shared_hfile m_handleDriver;
-    wil::shared_hfile m_handleDriverNotifications;
-    std::jthread m_notificationThread;
     std::shared_ptr<UwbDeviceConnector> m_uwbDeviceConnector;
 };
 } // namespace windows::devices::uwb

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
@@ -18,6 +18,7 @@
 #include <uwb/UwbSession.hxx>
 #include <uwb/protocols/fira/FiraDevice.hxx>
 #include <windows/devices/DeviceResource.hxx>
+#include <windows/devices/uwb/UwbDeviceConnector.hxx>
 
 namespace uwb
 {
@@ -139,6 +140,7 @@ private:
     wil::shared_hfile m_handleDriver;
     wil::shared_hfile m_handleDriverNotifications;
     std::jthread m_notificationThread;
+    std::shared_ptr<UwbDeviceConnector> m_uwbDeviceConnector;
 };
 } // namespace windows::devices::uwb
 

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
@@ -91,7 +91,7 @@ public:
     virtual std::future<::uwb::protocol::fira::UwbSessionUpdateMulicastListStatus>
     SessionUpdateControllerMulticastList(uint32_t sessionId, ::uwb::protocol::fira::UwbMulticastAction multicastAction, std::vector<::uwb::UwbMacAddress> controlees) override;
 
-    virtual std::future<std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus, std::shared_ptr<IUwbAppConfigurationParameter>>>>
+    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>>>
     SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> applicationConfigurationParameters) override;
 
 protected:

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
@@ -29,12 +29,6 @@ public:
     explicit UwbDeviceConnector(std::string deviceName);
     
     /**
-     * @brief Initialize the device.
-     */
-    void
-    Initialize();
-
-    /**
      * @brief Get the name of this device.
      *
      * @return const std::string&
@@ -79,32 +73,28 @@ public:
 
 protected:
     /**
-     * @brief Obtain a shared instance of the primary driver handle.
-     *
-     * @return wil::shared_hfile
+     * @brief Open a new handle to the driver. 
+     * 
+     * @param driverHandle The driver handle to update.
+     * @param isOverlapped Whether overlapped (async) i/o is requested on the handle.
+     * @return HRESULT 
      */
-    wil::shared_hfile
-    DriverHandle() noexcept;
-
-    /**
-     * @brief Obtain a shared instance of the notification driver handle.
-     *
-     * @return wil::shared_hfile
-     */
-    wil::shared_hfile
-    DriverHandleNotifications() noexcept;
+    HRESULT
+    OpenDriverHandle(wil::shared_hfile &driverHandle, bool isOverlapped) noexcept;
 
 private:
     /**
      * @brief Thread function for handling UWB notifications from the driver.
+     * 
+     * @param handleDriver The handle to the driver to use for listening for notifications.
+     * @param stopToken The token used to request the notification loop to stop.
+     * @param onNotification The callback function to invoke for each notification.
      */
     void
-    HandleNotifications();
+    HandleNotifications(wil::shared_hfile handleDriver, std::stop_token stopToken, std::function<void(::uwb::protocol::fira::UwbNotificationData)> onNotification);
 
 private:
     std::string m_deviceName{};
-    wil::shared_hfile m_handleDriver;
-    wil::shared_hfile m_handleDriverNotifications;
     std::jthread m_notificationThread;
 };
 } // namespace windows::devices::uwb

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
@@ -91,6 +91,9 @@ public:
     virtual std::future<::uwb::protocol::fira::UwbSessionUpdateMulicastListStatus>
     SessionUpdateControllerMulticastList(uint32_t sessionId, ::uwb::protocol::fira::UwbMulticastAction multicastAction, std::vector<::uwb::UwbMacAddress> controlees) override;
 
+    virtual std::future<std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus, std::shared_ptr<IUwbAppConfigurationParameter>>>>
+    SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> applicationConfigurationParameters) override;
+
 protected:
     /**
      * @brief Open a new handle to the driver. 

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
@@ -36,6 +36,26 @@ public:
     const std::string&
     DeviceName() const noexcept;
 
+    /**
+     * @brief Start listening for notifications.
+     * 
+     * Note: this is a rudimentary implementation and is only present to
+     * preserve existing behavior. It will eventually be replaced by a
+     * fine-grained publication/subscription model.
+     * 
+     * @param onNotification The handler to invoke for each notification.
+     * @return true If listening for notifications started successfully.
+     * @return false If listening for notifications could not be started.
+     */
+    bool
+    NotificationListenerStart(std::function<void(::uwb::protocol::fira::UwbNotificationData)> onNotification);
+
+    /**
+     * @brief Stop listening for notifications.
+     */
+    void
+    NotificationListenerStop();
+
 public:
     // IUwbDeviceDdi
     virtual std::future<::uwb::protocol::fira::UwbStatus>

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
@@ -1,0 +1,112 @@
+
+#ifndef UWB_DEVICE_CONNECTOR_HXX
+#define UWB_DEVICE_CONNECTOR_HXX
+
+#include <future>
+#include <memory>
+#include <optional>
+#include <string>
+#include <thread>
+#include <tuple>
+#include <vector>
+
+#include <wil/resource.h>
+
+#include <uwb/protocols/fira/UwbCapability.hxx>
+#include <windows/devices/uwb/IUwbDeviceDdi.hxx>
+
+namespace windows::devices::uwb
+{
+class UwbDeviceConnector :
+    public IUwbDeviceDdi
+{
+public:
+    /**
+     * @brief Construct a new UwbDeviceConnector object.
+     * 
+     * @param deviceName The interface path name.
+     */
+    explicit UwbDeviceConnector(std::string deviceName);
+    
+    /**
+     * @brief Initialize the device.
+     */
+    void
+    Initialize();
+
+    /**
+     * @brief Get the name of this device.
+     *
+     * @return const std::string&
+     */
+    const std::string&
+    DeviceName() const noexcept;
+
+public:
+    // IUwbDeviceDdi
+    virtual std::future<::uwb::protocol::fira::UwbStatus>
+    Reset() override;
+
+    virtual std::future<::uwb::protocol::fira::UwbDeviceInformation>
+    GetDeviceInformation() override;
+
+    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, ::uwb::protocol::fira::UwbCapability>>
+    GetCapabilities() override;
+
+    virtual std::future<::uwb::protocol::fira::UwbStatus>
+    GetSessionCount(uint32_t &sessionCount) override;
+
+    virtual std::future<::uwb::protocol::fira::UwbStatus>
+    SessionIntitialize(uint32_t sessionId, ::uwb::protocol::fira::UwbSessionType sessionType) override;
+    
+    virtual std::future<::uwb::protocol::fira::UwbStatus>
+    SessionDeinitialize(uint32_t sessionId) override;
+
+    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::optional<::uwb::protocol::fira::UwbSessionState>>>
+    SessionGetState(uint32_t sessionId) override;
+
+    virtual std::future<::uwb::protocol::fira::UwbStatus>
+    SessionRangingStart(uint32_t sessionId) override;
+
+    virtual std::future<::uwb::protocol::fira::UwbStatus>
+    SessionRangingStop(uint32_t sessionId) override;
+
+    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::optional<uint32_t>>>
+    SessionGetRangingCount(uint32_t sessionId) override;
+
+    virtual std::future<::uwb::protocol::fira::UwbSessionUpdateMulicastListStatus>
+    SessionUpdateControllerMulticastList(uint32_t sessionId, ::uwb::protocol::fira::UwbMulticastAction multicastAction, std::vector<::uwb::UwbMacAddress> controlees) override;
+
+protected:
+    /**
+     * @brief Obtain a shared instance of the primary driver handle.
+     *
+     * @return wil::shared_hfile
+     */
+    wil::shared_hfile
+    DriverHandle() noexcept;
+
+    /**
+     * @brief Obtain a shared instance of the notification driver handle.
+     *
+     * @return wil::shared_hfile
+     */
+    wil::shared_hfile
+    DriverHandleNotifications() noexcept;
+
+private:
+    /**
+     * @brief Thread function for handling UWB notifications from the driver.
+     */
+    void
+    HandleNotifications();
+
+private:
+    std::string m_deviceName{};
+    wil::shared_hfile m_handleDriver;
+    wil::shared_hfile m_handleDriverNotifications;
+    std::jthread m_notificationThread;
+};
+} // namespace windows::devices::uwb
+
+#endif // UWB_DEVICE_CONNECTOR_HXX

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
@@ -91,6 +91,9 @@ public:
     virtual std::future<::uwb::protocol::fira::UwbSessionUpdateMulicastListStatus>
     SessionUpdateControllerMulticastList(uint32_t sessionId, ::uwb::protocol::fira::UwbMulticastAction multicastAction, std::vector<::uwb::UwbMacAddress> controlees) override;
 
+    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>>>>
+    GetApplicationConfigurationParameters(uint32_t sessionId, std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameterType> applicationConfigurationParameterTypes) override;
+
     virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>>>
     SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> applicationConfigurationParameters) override;
 

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
@@ -53,8 +53,8 @@ public:
     virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, ::uwb::protocol::fira::UwbCapability>>
     GetCapabilities() override;
 
-    virtual std::future<::uwb::protocol::fira::UwbStatus>
-    GetSessionCount(uint32_t &sessionCount) override;
+    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::optional<uint32_t>>>
+    GetSessionCount() override;
 
     virtual std::future<::uwb::protocol::fira::UwbStatus>
     SessionIntitialize(uint32_t sessionId, ::uwb::protocol::fira::UwbSessionType sessionType) override;

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
@@ -23,11 +23,11 @@ class UwbDeviceConnector :
 public:
     /**
      * @brief Construct a new UwbDeviceConnector object.
-     * 
+     *
      * @param deviceName The interface path name.
      */
     explicit UwbDeviceConnector(std::string deviceName);
-    
+
     /**
      * @brief Get the name of this device.
      *
@@ -38,11 +38,11 @@ public:
 
     /**
      * @brief Start listening for notifications.
-     * 
+     *
      * Note: this is a rudimentary implementation and is only present to
      * preserve existing behavior. It will eventually be replaced by a
      * fine-grained publication/subscription model.
-     * 
+     *
      * @param onNotification The handler to invoke for each notification.
      * @return true If listening for notifications started successfully.
      * @return false If listening for notifications could not be started.
@@ -72,7 +72,7 @@ public:
 
     virtual std::future<::uwb::protocol::fira::UwbStatus>
     SessionIntitialize(uint32_t sessionId, ::uwb::protocol::fira::UwbSessionType sessionType) override;
-    
+
     virtual std::future<::uwb::protocol::fira::UwbStatus>
     SessionDeinitialize(uint32_t sessionId) override;
 
@@ -99,19 +99,19 @@ public:
 
 protected:
     /**
-     * @brief Open a new handle to the driver. 
-     * 
+     * @brief Open a new handle to the driver.
+     *
      * @param driverHandle The driver handle to update.
      * @param isOverlapped Whether overlapped (async) i/o is requested on the handle.
-     * @return HRESULT 
+     * @return HRESULT
      */
     HRESULT
-    OpenDriverHandle(wil::shared_hfile &driverHandle, bool isOverlapped) noexcept;
+    OpenDriverHandle(wil::shared_hfile& driverHandle, bool isOverlapped) noexcept;
 
 private:
     /**
      * @brief Thread function for handling UWB notifications from the driver.
-     * 
+     *
      * @param handleDriver The handle to the driver to use for listening for notifications.
      * @param stopToken The token used to request the notification loop to stop.
      * @param onNotification The callback function to invoke for each notification.

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
@@ -3,16 +3,13 @@
 #define WINDOWS_UWB_SESSION_HXX
 
 #include <cstdint>
-
-// NB: This must come before any other Windows include
-#include <windows.h>
-
-#include <wil/resource.h>
+#include <memory>
 
 #include <uwb/UwbMacAddress.hxx>
 #include <uwb/UwbSession.hxx>
 #include <uwb/UwbSessionEventCallbacks.hxx>
 #include <uwb/protocols/fira/UwbConfiguration.hxx>
+#include <windows/devices/uwb/UwbDeviceConnector.hxx>
 
 namespace windows::devices::uwb
 {
@@ -27,9 +24,9 @@ public:
      * @brief Construct a new UwbSession object.
      *
      * @param callbacks The event callback instance.
-     * @param handleDriver File handle for a UWB-CX driver instance.
+     * @param uwbDeviceConnector The connector to the UWB-CX driver instance.
      */
-    UwbSession(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, wil::shared_hfile handleDriver);
+    UwbSession(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, std::shared_ptr<UwbDeviceConnector> uwbDeviceConnector);
 
 private:
     /**
@@ -60,15 +57,15 @@ private:
 
 protected:
     /**
-     * @brief Obtain a shared instance of the primary driver handle.
+     * @brief Obtain a shared instance of the device driver connector.
      *
-     * @return wil::shared_hfile
+     * @return std::shared_ptr<UwbDeviceConnector>
      */
-    wil::shared_hfile
-    HandleDriver() noexcept;
+    std::shared_ptr<UwbDeviceConnector>
+    GetUwbDeviceConnector() noexcept;
 
 private:
-    wil::shared_hfile m_handleDriver;
+    std::shared_ptr<UwbDeviceConnector> m_uwbDeviceConnector;
 };
 
 } // namespace windows::devices::uwb

--- a/windows/devices/uwbsimulator/CMakeLists.txt
+++ b/windows/devices/uwbsimulator/CMakeLists.txt
@@ -7,8 +7,11 @@ set(WINDEVUWBSIM_DIR_PUBLIC_INCLUDE_PREFIX ${WINDEVUWBSIM_DIR_PUBLIC_INCLUDE}/wi
 target_sources(windev-uwb-simulator
     PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/UwbDeviceSimulator.cxx
+        ${CMAKE_CURRENT_LIST_DIR}/UwbDeviceSimulatorConnector.cxx
+        ${CMAKE_CURRENT_LIST_DIR}/UwbSessionSimulator.cxx
     PUBLIC
         ${WINDEVUWBSIM_DIR_PUBLIC_INCLUDE_PREFIX}/UwbDeviceSimulator.hxx
+        ${WINDEVUWBSIM_DIR_PUBLIC_INCLUDE_PREFIX}/UwbDeviceSimulatorConnector.hxx
         ${WINDEVUWBSIM_DIR_PUBLIC_INCLUDE_PREFIX}/UwbSessionSimulator.hxx
 )
 
@@ -19,6 +22,7 @@ target_include_directories(windev-uwb-simulator
 
 target_link_libraries(windev-uwb-simulator
     PRIVATE
+        plog::plog
         windev-util
     PUBLIC
         uwb-proto-fira
@@ -29,6 +33,7 @@ target_link_libraries(windev-uwb-simulator
 
 list(APPEND WINDEVUWBSIM_PUBLIC_HEADERS
     ${WINDEVUWBSIM_DIR_PUBLIC_INCLUDE_PREFIX}/UwbDeviceSimulator.hxx
+    ${WINDEVUWBSIM_DIR_PUBLIC_INCLUDE_PREFIX}/UwbDeviceSimulatorConnector.hxx
     ${WINDEVUWBSIM_DIR_PUBLIC_INCLUDE_PREFIX}/UwbSessionSimulator.hxx
 )
 

--- a/windows/devices/uwbsimulator/CMakeLists.txt
+++ b/windows/devices/uwbsimulator/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(windev-uwb-simulator
         ${CMAKE_CURRENT_LIST_DIR}/UwbDeviceSimulatorConnector.cxx
         ${CMAKE_CURRENT_LIST_DIR}/UwbSessionSimulator.cxx
     PUBLIC
+        ${WINDEVUWBSIM_DIR_PUBLIC_INCLUDE_PREFIX}/IUwbDeviceSimulatorDdi.hxx
         ${WINDEVUWBSIM_DIR_PUBLIC_INCLUDE_PREFIX}/UwbDeviceSimulator.hxx
         ${WINDEVUWBSIM_DIR_PUBLIC_INCLUDE_PREFIX}/UwbDeviceSimulatorConnector.hxx
         ${WINDEVUWBSIM_DIR_PUBLIC_INCLUDE_PREFIX}/UwbSessionSimulator.hxx
@@ -32,6 +33,7 @@ target_link_libraries(windev-uwb-simulator
 )
 
 list(APPEND WINDEVUWBSIM_PUBLIC_HEADERS
+    ${WINDEVUWBSIM_DIR_PUBLIC_INCLUDE_PREFIX}/IUwbDeviceSimulatorDdi.hxx
     ${WINDEVUWBSIM_DIR_PUBLIC_INCLUDE_PREFIX}/UwbDeviceSimulator.hxx
     ${WINDEVUWBSIM_DIR_PUBLIC_INCLUDE_PREFIX}/UwbDeviceSimulatorConnector.hxx
     ${WINDEVUWBSIM_DIR_PUBLIC_INCLUDE_PREFIX}/UwbSessionSimulator.hxx

--- a/windows/devices/uwbsimulator/UwbDeviceSimulator.cxx
+++ b/windows/devices/uwbsimulator/UwbDeviceSimulator.cxx
@@ -24,15 +24,15 @@ UwbDeviceSimulator::DeviceName() const noexcept
 bool
 UwbDeviceSimulator::Initialize()
 {
-    UwbDevice::Initialize();
-    m_handleDriver = UwbDevice::DriverHandle();
+    m_uwbDeviceConnector = std::make_shared<UwbDeviceConnector>(m_deviceName);
+    m_uwbDeviceSimulatorConnector = std::make_shared<UwbDeviceSimulatorConnector>(m_deviceName);
     return true;
 }
 
 std::shared_ptr<::uwb::UwbSession>
 UwbDeviceSimulator::CreateSessionImpl(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks)
 {
-    return UwbDevice::CreateSessionImpl<UwbSessionSimulator>(std::move(callbacks));
+    return std::make_shared<UwbSessionSimulator>(std::move(callbacks), m_uwbDeviceConnector, m_uwbDeviceSimulatorConnector);
 }
 
 UwbSimulatorCapabilities

--- a/windows/devices/uwbsimulator/UwbDeviceSimulatorConnector.cxx
+++ b/windows/devices/uwbsimulator/UwbDeviceSimulatorConnector.cxx
@@ -7,3 +7,24 @@ using namespace windows::devices::uwb::simulator;
 UwbDeviceSimulatorConnector::UwbDeviceSimulatorConnector(std::string deviceName) :
     m_deviceName(std::move(deviceName))
 {}
+
+std::future<UwbSimulatorCapabilities>
+UwbDeviceSimulatorConnector::GetCapabilites()
+{
+    std::promise<UwbSimulatorCapabilities> resultPromise;
+    auto resultFuture = resultPromise.get_future();
+    // TODO: invoke IOCTL_UWB_DEVICE_SIM_GET_CAPABILITIES
+
+    return resultFuture;
+}
+
+std::future<UwbSimulatorTriggerSessionEventResult>
+UwbDeviceSimulatorConnector::TriggerSessionEvent([[maybe_unused]] const UwbSimulatorTriggerSessionEventArgs& triggerSessionEventArgs)
+{
+    std::promise<UwbSimulatorTriggerSessionEventResult> resultPromise;
+    auto resultFuture = resultPromise.get_future();
+    // TODO: invoke IOCTL_UWB_DEVICE_SIM_TRIGGER_SESSION_EVENT
+
+    return resultFuture;
+
+}

--- a/windows/devices/uwbsimulator/UwbDeviceSimulatorConnector.cxx
+++ b/windows/devices/uwbsimulator/UwbDeviceSimulatorConnector.cxx
@@ -26,5 +26,4 @@ UwbDeviceSimulatorConnector::TriggerSessionEvent([[maybe_unused]] const UwbSimul
     // TODO: invoke IOCTL_UWB_DEVICE_SIM_TRIGGER_SESSION_EVENT
 
     return resultFuture;
-
 }

--- a/windows/devices/uwbsimulator/UwbDeviceSimulatorConnector.cxx
+++ b/windows/devices/uwbsimulator/UwbDeviceSimulatorConnector.cxx
@@ -1,0 +1,9 @@
+
+#include <windows/devices/uwb/simulator/UwbDeviceSimulatorConnector.hxx>
+
+using namespace windows::devices::uwb;
+using namespace windows::devices::uwb::simulator;
+
+UwbDeviceSimulatorConnector::UwbDeviceSimulatorConnector(std::string deviceName) :
+    m_deviceName(std::move(deviceName))
+{}

--- a/windows/devices/uwbsimulator/UwbSessionSimulator.cxx
+++ b/windows/devices/uwbsimulator/UwbSessionSimulator.cxx
@@ -1,2 +1,9 @@
 
 #include <windows/devices/uwb/simulator/UwbSessionSimulator.hxx>
+
+using namespace windows::devices::uwb::simulator;
+
+UwbSessionSimulator::UwbSessionSimulator(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, std::shared_ptr<UwbDeviceConnector> uwbDeviceConnector, std::shared_ptr<UwbDeviceSimulatorConnector> uwbDeviceSimulatorConnector) :
+    UwbSession(std::move(callbacks), std::move(uwbDeviceConnector)),
+    m_uwbDeviceSimulatorConnector(std::move(uwbDeviceSimulatorConnector))
+{}

--- a/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/IUwbDeviceSimulatorDdi.hxx
+++ b/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/IUwbDeviceSimulatorDdi.hxx
@@ -1,0 +1,23 @@
+
+#ifndef I_UWB_DEVICE_SIMULATOR_DDI_HXX
+#define I_UWB_DEVICE_SIMULATOR_DDI_HXX
+
+#include <future>
+
+#include <UwbSimulatorDdiGlue.h>
+
+namespace windows::devices::uwb::simulator
+{
+struct IUwbDeviceSimulatorDdi
+{
+    // IOCTL_UWB_DEVICE_SIM_GET_CAPABILITIES
+    virtual std::future<UwbSimulatorCapabilities>
+    GetCapabilites() = 0;
+
+    // IOCTL_UWB_DEVICE_SIM_TRIGGER_SESSION_EVENT
+    virtual std::future<UwbSimulatorTriggerSessionEventResult>
+    TriggerSessionEvent(const UwbSimulatorTriggerSessionEventArgs& triggerSessionEventArgs) = 0;
+};
+} // namespace windows::devices::uwb::simulator
+
+#endif // I_UWB_DEVICE_SIMULATOR_DDI_HXX

--- a/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbDeviceSimulator.hxx
+++ b/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbDeviceSimulator.hxx
@@ -3,6 +3,7 @@
 #define UWB_DEVICE_SIMULATOR_HXX
 
 #include <cstdint>
+#include <memory>
 #include <string>
 
 // NB: This must come before any other Windows include
@@ -14,6 +15,8 @@
 #include <wil/resource.h>
 #include <windows/devices/DeviceResource.hxx>
 #include <windows/devices/uwb/UwbDevice.hxx>
+#include <windows/devices/uwb/UwbDeviceConnector.hxx>
+#include <windows/devices/uwb/simulator/UwbDeviceSimulatorConnector.hxx>
 
 namespace windows::devices::uwb::simulator
 {
@@ -62,7 +65,8 @@ private:
 
 private:
     const std::string m_deviceName;
-    wil::shared_hfile m_handleDriver;
+    std::shared_ptr<UwbDeviceConnector> m_uwbDeviceConnector;
+    std::shared_ptr<UwbDeviceSimulatorConnector> m_uwbDeviceSimulatorConnector;
 };
 
 } // namespace windows::devices::uwb::simulator

--- a/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbDeviceSimulatorConnector.hxx
+++ b/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbDeviceSimulatorConnector.hxx
@@ -9,13 +9,16 @@
 
 #include <wil/resource.h>
 
+#include <windows/devices/uwb/simulator/IUwbDeviceSimulatorDdi.hxx>
+
 namespace windows::devices::uwb::simulator
 {
 /**
  * @brief Provides access to the DDI exposed by GUID_DEVINTERFACE_UWB_SIMULATOR
  * described in UwbSimulatorDdi.h.
  */
-class UwbDeviceSimulatorConnector
+class UwbDeviceSimulatorConnector :
+    public IUwbDeviceSimulatorDdi
 {
 public:
     /**
@@ -24,6 +27,14 @@ public:
      * @param deviceName 
      */
     explicit UwbDeviceSimulatorConnector(std::string deviceName);
+
+public:
+    // IUwbDeviceSimulatorDdi
+    virtual std::future<UwbSimulatorCapabilities>
+    GetCapabilites() override;
+
+    virtual std::future<UwbSimulatorTriggerSessionEventResult>
+    TriggerSessionEvent(const UwbSimulatorTriggerSessionEventArgs& triggerSessionEventArgs) override;
 
 private:
     wil::shared_hfile m_driverHandle;

--- a/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbDeviceSimulatorConnector.hxx
+++ b/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbDeviceSimulatorConnector.hxx
@@ -1,0 +1,34 @@
+
+#ifndef UWB_DEVICE_SIMULATOR_CONNECTOR_HXX
+#define UWB_DEVICE_SIMULATOR_CONNECTOR_HXX
+
+#include <memory>
+#include <string>
+
+#include <windows.h>
+
+#include <wil/resource.h>
+
+namespace windows::devices::uwb::simulator
+{
+/**
+ * @brief Provides access to the DDI exposed by GUID_DEVINTERFACE_UWB_SIMULATOR
+ * described in UwbSimulatorDdi.h.
+ */
+class UwbDeviceSimulatorConnector
+{
+public:
+    /**
+     * @brief Construct a new Uwb Device Simulator Connector object.
+     * 
+     * @param deviceName 
+     */
+    explicit UwbDeviceSimulatorConnector(std::string deviceName);
+
+private:
+    wil::shared_hfile m_driverHandle;
+    std::string m_deviceName{};
+};
+} //namespace windows::devices::uwb::simulator
+
+#endif // UWB_DEVICE_SIMULATOR_CONNECTOR_HXX

--- a/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbSessionSimulator.hxx
+++ b/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbSessionSimulator.hxx
@@ -10,6 +10,7 @@
 
 #include <uwb/UwbSessionEventCallbacks.hxx>
 #include <windows/devices/uwb/UwbSession.hxx>
+#include <windows/devices/uwb/simulator/UwbDeviceSimulatorConnector.hxx>
 
 namespace windows::devices::uwb::simulator
 {
@@ -17,10 +18,12 @@ class UwbSessionSimulator :
     public windows::devices::uwb::UwbSession
 {
 public:
-    // Inherit constructor for base class as nothing in for construction is different.
-    using windows::devices::uwb::UwbSession::UwbSession;
+    UwbSessionSimulator(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, std::shared_ptr<UwbDeviceConnector> uwbDeviceConnector, std::shared_ptr<UwbDeviceSimulatorConnector> uwbDeviceSimulatorConnector);
 
     virtual ~UwbSessionSimulator() = default;
+
+private:
+    std::shared_ptr<UwbDeviceSimulatorConnector> m_uwbDeviceSimulatorConnector;
 };
 } // namespace windows::devices::uwb::simulator
 

--- a/windows/drivers/uwb/simulator/IUwbSimulatorDdiCallbacksLrp.hxx
+++ b/windows/drivers/uwb/simulator/IUwbSimulatorDdiCallbacksLrp.hxx
@@ -79,12 +79,14 @@ struct IUwbSimulatorDdiCallbacksLrp
 
     /**
      * @brief Get the Application Configuration Parameters object
-     *
-     * @param applicationConfigurationParameters
-     * @return UwbStatus
+     * 
+     * @param sessionId 
+     * @param applicationConfigurationParameterTypes 
+     * @param applicationConfigurationParameters 
+     * @return UwbStatus 
      */
     virtual UwbStatus
-    GetApplicationConfigurationParameters(uint32_t sessionId, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> &applicationConfigurationParameters) = 0;
+    GetApplicationConfigurationParameters(uint32_t sessionId, std::vector<UwbApplicationConfigurationParameterType> applicationConfigurationParameterTypes, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> &applicationConfigurationParameters) = 0;
 
     /**
      * @brief Set the Application Configuration Parameters object

--- a/windows/drivers/uwb/simulator/IUwbSimulatorDdiCallbacksLrp.hxx
+++ b/windows/drivers/uwb/simulator/IUwbSimulatorDdiCallbacksLrp.hxx
@@ -86,7 +86,7 @@ struct IUwbSimulatorDdiCallbacksLrp
      * @return UwbStatus 
      */
     virtual UwbStatus
-    GetApplicationConfigurationParameters(uint32_t sessionId, std::vector<UwbApplicationConfigurationParameterType> applicationConfigurationParameterTypes, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> &applicationConfigurationParameters) = 0;
+    GetApplicationConfigurationParameters(uint32_t sessionId, const std::vector<UwbApplicationConfigurationParameterType> &applicationConfigurationParameterTypes, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> &applicationConfigurationParameters) = 0;
 
     /**
      * @brief Set the Application Configuration Parameters object
@@ -96,7 +96,7 @@ struct IUwbSimulatorDdiCallbacksLrp
      * @return UwbStatus
      */
     virtual UwbStatus
-    SetApplicationConfigurationParameters(uint32_t sessionId, const std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> &applicationConfigurationParameters, std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus, std::shared_ptr<IUwbAppConfigurationParameter>>> &applicationConfigurationParameterResults) = 0;
+    SetApplicationConfigurationParameters(uint32_t sessionId, const std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> &applicationConfigurationParameters, std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>> &applicationConfigurationParameterResults) = 0;
 
     /**
      * @brief Get the Session Count object

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
@@ -173,7 +173,7 @@ UwbSimulatorDdiCallbacks::SessionDeninitialize(uint32_t sessionId)
 }
 
 UwbStatus
-UwbSimulatorDdiCallbacks::SetApplicationConfigurationParameters(uint32_t sessionId, const std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> & /* applicationConfigurationParameters */, std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus, std::shared_ptr<IUwbAppConfigurationParameter>>> &applicationConfigurationParameterResults)
+UwbSimulatorDdiCallbacks::SetApplicationConfigurationParameters(uint32_t sessionId, const std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> & /* applicationConfigurationParameters */, std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>> &applicationConfigurationParameterResults)
 {
     TraceLoggingWrite(
         UwbSimulatorTraceloggingProvider,
@@ -181,7 +181,7 @@ UwbSimulatorDdiCallbacks::SetApplicationConfigurationParameters(uint32_t session
         TraceLoggingLevel(TRACE_LEVEL_INFORMATION),
         TraceLoggingUInt32(sessionId, "Session Id"));
 
-    std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus, std::shared_ptr<IUwbAppConfigurationParameter>>> results{};
+    std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>> results{};
     applicationConfigurationParameterResults = std::move(results);
     return UwbStatusOk;
 }

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
@@ -187,7 +187,7 @@ UwbSimulatorDdiCallbacks::SetApplicationConfigurationParameters(uint32_t session
 }
 
 UwbStatus
-UwbSimulatorDdiCallbacks::GetApplicationConfigurationParameters(uint32_t sessionId, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> &applicationConfigurationParameters)
+UwbSimulatorDdiCallbacks::GetApplicationConfigurationParameters(uint32_t sessionId, [[maybe_unused]] const std::vector<UwbApplicationConfigurationParameterType> &applicationConfigurationParameterTypes, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> &applicationConfigurationParameters)
 {
     TraceLoggingWrite(
         UwbSimulatorTraceloggingProvider,
@@ -204,6 +204,7 @@ UwbSimulatorDdiCallbacks::GetApplicationConfigurationParameters(uint32_t session
 
     const auto &[_, session] = *sessionIt;
     applicationConfigurationParameters = session.ApplicationConfigurationParameters;
+    // TODO: filter above with applicationConfigurationParameterTypes
     return UwbStatusOk;
 }
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
@@ -57,10 +57,10 @@ struct UwbSimulatorDdiCallbacks :
     SessionDeninitialize(uint32_t sessionId) override;
 
     virtual UwbStatus
-    SetApplicationConfigurationParameters(uint32_t sessionId, const std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> &applicationConfigurationParameters, std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus, std::shared_ptr<IUwbAppConfigurationParameter>>> &applicationConfigurationParameterResults) override;
+    SetApplicationConfigurationParameters(uint32_t sessionId, const std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> &applicationConfigurationParameters, std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>> &applicationConfigurationParameterResults) override;
 
     virtual UwbStatus
-    GetApplicationConfigurationParameters(uint32_t sessionId, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> &applicationConfigurationParameters) override;
+    GetApplicationConfigurationParameters(uint32_t sessionId, const std::vector<UwbApplicationConfigurationParameterType> &applicationConfigurationParameterTypes, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> &applicationConfigurationParameters) override;
 
     virtual UwbStatus
     GetSessionCount(uint32_t &sessionCount) override;

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.cxx
@@ -196,7 +196,7 @@ UwbSimulatorDdiHandler::OnUwbGetApplicationConfigurationParameters(WDFREQUEST re
     // Convert DDI input type to neutral type.
     auto &applicationConfigurationParametersIn = *reinterpret_cast<UWB_SET_APP_CONFIG_PARAMS *>(std::data(inputBuffer));
     std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> applicationConfigurationParameters{};
-    std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus, std::shared_ptr<IUwbAppConfigurationParameter>>> applicationConfigurationParameterResults;
+    std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>> applicationConfigurationParameterResults;
 
     // Invoke callback.
     auto statusUwb = m_callbacks->SetApplicationConfigurationParameters(applicationConfigurationParametersIn.sessionId, applicationConfigurationParameters, applicationConfigurationParameterResults);
@@ -223,7 +223,7 @@ UwbSimulatorDdiHandler::OnUwbSetApplicationConfigurationParameters(WDFREQUEST re
     // Convert DDI input type to neutral type.
     auto &applicationConfigurationParametersIn = *reinterpret_cast<UWB_SET_APP_CONFIG_PARAMS *>(std::data(inputBuffer));
     std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> applicationConfigurationParameters{};
-    std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus, std::shared_ptr<IUwbAppConfigurationParameter>>> applicationConfigurationParameterResults;
+    std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>> applicationConfigurationParameterResults{};
 
     // Invoke callback.
     auto statusUwb = m_callbacks->SetApplicationConfigurationParameters(applicationConfigurationParametersIn.sessionId, applicationConfigurationParameters, applicationConfigurationParameterResults);

--- a/windows/drivers/uwb/simulator/include/UwbSimulatorDdi.h
+++ b/windows/drivers/uwb/simulator/include/UwbSimulatorDdi.h
@@ -29,10 +29,10 @@ const GUID GUID_DEVINTERFACE_UWB_SIMULATOR = { 0x21663d8d, 0x2dd6, 0x45c7, { 0xa
 #define IOCTL_UWB_DEVICE_SIM_GET_CAPABILITIES CTL_CODE(FILE_DEVICE_UNKNOWN, 0x1000, METHOD_BUFFERED, FILE_ANY_ACCESS)
 
 /**
- * @brief 
- * 
+ * @brief
+ *
  * Input: UwbSimulatorTriggerSessionEventArgs
- * Output:
+ * Output: ???
  */
 #define IOCTL_UWB_DEVICE_SIM_TRIGGER_SESSION_EVENT CTL_CODE(FILE_DEVICE_UNKNOWN, 0x1001, METHOD_BUFFERED, FILE_ANY_ACCESS)
 
@@ -45,8 +45,7 @@ struct UwbSimulatorCapabilities
     uint32_t Version;
 };
 
-enum UwbSimulatorSessionEventAction
-{
+enum UwbSimulatorSessionEventAction {
     None = 0x00,
     RandomRangingMeasurementGenerationStart = 0x01,
     RandomRangingMeasurementGenerationStop = 0x02,
@@ -56,6 +55,11 @@ struct UwbSimulatorTriggerSessionEventArgs
 {
     uint32_t SessionId;
     UwbSimulatorSessionEventAction Action;
+};
+
+struct UwbSimulatorTriggerSessionEventResult
+{
+    // TODO
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Eliminate requirement of DDI implementation details from high-level abstractions.

### Technical Details

* Factor UWB LRP DDI interaction out of `UwbDevice` and `UwbSession` into an interface (`IUwbDeviceDdi`) and an implementation of it (`UwbDeviceConnector`).
* Factor UWB Simulator DDI interaction out of `UwbDeviceSimulator` and `UwbSessionSimulator` into an interface (`IUwbDeviceSimulator`) and an implementation of it (`UwbDeviceSimulatorConnector`).
* Add helper for checking if `UwbStatus` contains a successful result.
* Create driver handles (primary, notification) on-demand instead of keeping them open.

### Test Results

Compile tested only so far.

### Reviewer Focus

None

### Future Work

* `UwbDevice` top-level functions need their return type updated to accept some form of status (mostly `UwbStatus`).
* Many of the connector functions needs to be implemented.
* The LRP DDI interface is missing prototypes for `IOCTL_UWB_SET_DEVICE_CONFIG_PARAMS` and `IOCTL_UWB_GET_DEVICE_CONFIG_PARAMS`

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
