### PR TITLE
Implement GetDeviceInfo (IOCTL_UWB_GET_DEVICE_INFO) connector function

### DIFF
--- a/lib/uwb/UwbVersion.cxx
+++ b/lib/uwb/UwbVersion.cxx
@@ -25,3 +25,19 @@ UwbVersion::Parse(const std::string& /* str */) noexcept
     // TODO: implement me
     return std::nullopt;
 }
+
+/* static */
+UwbVersion
+UwbVersion::FromUci(uint8_t major, uint8_t minorAndMaintenance)
+{
+    static constexpr uint8_t MaskMinor = 0b11110000;
+    static constexpr uint8_t MaskMaintenance = 0b00001111U;
+    static constexpr uint8_t ShiftMinor = 4U;
+    static constexpr uint8_t ShiftMaintenance = 0U;
+
+    return UwbVersion{
+        .Major = major,
+        .Minor = static_cast<uint8_t>((minorAndMaintenance & MaskMinor) >> ShiftMinor),
+        .Maintenance = static_cast<uint8_t>((minorAndMaintenance & MaskMaintenance) >> ShiftMaintenance),
+    };
+}

--- a/lib/uwb/include/uwb/UwbVersion.hxx
+++ b/lib/uwb/include/uwb/UwbVersion.hxx
@@ -52,6 +52,20 @@ struct UwbVersion
      */
     static std::optional<UwbVersion>
     Parse(const std::string& str) noexcept;
+
+    /**
+     * @brief Create an instance from a pari of UCI encoded version values. 
+     * 
+     * This assumes the minor and maintenance value are encoded per FiRa UCI
+     * Specification v1.1.0, page 18, Table 5: 'Control Messages to get the
+     * Device Information'.
+     *
+     * @param major The major version value.
+     * @param minorAndMaintenance The minor and maintenance version values.
+     * @return UwbVersion 
+     */
+    static UwbVersion
+    FromUci(uint8_t major, uint8_t minorAndMaintenance);
 };
 } // namespace uwb
 

--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -371,9 +371,9 @@ struct UwbDeviceInfoVendor
     /**
      * @brief Provides a view of the vendor-specific data.
      *
-     * @return std::span<uint8_t>
+     * @return std::span<const uint8_t>
      */
-    virtual std::span<uint8_t>
+    virtual std::span<const uint8_t>
     GetData() const noexcept = 0;
 };
 

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -1,5 +1,6 @@
 
 #include <ios>
+#include <ranges>
 #include <stdexcept>
 
 #include <plog/Log.h>
@@ -48,7 +49,44 @@ UwbDeviceConnector::GetDeviceInformation()
 {
     std::promise<UwbDeviceInformation> resultPromise;
     auto resultFuture = resultPromise.get_future();
-    // TODO: invoke IOCTL_UWB_GET_DEVICE_INFO
+
+    wil::unique_hfile handleDriver;
+    auto hr = OpenDriverHandle(handleDriver, m_deviceName.c_str());
+    if (FAILED(hr)) {
+        PLOG_ERROR << "failed to obtain driver handle for " << m_deviceName << ", hr=" << std::showbase << std::hex << hr;
+        return resultFuture;
+    }
+
+    std::vector<uint8_t> deviceInformationBuffer{};
+    DWORD bytesRequired = sizeof(UWB_DEVICE_INFO);
+
+    // Attempt at most twice to obtain device information. On the first attempt,
+    // we guess that no vendor-specific information will be supplied. If this is
+    // the case, the first attempt will succeed. Otherwise, the buffer is grown
+    // to account for the vendor specific information, and the IOCTL attempted a
+    // second time.
+    for (const auto i : std::ranges::iota_view{1,2}) {
+        deviceInformationBuffer.resize(bytesRequired);
+        PLOG_DEBUG << "IOCTL_UWB_GET_DEVICE_INFO attempt #" << i << " with " << std::size(deviceInformationBuffer) << "-byte buffer";
+        BOOL ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_GET_DEVICE_INFO, nullptr, 0, std::data(deviceInformationBuffer), std::size(deviceInformationBuffer), &bytesRequired, nullptr);
+        if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
+            DWORD lastError = GetLastError();
+            // Treat all errors other than insufficient buffer size as fatal.
+            if (lastError != ERROR_INSUFFICIENT_BUFFER) {
+                HRESULT hr = HRESULT_FROM_WIN32(lastError);
+                PLOG_ERROR << "error when sending IOCTL_UWB_GET_DEVICE_INFO, hr=" << std::showbase << std::hex << hr;
+                break;
+            }
+            // Attempt to retry the ioctl with the appropriate buffer size, which is now held in bytesRequired.
+            continue;
+        } else {
+            PLOG_DEBUG << "IOCTL_UWB_GET_DEVICE_INFO succeeded";
+            const auto &deviceInformation = *reinterpret_cast<UWB_DEVICE_INFO*>(std::data(deviceInformationBuffer));
+            const auto uwbDeviceInformation = UwbCxDdi::To(deviceInformation);
+            resultPromise.set_value(std::move(uwbDeviceInformation));
+            break;
+        }
+    }
 
     return resultFuture;
 }

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -42,9 +42,9 @@ From(const ::uwb::protocol::fira::UwbDeviceState &uwbDeviceState);
 
 /**
  * @brief Converts UwbSessionType to UWB_SESSION_TYPE.
- * 
- * @param uwbSessionType 
- * @return UWB_SESSION_TYPE 
+ *
+ * @param uwbSessionType
+ * @return UWB_SESSION_TYPE
  */
 UWB_SESSION_TYPE
 From(const ::uwb::protocol::fira::UwbSessionType &uwbSessionType);
@@ -295,12 +295,11 @@ To(const UWB_STATUS &status);
 ::uwb::protocol::fira::UwbDeviceState
 To(const UWB_DEVICE_STATE &deviceState);
 
-
 /**
- * @brief Converts UWB_SESSION_TYPE to UwbSessionType. 
- * 
- * @param sessionType 
- * @return ::uwb::protocol::fira::UwbSessionType 
+ * @brief Converts UWB_SESSION_TYPE to UwbSessionType.
+ *
+ * @param sessionType
+ * @return ::uwb::protocol::fira::UwbSessionType
  */
 ::uwb::protocol::fira::UwbSessionType
 To(const UWB_SESSION_TYPE &sessionType);
@@ -375,6 +374,15 @@ To(const UWB_SESSION_STATE &sessionState);
  */
 ::uwb::protocol::fira::UwbSessionStatus
 To(const UWB_SESSION_STATUS &sessionStatus);
+
+/**
+ * @brief Converts UWB_DEVICE_INFO to UwbDeviceInformation.
+ *
+ * @param deviceInfo
+ * @return ::uwb::protocol::fira::UwbDeviceInformation
+ */
+::uwb::protocol::fira::UwbDeviceInformation
+To(const UWB_DEVICE_INFO &deviceInfo);
 
 /**
  * @brief Converts UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF to UwbSessionUpdateMulicastListStatus.


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

* Allow the `IOCTL_UWB_GET_DEVICE_INFO` ioctl to be invoked through the UWB device connector.

### Technical Details

* Add factory function to create a `UwbVersion` from UCI encoded version values.
* Add neutral <-> DDI type conversion function for `UWB_DEVICE_INFO`.
* Implement simple, untyped container version of `UwbDeviceInfoVendor`.
* Implement `UwbDeviceConnector::GetDeviceInfo`

### Test Results

None yet. This will be tested through the simulator driver once the higher-layer abstraction (`UwbDevice`) supports calling the connector.

### Reviewer Focus

None

### Future Work

* `UwbDevice` implementation needs to be modified to call `UwbDeviceConnector::GetDeviceInfo`.
* `nocli` needs to be updated to allow calling the above added functionality through a switch.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
