### PR TITLE
Implement simulator driver capability query and connect to direct tool

### DIFF
--- a/windows/devices/uwbsimulator/UwbDeviceSimulator.cxx
+++ b/windows/devices/uwbsimulator/UwbDeviceSimulator.cxx
@@ -53,7 +53,7 @@ UwbDeviceSimulator::GetSimulatorCapabilities()
     try {
         auto simulatorCapabilities = resultFuture.get();
         return std::move(simulatorCapabilities);
-    } catch (const UwbException &e) {
+    } catch (const UwbException& e) {
         PLOG_ERROR << "caught exception obtaining simulator capabilities";
         throw e;
     }

--- a/windows/devices/uwbsimulator/UwbDeviceSimulator.cxx
+++ b/windows/devices/uwbsimulator/UwbDeviceSimulator.cxx
@@ -1,7 +1,13 @@
 
+#include <exception>
+
+#include <plog/Log.h>
+
+#include <uwb/protocols/fira/UwbException.hxx>
 #include <windows/devices/uwb/simulator/UwbDeviceSimulator.hxx>
 #include <windows/devices/uwb/simulator/UwbSessionSimulator.hxx>
 
+using namespace ::uwb::protocol::fira;
 using namespace windows::devices::uwb::simulator;
 
 UwbDeviceSimulator::UwbDeviceSimulator(std::string deviceName) :
@@ -38,7 +44,17 @@ UwbDeviceSimulator::CreateSessionImpl(std::weak_ptr<::uwb::UwbSessionEventCallba
 UwbSimulatorCapabilities
 UwbDeviceSimulator::GetSimulatorCapabilities()
 {
-    UwbSimulatorCapabilities uwbSimulatorCapabilities{};
-    // TODO: invoke IOCTL_UWB_DEVICE_SIM_GET_CAPABILITIES IOCTL
-    return uwbSimulatorCapabilities;
+    auto resultFuture = m_uwbDeviceSimulatorConnector->GetCapabilites();
+    if (!resultFuture.valid()) {
+        PLOG_ERROR << "failed to obtain simulator capabilities";
+        throw UwbException(UwbStatusGeneric::Failed);
+    }
+
+    try {
+        auto simulatorCapabilities = resultFuture.get();
+        return std::move(simulatorCapabilities);
+    } catch (const UwbException &e) {
+        PLOG_ERROR << "caught exception obtaining simulator capabilities";
+        throw e;
+    }
 }

--- a/windows/tools/uwb/simulator/Main.cxx
+++ b/windows/tools/uwb/simulator/Main.cxx
@@ -36,8 +36,8 @@ main(int argc, char* argv[])
     CLI::App app{};
     app.name("uwbsim");
     app.description("control and interact with uwb simulator devices");
-    bool getCapabilities{ false };
 
+    bool getCapabilities{ false };
     std::string deviceName{};
     app.add_option("--deviceName, -d", deviceName, "The uwb simulator device name (path)");
     app.add_flag("--getCapabilities", getCapabilities, "enumerate the capabilities of the simulator");
@@ -78,7 +78,7 @@ main(int argc, char* argv[])
         try {
             auto capabilities = uwbDeviceSimulator->GetSimulatorCapabilities();
             std::cout << "Capabilities: Version " << std::showbase << std::hex << capabilities.Version << std::endl;
-        } catch (const UwbException &e) {
+        } catch (const UwbException& e) {
             std::cerr << "failed to obtain uwb simulator capabilities (error=" << ::ToString(e.Status) << ")";
             return -3;
         }


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Allow the simulator capabilities to be queried.

### Technical Details

* Connect the `UwbDeviceSimulator` class to the connector function for retrieving capabilities.
* Add a `--getCapabilities` flag to the standalone simulator command-line tool to retrieve and print the capabilities.

### Test Results

None

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
