### PR TITLE
Add helper to open driver handles

### DIFF
--- a/windows/devices/util/CMakeLists.txt
+++ b/windows/devices/util/CMakeLists.txt
@@ -7,9 +7,11 @@ set(WINDEVUTIL_DIR_PUBLIC_INCLUDE_PREFIX ${WINDEVUTIL_DIR_PUBLIC_INCLUDE}/window
 target_sources(windev-util
     PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/DeviceEnumerator.cxx
+        ${CMAKE_CURRENT_LIST_DIR}/DeviceHandle.cxx
         ${CMAKE_CURRENT_LIST_DIR}/DevicePresenceMonitor.cxx
     PUBLIC
         ${WINDEVUTIL_DIR_PUBLIC_INCLUDE_PREFIX}/DeviceEnumerator.hxx
+        ${WINDEVUTIL_DIR_PUBLIC_INCLUDE_PREFIX}/DeviceHandle.hxx
         ${WINDEVUTIL_DIR_PUBLIC_INCLUDE_PREFIX}/DevicePresenceMonitor.hxx
         ${WINDEVUTIL_DIR_PUBLIC_INCLUDE_PREFIX}/DeviceResource.hxx
 )
@@ -30,6 +32,7 @@ target_link_libraries(windev-util
 
 list(APPEND WINDEVUTIL_PUBLIC_HEADERS
     ${WINDEVUTIL_DIR_PUBLIC_INCLUDE_PREFIX}/DeviceEnumerator.hxx
+    ${WINDEVUTIL_DIR_PUBLIC_INCLUDE_PREFIX}/DeviceHandle.hxx
     ${WINDEVUTIL_DIR_PUBLIC_INCLUDE_PREFIX}/DevicePresenceMonitor.hxx
     ${WINDEVUTIL_DIR_PUBLIC_INCLUDE_PREFIX}/DeviceResource.hxx
 )

--- a/windows/devices/util/DeviceHandle.cxx
+++ b/windows/devices/util/DeviceHandle.cxx
@@ -8,7 +8,7 @@ windows::devices::OpenDriverHandleShared(wil::shared_hfile &driverHandle, const 
 }
 
 HRESULT
-windows::devices::OpenDriverHandle(wil::unique_hfile &driverHandle, const char *deviceName, bool isOverlapped)
+windows::devices::OpenDriverHandleUnique(wil::unique_hfile &driverHandle, const char *deviceName, bool isOverlapped)
 {
     return OpenDriverHandle<wil::unique_hfile>(driverHandle, deviceName, isOverlapped);
 }

--- a/windows/devices/util/DeviceHandle.cxx
+++ b/windows/devices/util/DeviceHandle.cxx
@@ -1,0 +1,14 @@
+
+#include <windows/devices/DeviceHandle.hxx>
+
+HRESULT
+windows::devices::OpenDriverHandleShared(wil::shared_hfile &driverHandle, const char *deviceName, bool isOverlapped)
+{
+    return OpenDriverHandle<wil::shared_hfile>(driverHandle, deviceName, isOverlapped);
+}
+
+HRESULT
+windows::devices::OpenDriverHandle(wil::unique_hfile &driverHandle, const char *deviceName, bool isOverlapped)
+{
+    return OpenDriverHandle<wil::unique_hfile>(driverHandle, deviceName, isOverlapped);
+}

--- a/windows/devices/util/include/windows/devices/DeviceHandle.hxx
+++ b/windows/devices/util/include/windows/devices/DeviceHandle.hxx
@@ -46,7 +46,7 @@ template <typename HandleSmartT>
 requires detail::HasReset<HandleSmartT, HANDLE>
 // clang-format on
 HRESULT
-OpenDriverHandle(HandleSmartT &driverHandle, const char *deviceName, bool isOverlapped)
+OpenDriverHandle(HandleSmartT &driverHandle, const char *deviceName, bool isOverlapped = false)
 {
     driverHandle.reset(CreateFileA(
         deviceName,
@@ -80,7 +80,7 @@ OpenDriverHandleShared(wil::shared_hfile &driverHandle, const char *deviceName, 
  * @return HRESULT S_OK if successful.
  */
 HRESULT
-OpenDriverHandle(wil::unique_hfile &driverHandle, const char *deviceName, bool isOverlapped = false);
+OpenDriverHandleUnique(wil::unique_hfile &driverHandle, const char *deviceName, bool isOverlapped = false);
 
 } // namespace windows::devices
 

--- a/windows/devices/util/include/windows/devices/DeviceHandle.hxx
+++ b/windows/devices/util/include/windows/devices/DeviceHandle.hxx
@@ -8,7 +8,6 @@
 #include <windows.h>
 
 #include <fileapi.h>
-
 #include <wil/resource.h>
 #include <wil/result.h>
 
@@ -18,14 +17,17 @@ namespace detail
 {
 /**
  * @brief Helper concept to check whether a type has a reset() function for a
- * particular contained type. 
- * 
+ * particular contained type.
+ *
  * @tparam HandleSmartT The smart type managing a contained type.
  * @tparam ContainedT The contained type managed by the smart type.
  */
-template <typename HandleSmartT, typename ContainedT> concept HasReset = requires (HandleSmartT handleSmart, ContainedT handle) {
+// clang-format off
+template <typename HandleSmartT, typename ContainedT>
+concept HasReset = requires (HandleSmartT handleSmart, ContainedT handle) {
     handleSmart.reset(handle);
 };
+// clang-format on
 } // namespace detail
 
 /**
@@ -39,8 +41,10 @@ template <typename HandleSmartT, typename ContainedT> concept HasReset = require
  * @param deviceName The device interface path to open.
  * @param isOverlapped Whether the handle should be opened in overlapped (async) mode or not.
  */
+// clang-format off
 template <typename HandleSmartT>
 requires detail::HasReset<HandleSmartT, HANDLE>
+// clang-format on
 HRESULT
 OpenDriverHandle(HandleSmartT &driverHandle, const char *deviceName, bool isOverlapped)
 {

--- a/windows/devices/util/include/windows/devices/DeviceHandle.hxx
+++ b/windows/devices/util/include/windows/devices/DeviceHandle.hxx
@@ -2,6 +2,7 @@
 #ifndef DEVICE_HANDLE_HXX
 #define DEVICE_HANDLE_HXX
 
+#include <concepts>
 #include <memory>
 
 #include <windows.h>
@@ -13,6 +14,20 @@
 
 namespace windows::devices
 {
+namespace detail
+{
+/**
+ * @brief Helper concept to check whether a type has a reset() function for a
+ * particular contained type. 
+ * 
+ * @tparam HandleSmartT The smart type managing a contained type.
+ * @tparam ContainedT The contained type managed by the smart type.
+ */
+template <typename HandleSmartT, typename ContainedT> concept HasReset = requires (HandleSmartT handleSmart, ContainedT handle) {
+    handleSmart.reset(handle);
+};
+} // namespace detail
+
 /**
  * @brief Open a HANDLE to a device interface path, using an RAII-wrapper.
  *
@@ -25,6 +40,7 @@ namespace windows::devices
  * @param isOverlapped Whether the handle should be opened in overlapped (async) mode or not.
  */
 template <typename HandleSmartT>
+requires detail::HasReset<HandleSmartT, HANDLE>
 HRESULT
 OpenDriverHandle(HandleSmartT &driverHandle, const char *deviceName, bool isOverlapped)
 {

--- a/windows/devices/util/include/windows/devices/DeviceHandle.hxx
+++ b/windows/devices/util/include/windows/devices/DeviceHandle.hxx
@@ -1,0 +1,67 @@
+
+#ifndef DEVICE_HANDLE_HXX
+#define DEVICE_HANDLE_HXX
+
+#include <memory>
+
+#include <windows.h>
+
+#include <fileapi.h>
+
+#include <wil/resource.h>
+#include <wil/result.h>
+
+namespace windows::devices
+{
+/**
+ * @brief Open a HANDLE to a device interface path, using an RAII-wrapper.
+ *
+ * @tparam HandleSmartT The RAII-wrapper type to hold the HANDLE. This must
+ * contain a reset() function which takes a HANDLE, such as the smart wil
+ * RAII types like wil::unique_hfile and wil::shared_hfile.
+ *
+ * @param driverHandle The driver smart handle to update.
+ * @param deviceName The device interface path to open.
+ * @param isOverlapped Whether the handle should be opened in overlapped (async) mode or not.
+ */
+template <typename HandleSmartT>
+HRESULT
+OpenDriverHandle(HandleSmartT &driverHandle, const char *deviceName, bool isOverlapped)
+{
+    driverHandle.reset(CreateFileA(
+        deviceName,
+        GENERIC_READ | GENERIC_WRITE,
+        FILE_SHARE_READ | FILE_SHARE_WRITE,
+        nullptr,
+        OPEN_EXISTING,
+        isOverlapped ? FILE_FLAG_OVERLAPPED : FILE_ATTRIBUTE_NORMAL,
+        nullptr));
+    RETURN_LAST_ERROR_IF(driverHandle.get() == INVALID_HANDLE_VALUE);
+    return S_OK;
+}
+
+/**
+ * @brief Open a shared HANDLE to a device interface path, using an RAII-wrapper.
+ *
+ * @param driverHandle The RAII-wrapper instance to store the HANDLE.
+ * @param deviceName The device interface path to open.
+ * @param isOverlapped Whether the HANDLE should be opened in overlapped (async) mode.
+ * @return HRESULT S_OK if successful.
+ */
+HRESULT
+OpenDriverHandleShared(wil::shared_hfile &driverHandle, const char *deviceName, bool isOverlapped = false);
+
+/**
+ * @brief Open a unique HANDLE to a device interface path, using an RAII-wrapper.
+ *
+ * @param driverHandle The RAII-wrapper instance to store the HANDLE.
+ * @param deviceName The device interface path to open.
+ * @param isOverlapped Whether the HANDLE should be opened in overlapped (async) mode.
+ * @return HRESULT S_OK if successful.
+ */
+HRESULT
+OpenDriverHandle(wil::unique_hfile &driverHandle, const char *deviceName, bool isOverlapped = false);
+
+} // namespace windows::devices
+
+#endif // DEVICE_HANDLE_HXX

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -10,6 +10,7 @@
 #include <windows/devices/uwb/UwbCxDdiLrp.hxx>
 #include <windows/devices/uwb/UwbDeviceConnector.hxx>
 
+using namespace windows::devices;
 using namespace windows::devices::uwb;
 using namespace ::uwb::protocol::fira;
 

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -5,6 +5,7 @@
 #include <plog/Log.h>
 #include <wil/result.h>
 
+#include <windows/devices/DeviceHandle.hxx>
 #include <windows/devices/uwb/UwbCxAdapterDdiLrp.hxx>
 #include <windows/devices/uwb/UwbCxDdiLrp.hxx>
 #include <windows/devices/uwb/UwbDeviceConnector.hxx>
@@ -21,21 +22,6 @@ namespace UwbCxDdi = windows::devices::uwb::ddi::lrp;
 UwbDeviceConnector::UwbDeviceConnector(std::string deviceName) :
     m_deviceName(std::move(deviceName))
 {}
-
-HRESULT
-UwbDeviceConnector::OpenDriverHandle(wil::shared_hfile& driverHandle, bool isOverlapped = false) noexcept
-{
-    driverHandle.reset(CreateFileA(
-        m_deviceName.c_str(),
-        GENERIC_READ | GENERIC_WRITE,
-        FILE_SHARE_READ | FILE_SHARE_WRITE,
-        nullptr,
-        OPEN_EXISTING,
-        isOverlapped ? FILE_FLAG_OVERLAPPED : FILE_ATTRIBUTE_NORMAL,
-        nullptr));
-    RETURN_LAST_ERROR_IF(driverHandle.get() == INVALID_HANDLE_VALUE);
-    return S_OK;
-}
 
 const std::string&
 UwbDeviceConnector::DeviceName() const noexcept
@@ -73,7 +59,7 @@ UwbDeviceConnector::GetCapabilities()
     auto resultFuture = resultPromise.get_future();
 
     wil::shared_hfile handleDriver;
-    auto hr = OpenDriverHandle(handleDriver);
+    auto hr = OpenDriverHandle(handleDriver, m_deviceName.c_str());
     if (FAILED(hr)) {
         PLOG_ERROR << "failed to obtain driver handle for " << m_deviceName << ", hr=" << hr;
         return resultFuture;
@@ -257,7 +243,7 @@ bool
 UwbDeviceConnector::NotificationListenerStart(std::function<void(::uwb::protocol::fira::UwbNotificationData)> onNotification)
 {
     wil::shared_hfile handleDriver;
-    auto hr = OpenDriverHandle(handleDriver);
+    auto hr = OpenDriverHandle(handleDriver, m_deviceName.c_str());
     if (FAILED(hr)) {
         PLOG_ERROR << "failed to obtain driver handle for " << m_deviceName << ", hr=" << hr;
         return false;

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
@@ -97,17 +97,6 @@ public:
     virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>>>
     SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> applicationConfigurationParameters) override;
 
-protected:
-    /**
-     * @brief Open a new handle to the driver.
-     *
-     * @param driverHandle The driver handle to update.
-     * @param isOverlapped Whether overlapped (async) i/o is requested on the handle.
-     * @return HRESULT
-     */
-    HRESULT
-    OpenDriverHandle(wil::shared_hfile& driverHandle, bool isOverlapped) noexcept;
-
 private:
     /**
      * @brief Thread function for handling UWB notifications from the driver.

--- a/windows/devices/uwbsimulator/UwbDeviceSimulatorConnector.cxx
+++ b/windows/devices/uwbsimulator/UwbDeviceSimulatorConnector.cxx
@@ -1,6 +1,16 @@
 
+#include <ios>
+#include <iomanip>
+
+#include <plog/Log.h>
+#include <wil/result.h>
+
+#include <ioapiset.h>
+
+#include <windows/devices/DeviceHandle.hxx>
 #include <windows/devices/uwb/simulator/UwbDeviceSimulatorConnector.hxx>
 
+using namespace windows::devices;
 using namespace windows::devices::uwb;
 using namespace windows::devices::uwb::simulator;
 
@@ -13,7 +23,23 @@ UwbDeviceSimulatorConnector::GetCapabilites()
 {
     std::promise<UwbSimulatorCapabilities> resultPromise;
     auto resultFuture = resultPromise.get_future();
-    // TODO: invoke IOCTL_UWB_DEVICE_SIM_GET_CAPABILITIES
+
+    wil::unique_hfile handleDriver;
+    auto hr = OpenDriverHandle(handleDriver, m_deviceName.c_str());
+    if (FAILED(hr)) {
+        PLOG_ERROR << "failed to obtain driver handle for " << m_deviceName << ", hr=" << std::showbase << std::hex << hr;
+        return resultFuture;
+    }
+
+    UwbSimulatorCapabilities simulatorCapabilities{};
+    DWORD bytesRequired = sizeof simulatorCapabilities;
+    BOOL ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_DEVICE_SIM_GET_CAPABILITIES, nullptr, 0, &simulatorCapabilities, sizeof simulatorCapabilities, nullptr, nullptr);
+    if (!ioResult) {
+        HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
+        PLOG_ERROR << "error when sending IOCTL_UWB_DEVICE_SIM_GET_CAPABILITIES, hr=" << std::showbase << std::hex << hr;
+    }
+
+    resultPromise.set_value(std::move(simulatorCapabilities));
 
     return resultFuture;
 }

--- a/windows/devices/uwbsimulator/UwbDeviceSimulatorConnector.cxx
+++ b/windows/devices/uwbsimulator/UwbDeviceSimulatorConnector.cxx
@@ -1,6 +1,6 @@
 
-#include <ios>
 #include <iomanip>
+#include <ios>
 
 #include <plog/Log.h>
 #include <wil/result.h>

--- a/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbDeviceSimulatorConnector.hxx
+++ b/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbDeviceSimulatorConnector.hxx
@@ -23,8 +23,8 @@ class UwbDeviceSimulatorConnector :
 public:
     /**
      * @brief Construct a new Uwb Device Simulator Connector object.
-     * 
-     * @param deviceName 
+     *
+     * @param deviceName
      */
     explicit UwbDeviceSimulatorConnector(std::string deviceName);
 
@@ -40,6 +40,6 @@ private:
     wil::shared_hfile m_driverHandle;
     std::string m_deviceName{};
 };
-} //namespace windows::devices::uwb::simulator
+} // namespace windows::devices::uwb::simulator
 
 #endif // UWB_DEVICE_SIMULATOR_CONNECTOR_HXX

--- a/windows/tools/nocli/Main.cxx
+++ b/windows/tools/nocli/Main.cxx
@@ -11,9 +11,6 @@
 
 #include <nearobject/cli/NearObjectCli.hxx>
 #include <nearobject/cli/NearObjectCliUwbSessionEventCallbacks.hxx>
-#include <windows/devices/DeviceEnumerator.hxx>
-#include <windows/devices/DevicePresenceMonitor.hxx>
-#include <windows/devices/uwb/UwbDevice.hxx>
 
 #include <plog/Appenders/ColorConsoleAppender.h>
 #include <plog/Appenders/DebugOutputAppender.h>


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Allow driver handles to be opened in a consistent way.

### Technical Details

* Add helper function to windows devices util library for opening both unique and shared handles, with or without overlapped mode.

### Test Results

* All unit tests pass on both Linux and Windows.

### Reviewer Focus

None

### Future Work

Eventually, a generic handle I/O helper will be added to this library to make executing both synchronous and asynchronous i/o on a `HANDLE` consistent to perform.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
