### PR TITLE
Fix UWB simulator driver DDI handler dispatching

### DIFF
--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.hxx
@@ -20,7 +20,7 @@ class UwbSimulatorDdiHandler :
     public IUwbSimulatorDdiHandler
 {
 public:
-    UwbSimulatorDdiHandler();
+    explicit UwbSimulatorDdiHandler(WDFFILEOBJECT wdfFile);
 
     /**
      * @brief Indicates whether the specified i/o control code is handled by
@@ -123,6 +123,7 @@ private:
     static const std::initializer_list<windows::devices::uwb::simulator::UwbSimulatorDispatchEntry<UwbSimulatorDdiHandler>> Dispatch;
 
 private:
+    WDFFILEOBJECT m_wdfFile;
     std::unique_ptr<windows::devices::uwb::simulator::UwbSimulatorDdiCallbacks> m_callbacks;
 };
 } // namespace windows::devices::uwb::simulator

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.cxx
@@ -499,7 +499,8 @@ UwbSimulatorDdiHandler::OnUwbSimulatorTriggerSessionEvent(WDFREQUEST request, st
     return status;
 }
 
-UwbSimulatorDdiHandler::UwbSimulatorDdiHandler() :
+UwbSimulatorDdiHandler::UwbSimulatorDdiHandler(WDFFILEOBJECT wdfFile) :
+    m_wdfFile(wdfFile),
     m_callbacks(std::make_unique<UwbSimulatorDdiCallbacks>())
 {
 }

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.cxx
@@ -63,7 +63,7 @@ const std::initializer_list<UwbSimulatorDispatchEntry<UwbSimulatorDdiHandler>> U
     MakeLrpDispatchEntry<UWB_GET_RANGING_COUNT, UWB_RANGING_COUNT>(IOCTL_UWB_GET_RANGING_COUNT, &UwbSimulatorDdiHandler::OnUwbSessionGetRangingCount),
     MakeLrpDispatchEntry<Unrestricted, UWB_NOTIFICATION_DATA>(IOCTL_UWB_NOTIFICATION, &UwbSimulatorDdiHandler::OnUwbNotification),
     // GUID_DEVINTERFACE_UWB_SIMULATOR Handlers
-    MakeLrpDispatchEntry<UwbSimulatorCapabilities, Unrestricted>(IOCTL_UWB_DEVICE_SIM_GET_CAPABILITIES, &UwbSimulatorDdiHandler::OnUwbSimulatorCapabilities),
+    MakeLrpDispatchEntry<Unrestricted, UwbSimulatorCapabilities>(IOCTL_UWB_DEVICE_SIM_GET_CAPABILITIES, &UwbSimulatorDdiHandler::OnUwbSimulatorCapabilities),
     MakeLrpDispatchEntry<UwbSimulatorTriggerSessionEventArgs, Unrestricted>(IOCTL_UWB_DEVICE_SIM_TRIGGER_SESSION_EVENT, &UwbSimulatorDdiHandler::OnUwbSimulatorTriggerSessionEvent),
 };
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDevice.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDevice.cxx
@@ -1,9 +1,12 @@
 
 #include <memory>
 
+#include "UwbSimulatorDdiHandler.hxx"
 #include "UwbSimulatorDevice.hxx"
 #include "UwbSimulatorDeviceFile.hxx"
 #include "UwbSimulatorTracelogging.hxx"
+
+using windows::devices::uwb::simulator::UwbSimulatorDdiHandler;
 
 UwbSimulatorDevice::UwbSimulatorDevice(WDFDEVICE wdfDevice) :
     m_wdfDevice(wdfDevice)
@@ -167,6 +170,8 @@ UwbSimulatorDevice::OnFileCreate(WDFDEVICE device, WDFREQUEST request, WDFFILEOB
 
     auto uwbSimulatorFileBuffer = GetUwbSimulatorFile(file);
     auto uwbSimulatorFile [[maybe_unused]] = new (uwbSimulatorFileBuffer) UwbSimulatorDeviceFile(file);
+    auto uwbSimulatorHandler = std::make_unique<UwbSimulatorDdiHandler>(file);
+    uwbSimulatorFile->RegisterHandler(std::move(uwbSimulatorHandler));
 
     // TODO: Here, uwbSimulatorFile should be associated with the DDI it is responsible for handling.
     // It could make sense for it to use the pimpl idiom since the storage for the class is pre-allocated

--- a/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.cxx
@@ -3,10 +3,19 @@
 #include <iterator>
 
 #include "UwbSimulatorDeviceFile.hxx"
+#include "UwbSimulatorTracelogging.hxx"
+
+using windows::devices::uwb::simulator::IUwbSimulatorDdiHandler;
 
 UwbSimulatorDeviceFile::UwbSimulatorDeviceFile(WDFFILEOBJECT wdfFile) :
     m_wdfFile(wdfFile)
 {}
+
+void
+UwbSimulatorDeviceFile::RegisterHandler(std::unique_ptr<IUwbSimulatorDdiHandler> handler)
+{
+    m_ddiHandlers.push_back(std::move(handler));
+}
 
 /* static */
 VOID
@@ -48,24 +57,34 @@ UwbSimulatorDeviceFile::OnRequestCancel(WDFREQUEST /* request */)
 NTSTATUS
 UwbSimulatorDeviceFile::OnRequest(WDFREQUEST request, ULONG ioControlCode, size_t inputBufferLength, size_t outputBufferLength)
 {
+    NTSTATUS status;
+
     // Find a handler for this i/o control code.
     auto ddiHandlerIt = std::find_if(std::begin(m_ddiHandlers), std::end(m_ddiHandlers), [&](const auto &ddiHandler) {
         return (ddiHandler->HandlesIoControlCode(ioControlCode));
     });
     if (ddiHandlerIt == std::cend(m_ddiHandlers)) {
-        return STATUS_NOT_IMPLEMENTED;
+        TraceLoggingWrite(
+            UwbSimulatorTraceloggingProvider,
+            "RequestNotImplemented",
+            TraceLoggingLevel(TRACE_LEVEL_ERROR),
+            TraceLoggingHexUInt32(ioControlCode, "IoControlCode"));
+        status = STATUS_NOT_IMPLEMENTED;
+        WdfRequestComplete(request, status);
+        return status;
     }
 
     // Use the handler to validate the request.
     auto &ddiHandler = *ddiHandlerIt;
-    auto status = ddiHandler->ValidateRequest(request, ioControlCode, inputBufferLength, outputBufferLength);
+    status = ddiHandler->ValidateRequest(request, ioControlCode, inputBufferLength, outputBufferLength);
     switch (status) {
     case STATUS_SUCCESS:
         break;
     case STATUS_BUFFER_TOO_SMALL:
         WdfRequestCompleteWithInformation(request, status, outputBufferLength);
-        // intentional fall-through
+        return status;
     default:
+        WdfRequestComplete(request, status);
         return status;
     }
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.hxx
@@ -20,6 +20,14 @@ public:
     explicit UwbSimulatorDeviceFile(WDFFILEOBJECT wdfFile);
 
     /**
+     * @brief Register a DDI handler with this file instance.
+     *
+     * @param handler The handler to register.
+     */
+    void
+    RegisterHandler(std::unique_ptr<windows::devices::uwb::simulator::IUwbSimulatorDdiHandler> handler);
+
+    /**
      * @brief Device i/o control handler function.
      *
      * This is invoked when the driver receives an i/o control request on the

--- a/windows/drivers/uwb/simulator/UwbSimulatorDispatchEntry.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDispatchEntry.hxx
@@ -101,8 +101,12 @@ MakeDispatchEntry(ULONG ioControlCode, typename UwbSimulatorDispatchEntry<ClassT
     };
 }
 
-namespace detail
-{
+/**
+ * @brief Sentinel type to denote that the buffer size should be unrestricted.
+ */
+struct Unrestricted
+{};
+
 /**
  * @brief Type trait to define the minimum size for a dispatch entry.
  *
@@ -111,16 +115,10 @@ namespace detail
  * @tparam T The expected type contained in the buffer.
  */
 template <typename BufferT>
-struct DispatchEntryMinimumSizeImpl
+struct DispatchEntryMinimumSize
 {
     static constexpr std::size_t value = sizeof(BufferT);
 };
-
-/**
- * @brief Sentinel type to denote that the buffer size should be unrestricted.
- */
-struct Unrestricted
-{};
 
 /**
  * @brief Specialization to enforce no minimum buffer size (0).
@@ -128,26 +126,10 @@ struct Unrestricted
  * @tparam Sentinel Unrestricted type.
  */
 template <>
-struct DispatchEntryMinimumSizeImpl<Unrestricted>
+struct DispatchEntryMinimumSize<Unrestricted>
 {
     static constexpr std::size_t value = 0;
 };
-
-/**
- * @brief Helper alias to resolve the type value of the
- * DispatchEntryMinimumSizeImpl trait, which denotes the size of the buffer.
- *
- * @tparam T The expected type contained in the buffer.
- */
-template <typename BufferT>
-inline constexpr std::size_t DispatchEntryMinimumSizeImpl_v = DispatchEntryMinimumSizeImpl<BufferT>::value;
-
-} // namespace detail
-
-/**
- * @brief Helper type to denote that the buffer size should not be restricted.
- */
-using Unrestricted = detail::DispatchEntryMinimumSizeImpl<detail::Unrestricted>;
 
 /**
  * @brief Helper function to create a UwbSimulatorDispatchEntry that uses the
@@ -174,8 +156,8 @@ MakeDispatchEntry(ULONG ioControlCode, typename UwbSimulatorDispatchEntry<ClassT
     return MakeDispatchEntry<ClassT>(
         ioControlCode,
         handler,
-        detail::DispatchEntryMinimumSizeImpl_v<InputT>,
-        detail::DispatchEntryMinimumSizeImpl_v<OutputT>);
+        DispatchEntryMinimumSize<InputT>::value,
+        DispatchEntryMinimumSize<OutputT>::value);
 }
 } // namespace windows::devices::uwb::simulator
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorIoQueue.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorIoQueue.cxx
@@ -86,6 +86,8 @@ UwbSimulatorIoQueue::OnIoDeviceControl(WDFREQUEST request, size_t outputBufferLe
     UwbSimulatorDeviceFile *uwbSimulatorDeviceFile = GetUwbSimulatorFile(WdfRequestGetFileObject(request));
     if (uwbSimulatorDeviceFile != nullptr) {
         status = uwbSimulatorDeviceFile->OnRequest(request, ioControlCode, inputBufferLength, outputBufferLength);
+    } else {
+        WdfRequestComplete(request, status);
     }
 
     TraceLoggingWrite(

--- a/windows/tools/uwb/simulator/Main.cxx
+++ b/windows/tools/uwb/simulator/Main.cxx
@@ -44,8 +44,8 @@ decodeSimulatorCapabilitiesVersion(const UwbSimulatorCapabilities& capabilities)
     static constexpr auto VersionMinorShift = 0U;
 
     const auto& version = capabilities.Version;
-    const uint16_t versionMajor = static_cast<uint16_t>((version & VersionMajorMask) >> VersionMajorShift);
-    const uint16_t versionMinor = static_cast<uint16_t>((version & VersionMinorMask) >> VersionMinorShift);
+    const auto versionMajor = static_cast<uint16_t>((version & VersionMajorMask) >> VersionMajorShift);
+    const auto versionMinor = static_cast<uint16_t>((version & VersionMinorMask) >> VersionMinorShift);
     return std::make_tuple(versionMajor, versionMinor);
 }
 } // namespace detail


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Ensure the simulator driver dispatches DDI requests to the appropriate handlers.

### Technical Details

* Register DDI handlers with each file object.
* Fix template-foo used to establish buffer size bounds.
* Fix incorrect order of input/output buffer size bounds for `IOCTL_UWB_DEVICE_SIM_GET_CAPABILITIES` dispatch table entry.
* Print uwb simulator version in command line tool.
* Complete driver request on some error conditions that previously omitted this.

### Test Results

Ran `uwbsim.exe` against simulator driver (under a debugger) and observed version number being printed on the console without any exceptions being thrown in either process:

```
PS C:\src\nearobject-framework\windows\drivers\uwb\simulator> cmdd .\uwbsim.exe --getCapabilities
creating uwb simulator device \\?\ROOT#PROXIMITY#0000#{21663d8d-2dd6-45c7-a54a-d902202124d7}

Capabilities: Version v1.0
initialization succeeded
```

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
