### PR TITLE
Expose functions for resetting and getting device information from UwbDevice

### DIFF
--- a/lib/uwb/UwbDevice.cxx
+++ b/lib/uwb/UwbDevice.cxx
@@ -191,6 +191,13 @@ UwbDevice::GetDeviceInformation()
     return GetDeviceInformationImpl();
 }
 
+void
+UwbDevice::Reset()
+{
+    PLOG_INFO << "Reset";
+    ResetImpl();
+}
+
 bool
 uwb::operator==(const UwbDevice& lhs, const UwbDevice& rhs) noexcept
 {

--- a/lib/uwb/UwbDevice.cxx
+++ b/lib/uwb/UwbDevice.cxx
@@ -175,7 +175,8 @@ UwbDevice::CreateSession(std::weak_ptr<UwbSessionEventCallbacks> callbacks)
 UwbCapability
 UwbDevice::GetCapabilities()
 {
-    return {};
+    PLOG_INFO << "GetCapabilities()";
+    return GetCapabilitiesImpl();
 }
 
 /**
@@ -186,7 +187,8 @@ UwbDevice::GetCapabilities()
 UwbDeviceInformation
 UwbDevice::GetDeviceInformation()
 {
-    return {};
+    PLOG_INFO << "GetDeviceInformation";
+    return GetDeviceInformationImpl();
 }
 
 bool

--- a/lib/uwb/UwbDevice.cxx
+++ b/lib/uwb/UwbDevice.cxx
@@ -172,6 +172,23 @@ UwbDevice::CreateSession(std::weak_ptr<UwbSessionEventCallbacks> callbacks)
     return session;
 }
 
+UwbCapability
+UwbDevice::GetCapabilities()
+{
+    return {};
+}
+
+/**
+ * @brief Get the FiRa device information of the device.
+ * 
+ * @return ::uwb::protocol::fira::UwbDeviceInformation 
+ */
+UwbDeviceInformation
+UwbDevice::GetDeviceInformation()
+{
+    return {};
+}
+
 bool
 uwb::operator==(const UwbDevice& lhs, const UwbDevice& rhs) noexcept
 {

--- a/lib/uwb/include/uwb/UwbDevice.hxx
+++ b/lib/uwb/include/uwb/UwbDevice.hxx
@@ -38,6 +38,14 @@ public:
     GetCapabilities();
 
     /**
+     * @brief Get the FiRa device information of the device.
+     * 
+     * @return ::uwb::protocol::fira::UwbDeviceInformation 
+     */
+    ::uwb::protocol::fira::UwbDeviceInformation
+    GetDeviceInformation();
+
+    /**
      * @brief Determine if this device is the same as another.
      *
      * @param other
@@ -69,6 +77,14 @@ private:
      */
     virtual uwb::protocol::fira::UwbCapability
     GetCapabilitiesImpl() = 0;
+
+    /**
+     * @brief Get the FiRa device information of the device.
+     * 
+     * @return ::uwb::protocol::fira::UwbDeviceInformation 
+     */
+    virtual ::uwb::protocol::fira::UwbDeviceInformation
+    GetDeviceInformationImpl() = 0;
 
 protected:
     /**

--- a/lib/uwb/include/uwb/UwbDevice.hxx
+++ b/lib/uwb/include/uwb/UwbDevice.hxx
@@ -46,6 +46,12 @@ public:
     GetDeviceInformation();
 
     /**
+     * @brief Reset the device to an initial clean state. 
+     */
+    void
+    Reset();
+
+    /**
      * @brief Determine if this device is the same as another.
      *
      * @param other
@@ -85,6 +91,12 @@ private:
      */
     virtual ::uwb::protocol::fira::UwbDeviceInformation
     GetDeviceInformationImpl() = 0;
+
+    /**
+     * @brief Reset the device to an initial clean state. 
+     */
+    virtual void
+    ResetImpl() = 0;
 
 protected:
     /**

--- a/lib/uwb/include/uwb/protocols/fira/UwbException.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/UwbException.hxx
@@ -1,0 +1,21 @@
+
+#ifndef UWB_EXCEPTION_HXX
+#define UWB_EXCEPTION_HXX
+
+#include <utility>
+
+#include <uwb/protocols/fira/FiraDevice.hxx>
+
+namespace uwb::protocol::fira
+{
+struct UwbException
+{
+    explicit UwbException(UwbStatus status) :
+        Status(std::move(status))
+    {}
+
+    UwbStatus Status{ UwbStatusGeneric::Ok };
+};
+} // namespace uwb::protocol::fira
+
+#endif // UWB_EXCEPTION_HXX

--- a/lib/uwb/protocols/fira/CMakeLists.txt
+++ b/lib/uwb/protocols/fira/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(uwb-proto-fira
         ${UWB_PROTO_FIRA_DIR_PUBLIC_INCLUDE_PREFIX}/UwbCapability.hxx
         ${UWB_PROTO_FIRA_DIR_PUBLIC_INCLUDE_PREFIX}/UwbConfiguration.hxx
         ${UWB_PROTO_FIRA_DIR_PUBLIC_INCLUDE_PREFIX}/UwbConfigurationBuilder.hxx
+        ${UWB_PROTO_FIRA_DIR_PUBLIC_INCLUDE_PREFIX}/UwbException.hxx
         ${UWB_PROTO_FIRA_DIR_PUBLIC_INCLUDE_PREFIX}/UwbRegulatoryInformation.hxx
         ${UWB_PROTO_FIRA_DIR_PUBLIC_INCLUDE_PREFIX}/UwbSessionData.hxx
 )
@@ -53,6 +54,7 @@ list(APPEND UWBPROTOFIRA_PUBLIC_HEADERS
     ${UWB_PROTO_FIRA_DIR_PUBLIC_INCLUDE_PREFIX}/UwbCapability.hxx
     ${UWB_PROTO_FIRA_DIR_PUBLIC_INCLUDE_PREFIX}/UwbConfiguration.hxx
     ${UWB_PROTO_FIRA_DIR_PUBLIC_INCLUDE_PREFIX}/UwbConfigurationBuilder.hxx
+    ${UWB_PROTO_FIRA_DIR_PUBLIC_INCLUDE_PREFIX}/UwbException.hxx
     ${UWB_PROTO_FIRA_DIR_PUBLIC_INCLUDE_PREFIX}/UwbRegulatoryInformation.hxx
     ${UWB_PROTO_FIRA_DIR_PUBLIC_INCLUDE_PREFIX}/UwbSessionData.hxx
 )

--- a/linux/devices/uwb/UwbDevice.cxx
+++ b/linux/devices/uwb/UwbDevice.cxx
@@ -25,6 +25,11 @@ GetDeviceInformationImpl()
     return {};
 }
 
+void
+ResetImpl()
+{
+}
+
 bool
 UwbDevice::IsEqual(const uwb::UwbDevice& other) const noexcept
 {

--- a/linux/devices/uwb/UwbDevice.cxx
+++ b/linux/devices/uwb/UwbDevice.cxx
@@ -2,6 +2,7 @@
 #include <linux/uwb/UwbDevice.hxx>
 
 using namespace linux::devices;
+using namespace uwb::protocol::fira;
 
 std::shared_ptr<uwb::UwbSession>
 UwbDevice::CreateSessionImpl(std::weak_ptr<uwb::UwbSessionEventCallbacks> /* callbacks */)
@@ -10,8 +11,15 @@ UwbDevice::CreateSessionImpl(std::weak_ptr<uwb::UwbSessionEventCallbacks> /* cal
     return nullptr;
 }
 
-uwb::protocol::fira::UwbCapability
+UwbCapability
 UwbDevice::GetCapabilitiesImpl()
+{
+    // TODO
+    return {};
+}
+
+UwbDeviceInformation
+GetDeviceInformationImpl()
 {
     // TODO
     return {};

--- a/linux/devices/uwb/include/linux/uwb/UwbDevice.hxx
+++ b/linux/devices/uwb/include/linux/uwb/UwbDevice.hxx
@@ -48,6 +48,14 @@ private:
      */
     uwb::protocol::fira::UwbCapability
     GetCapabilitiesImpl() override;
+
+    /**
+     * @brief Get the FiRa device information of the device.
+     * 
+     * @return uwb::protocol::fira::UwbDeviceInformation 
+     */
+    uwb::protocol::fira::UwbDeviceInformation
+    GetDeviceInformationImpl() override;
 };
 
 } // namespace devices

--- a/linux/devices/uwb/include/linux/uwb/UwbDevice.hxx
+++ b/linux/devices/uwb/include/linux/uwb/UwbDevice.hxx
@@ -56,6 +56,12 @@ private:
      */
     uwb::protocol::fira::UwbDeviceInformation
     GetDeviceInformationImpl() override;
+
+    /**
+     * @brief Reset the device to an initial clean state. 
+     */
+    void
+    ResetImpl() override;
 };
 
 } // namespace devices

--- a/tests/unit/uwb/TestUwbDevice.cxx
+++ b/tests/unit/uwb/TestUwbDevice.cxx
@@ -31,6 +31,12 @@ struct UwbDeviceTestBase : public uwb::UwbDevice
     {
         return {};
     }
+
+    uwb::protocol::fira::UwbDeviceInformation
+    GetDeviceInformationImpl() override
+    {
+        return {};
+    }
 };
 
 struct UwbDeviceTestDerivedOne : UwbDeviceTestBase

--- a/tests/unit/uwb/TestUwbDevice.cxx
+++ b/tests/unit/uwb/TestUwbDevice.cxx
@@ -37,6 +37,11 @@ struct UwbDeviceTestBase : public uwb::UwbDevice
     {
         return {};
     }
+
+    void
+    ResetImpl() override
+    {
+    }
 };
 
 struct UwbDeviceTestDerivedOne : UwbDeviceTestBase

--- a/windows/devices/uwb/UwbDevice.cxx
+++ b/windows/devices/uwb/UwbDevice.cxx
@@ -76,21 +76,16 @@ UwbDevice::GetDeviceInformationImpl()
 {
     auto resultFuture = m_uwbDeviceConnector->GetDeviceInformation();
     if (!resultFuture.valid()) {
-        // TODO: need to do something different than just return a default-constructed object here
         PLOG_ERROR << "failed to obtain capabilities from driver";
-        return {};
+        throw std::make_exception_ptr(UwbException(UwbStatusGeneric::Rejected));
     }
 
     try {
-        auto [uwbStatus, uwbDeviceInformation] = resultFuture.get();
-        if (!IsUwbStatusOk(uwbStatus)) {
-            PLOG_ERROR << "uwb device reported an error obtaining uwb device information, status =" << ::ToString(uwbStatus);
-            return {};
-        }
+        auto uwbDeviceInformation = resultFuture.get();
         return std::move(uwbDeviceInformation);
-    } catch (std::exception& e) {
-        PLOG_ERROR << "caught exception obtaining uwb device information (" << e.what() << ")";
-        return {};
+    } catch (const UwbException& e) {
+        PLOG_ERROR << "caught exception obtaining uwb device information (" << ::ToString(e.Status) << ")";
+        throw e;
     }
 }
 

--- a/windows/devices/uwb/UwbDevice.cxx
+++ b/windows/devices/uwb/UwbDevice.cxx
@@ -69,6 +69,29 @@ UwbDevice::GetCapabilitiesImpl()
     }
 }
 
+UwbDeviceInformation
+UwbDevice::GetDeviceInformationImpl()
+{
+    auto resultFuture = m_uwbDeviceConnector->GetDeviceInformation();
+    if (!resultFuture.valid()) {
+        // TODO: need to do something different than just return a default-constructed object here
+        PLOG_ERROR << "failed to obtain capabilities from driver";
+        return {};
+    }
+
+    try {
+        auto [uwbStatus, uwbDeviceInformation] = resultFuture.get();
+        if (!IsUwbStatusOk(uwbStatus)) {
+            PLOG_ERROR << "uwb device reported an error obtaining uwb device information, status =" << ::ToString(uwbStatus);
+            return {};
+        }
+        return std::move(uwbDeviceInformation);
+    } catch (std::exception& e) {
+        PLOG_ERROR << "caught exception obtaining uwb device information (" << e.what() << ")";
+        return {};
+    }
+}
+
 bool
 UwbDevice::IsEqual(const ::uwb::UwbDevice& other) const noexcept
 {

--- a/windows/devices/uwb/UwbDevice.cxx
+++ b/windows/devices/uwb/UwbDevice.cxx
@@ -3,6 +3,8 @@
 #include <ios>
 #include <stdexcept>
 
+#include <uwb/protocols/fira/FiraDevice.hxx>
+#include <uwb/protocols/fira/UwbException.hxx>
 #include <windows/devices/uwb/UwbCxAdapterDdiLrp.hxx>
 #include <windows/devices/uwb/UwbCxDdiLrp.hxx>
 #include <windows/devices/uwb/UwbDevice.hxx>
@@ -89,6 +91,24 @@ UwbDevice::GetDeviceInformationImpl()
     } catch (std::exception& e) {
         PLOG_ERROR << "caught exception obtaining uwb device information (" << e.what() << ")";
         return {};
+    }
+}
+
+void
+UwbDevice::ResetImpl()
+{
+    auto resultFuture = m_uwbDeviceConnector->Reset();
+    if (!resultFuture.valid()) {
+        // TODO: need to do something different than just return a default-constructed object here
+        PLOG_ERROR << "failed to reset the uwb device";
+        throw UwbException(UwbStatusGeneric::Failed);
+    }
+
+    try {
+        resultFuture.get();
+    } catch (const UwbException& e) {
+        PLOG_ERROR << "caught exception resetting the uwb device (" << ::ToString(e.Status) << ")";
+        throw e;
     }
 }
 

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -44,10 +44,10 @@ UwbDeviceConnector::Reset()
     return resultFuture;
 }
 
-std::future<::uwb::protocol::fira::UwbDeviceInformation>
+std::future<std::tuple<UwbStatus, UwbDeviceInformation>>
 UwbDeviceConnector::GetDeviceInformation()
 {
-    std::promise<UwbDeviceInformation> resultPromise;
+    std::promise<std::tuple<UwbStatus, UwbDeviceInformation>> resultPromise;
     auto resultFuture = resultPromise.get_future();
 
     wil::unique_hfile handleDriver;
@@ -83,7 +83,8 @@ UwbDeviceConnector::GetDeviceInformation()
             PLOG_DEBUG << "IOCTL_UWB_GET_DEVICE_INFO succeeded";
             const auto &deviceInformation = *reinterpret_cast<UWB_DEVICE_INFO*>(std::data(deviceInformationBuffer));
             const auto uwbDeviceInformation = UwbCxDdi::To(deviceInformation);
-            resultPromise.set_value(std::move(uwbDeviceInformation));
+            const auto uwbStatus = UwbCxDdi::To(deviceInformation.status);
+            resultPromise.set_value(std::make_tuple(std::move(uwbStatus), std::move(uwbDeviceInformation)));
             break;
         }
     }

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -1,4 +1,5 @@
 
+#include <exception>
 #include <ios>
 #include <ranges>
 #include <stdexcept>
@@ -6,6 +7,7 @@
 #include <plog/Log.h>
 #include <wil/result.h>
 
+#include <uwb/protocols/fira/UwbException.hxx>
 #include <windows/devices/DeviceHandle.hxx>
 #include <windows/devices/uwb/UwbCxAdapterDdiLrp.hxx>
 #include <windows/devices/uwb/UwbCxDdiLrp.hxx>
@@ -31,15 +33,30 @@ UwbDeviceConnector::DeviceName() const noexcept
     return m_deviceName;
 }
 
-std::future<UwbStatus>
+std::future<void>
 UwbDeviceConnector::Reset()
 {
-    std::promise<UwbStatus> resultPromise{};
+    std::promise<void> resultPromise{};
     auto resultFuture = resultPromise.get_future();
-    // TODO: invoke IOCTL_UWB_DEVICE_RESET
 
-    UwbStatus uwbStatus{}; // TODO: set this to value obtained from IOCTL
-    resultPromise.set_value(uwbStatus);
+    wil::unique_hfile handleDriver;
+    auto hr = OpenDriverHandle(handleDriver, m_deviceName.c_str());
+    if (FAILED(hr)) {
+        PLOG_ERROR << "failed to obtain driver handle for " << m_deviceName << ", hr=" << std::showbase << std::hex << hr;
+        resultPromise.set_exception(std::make_exception_ptr(UwbException(UwbStatusGeneric::Rejected)));
+        return resultFuture;
+    }
+
+    UWB_STATUS status;
+    BOOL ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_DEVICE_RESET, nullptr, 0, &status, sizeof status, nullptr, nullptr);
+    if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
+        HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
+        PLOG_ERROR << "error when sending IOCTL_UWB_DEVICE_RESET, hr=" << std::showbase << std::hex << hr;
+        resultPromise.set_exception(std::make_exception_ptr(UwbException(UwbStatusGeneric::Failed)));
+        return resultFuture;
+    }
+
+    resultPromise.set_value();
 
     return resultFuture;
 }
@@ -81,9 +98,9 @@ UwbDeviceConnector::GetDeviceInformation()
             continue;
         } else {
             PLOG_DEBUG << "IOCTL_UWB_GET_DEVICE_INFO succeeded";
-            const auto &deviceInformation = *reinterpret_cast<UWB_DEVICE_INFO*>(std::data(deviceInformationBuffer));
-            const auto uwbDeviceInformation = UwbCxDdi::To(deviceInformation);
-            const auto uwbStatus = UwbCxDdi::To(deviceInformation.status);
+            auto &deviceInformation = *reinterpret_cast<UWB_DEVICE_INFO*>(std::data(deviceInformationBuffer));
+            auto uwbDeviceInformation = UwbCxDdi::To(deviceInformation);
+            auto uwbStatus = UwbCxDdi::To(deviceInformation.status);
             resultPromise.set_value(std::make_tuple(std::move(uwbStatus), std::move(uwbDeviceInformation)));
             break;
         }

--- a/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
@@ -23,7 +23,7 @@ struct IUwbDeviceDdi
     Reset() = 0;
 
     // IOCTL_UWB_GET_DEVICE_INFO
-    virtual std::future<::uwb::protocol::fira::UwbDeviceInformation>
+    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, ::uwb::protocol::fira::UwbDeviceInformation>>
     GetDeviceInformation() = 0;
 
     // IOCTL_UWB_GET_DEVICE_CAPABILITIES

--- a/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
@@ -19,7 +19,7 @@ namespace windows::devices::uwb
 struct IUwbDeviceDdi
 {
     // IOCTL_UWB_DEVICE_RESET
-    virtual std::future<::uwb::protocol::fira::UwbStatus>
+    virtual std::future<void>
     Reset() = 0;
 
     // IOCTL_UWB_GET_DEVICE_INFO

--- a/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
@@ -23,7 +23,7 @@ struct IUwbDeviceDdi
     Reset() = 0;
 
     // IOCTL_UWB_GET_DEVICE_INFO
-    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, ::uwb::protocol::fira::UwbDeviceInformation>>
+    virtual std::future<::uwb::protocol::fira::UwbDeviceInformation>
     GetDeviceInformation() = 0;
 
     // IOCTL_UWB_GET_DEVICE_CAPABILITIES

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
@@ -85,6 +85,14 @@ private:
     virtual ::uwb::protocol::fira::UwbCapability
     GetCapabilitiesImpl() override;
 
+    /**
+     * @brief Get the FiRa device information of the device.
+     * 
+     * @return ::uwb::protocol::fira::UwbDeviceInformation 
+     */
+    virtual ::uwb::protocol::fira::UwbDeviceInformation
+    GetDeviceInformationImpl() override;
+
 private:
     const std::string m_deviceName;
     std::shared_ptr<UwbDeviceConnector> m_uwbDeviceConnector;

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
@@ -93,6 +93,12 @@ private:
     virtual ::uwb::protocol::fira::UwbDeviceInformation
     GetDeviceInformationImpl() override;
 
+    /**
+     * @brief Reset the device to an initial clean state. 
+     */
+    virtual void
+    ResetImpl() override;
+
 private:
     const std::string m_deviceName;
     std::shared_ptr<UwbDeviceConnector> m_uwbDeviceConnector;

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
@@ -61,7 +61,7 @@ public:
     virtual std::future<void>
     Reset() override;
 
-    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, ::uwb::protocol::fira::UwbDeviceInformation>>
+    virtual std::future<::uwb::protocol::fira::UwbDeviceInformation>
     GetDeviceInformation() override;
 
     virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, ::uwb::protocol::fira::UwbCapability>>

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
@@ -61,7 +61,7 @@ public:
     virtual std::future<::uwb::protocol::fira::UwbStatus>
     Reset() override;
 
-    virtual std::future<::uwb::protocol::fira::UwbDeviceInformation>
+    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, ::uwb::protocol::fira::UwbDeviceInformation>>
     GetDeviceInformation() override;
 
     virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, ::uwb::protocol::fira::UwbCapability>>

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
@@ -58,7 +58,7 @@ public:
 
 public:
     // IUwbDeviceDdi
-    virtual std::future<::uwb::protocol::fira::UwbStatus>
+    virtual std::future<void>
     Reset() override;
 
     virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, ::uwb::protocol::fira::UwbDeviceInformation>>


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

* Allow uwb devices to be reset.
* Allow obtaining FIRA device information from a uwb device.

### Technical Details

* Add `UwbDevice` top-level functions for:
    - resetting the device
    - obtaining device information
* Implement `IOCTL_UWB_DEVICE_RESET`.
* Introduce `UwbException` for reporting API errors.

### Test Results

TBD

### Reviewer Focus

None

### Future Work

* The existing impls need to be converted to throw `UwbException` instead of returning it directly in a `std::tuple`

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
