### PR TITLE
Add error message indicating no device found

### DIFF
--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -269,6 +269,7 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App* parent)
     rangeStartApp->final_callback([this] {
         auto uwbDevice = GetUwbDevice();
         if (!uwbDevice) {
+            std::cerr << "no device found" << std::endl;
             return;
         }
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [x] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Add error message to indicate that no UWB device is selected/found.

### Technical Details

Add `std::cerr` message in the final callback of `NearObjectCli.cxx`

### Test Results

Error message tested on machine with no device installed. Verified that error message printed to console.

### Reviewer Focus

None.

### Future Work

None.

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
