### PR TITLE
User/corbinphipps/nocli add reset

### DIFF
--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -80,6 +80,12 @@ NearObjectCli::GetRangeStopApp() noexcept
 }
 
 CLI::App&
+NearObjectCli::GetRawDeviceResetApp() noexcept
+{
+    return *m_rawDeviceResetApp;
+}
+
+CLI::App&
 NearObjectCli::GetRawGetDeviceInfoApp() noexcept
 {
     return *m_rawGetDeviceInfoApp;
@@ -216,6 +222,7 @@ NearObjectCli::AddSubcommandUwbRaw(CLI::App* parent)
     auto rawApp = parent->add_subcommand("raw", "individual commands")->require_subcommand()->fallthrough();
 
     // sub-commands
+    m_rawDeviceResetApp = AddSubcommandUwbRawDeviceReset(rawApp);
     m_rawGetDeviceInfoApp = AddSubcommandUwbRawGetDeviceInfo(rawApp);
 
     return rawApp;
@@ -316,6 +323,32 @@ NearObjectCli::AddSubcommandUwbRangeStop(CLI::App* parent)
     });
 
     return rangeStopApp;
+}
+
+CLI::App*
+NearObjectCli::AddSubcommandUwbRawDeviceReset(CLI::App* parent)
+{
+    // top-level command
+    auto rawDeviceResetApp = parent->add_subcommand("devicereset", "DeviceReset")->fallthrough();
+
+    rawDeviceResetApp->parse_complete_callback([this] {
+        std::cout << "device reset" << std::endl;
+    });
+
+    rawDeviceResetApp->final_callback([this] {
+        auto uwbDevice = GetUwbDevice();
+        if (!uwbDevice) {
+            std::cerr << "no device found" << std::endl;
+            return;
+        }
+        if (!uwbDevice->Initialize()) {
+            std::cerr << "device not initialized" << std::endl;
+        }
+
+        m_cliHandler->HandleDeviceReset(uwbDevice);
+    });
+
+    return rawDeviceResetApp;
 }
 
 CLI::App*

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -79,18 +79,6 @@ NearObjectCli::GetRangeStopApp() noexcept
     return *m_rangeStopApp;
 }
 
-CLI::App&
-NearObjectCli::GetRawDeviceResetApp() noexcept
-{
-    return *m_rawDeviceResetApp;
-}
-
-CLI::App&
-NearObjectCli::GetRawGetDeviceInfoApp() noexcept
-{
-    return *m_rawGetDeviceInfoApp;
-}
-
 std::shared_ptr<uwb::UwbDevice>
 NearObjectCli::GetUwbDevice() noexcept
 {
@@ -222,8 +210,8 @@ NearObjectCli::AddSubcommandUwbRaw(CLI::App* parent)
     auto rawApp = parent->add_subcommand("raw", "individual commands")->require_subcommand()->fallthrough();
 
     // sub-commands
-    m_rawDeviceResetApp = AddSubcommandUwbRawDeviceReset(rawApp);
-    m_rawGetDeviceInfoApp = AddSubcommandUwbRawGetDeviceInfo(rawApp);
+    AddSubcommandUwbRawDeviceReset(rawApp);
+    AddSubcommandUwbRawGetDeviceInfo(rawApp);
 
     return rawApp;
 }

--- a/tools/cli/NearObjectCliHandler.cxx
+++ b/tools/cli/NearObjectCliHandler.cxx
@@ -36,6 +36,13 @@ NearObjectCliHandler::HandleMonitorMode() noexcept
 }
 
 void
+NearObjectCliHandler::HandleDeviceReset(std::shared_ptr<uwb::UwbDevice> uwbDevice) noexcept
+{
+    uwbDevice->Reset();
+    std::cout << "Device reset successful" << std::endl;
+}
+
+void
 NearObjectCliHandler::HandleGetDeviceInfo(std::shared_ptr<uwb::UwbDevice> uwbDevice) noexcept
 {
     auto deviceInfo = uwbDevice->GetDeviceInformation();

--- a/tools/cli/NearObjectCliHandler.cxx
+++ b/tools/cli/NearObjectCliHandler.cxx
@@ -39,7 +39,6 @@ void
 NearObjectCliHandler::HandleDeviceReset(std::shared_ptr<uwb::UwbDevice> uwbDevice) noexcept
 {
     uwbDevice->Reset();
-    std::cout << "Device reset successful" << std::endl;
 }
 
 void

--- a/tools/cli/include/nearobject/cli/NearObjectCli.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCli.hxx
@@ -97,22 +97,6 @@ public:
     CLI::App&
     GetRangeStopApp() noexcept;
 
-    /**
-     * @brief Get the app object associated with the "uwb raw devicereset" sub-command.
-     * 
-     * @return CLI::App&
-     */
-    CLI::App&
-    GetRawDeviceResetApp() noexcept;
-
-    /**
-    * @brief Get the app object associated with the "uwb raw getdeviceinfo" sub-command.
-    *
-    * @return CLI::App&
-    */
-    CLI::App&
-    GetRawGetDeviceInfoApp() noexcept;
-
 private:
     /**
      * @brief Obtain a reference to the resolved uwb device.
@@ -225,8 +209,6 @@ private:
     CLI::App* m_rawApp;
     CLI::App* m_rangeStartApp;
     CLI::App* m_rangeStopApp;
-    CLI::App* m_rawDeviceResetApp;
-    CLI::App* m_rawGetDeviceInfoApp;
 };
 } // namespace nearobject::cli
 

--- a/tools/cli/include/nearobject/cli/NearObjectCli.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCli.hxx
@@ -98,6 +98,14 @@ public:
     GetRangeStopApp() noexcept;
 
     /**
+     * @brief Get the app object associated with the "uwb raw devicereset" sub-command.
+     * 
+     * @return CLI::App&
+     */
+    CLI::App&
+    GetRawDeviceResetApp() noexcept;
+
+    /**
     * @brief Get the app object associated with the "uwb raw getdeviceinfo" sub-command.
     *
     * @return CLI::App&
@@ -185,6 +193,15 @@ private:
     AddSubcommandUwbRangeStop(CLI::App* parent);
 
     /**
+     * @brief Add the 'uwb raw devicereset' sub-command.
+     * 
+     * @param parent The parent app to add the command to.
+     * @return CLI::App*
+     */
+    CLI::App*
+    AddSubcommandUwbRawDeviceReset(CLI::App* parent);
+
+    /**
     * @brief Add the 'uwb raw getdeviceinfo' sub-command.
     *
     * @param parent The parent app to add the command to.
@@ -208,6 +225,7 @@ private:
     CLI::App* m_rawApp;
     CLI::App* m_rangeStartApp;
     CLI::App* m_rangeStopApp;
+    CLI::App* m_rawDeviceResetApp;
     CLI::App* m_rawGetDeviceInfoApp;
 };
 } // namespace nearobject::cli

--- a/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
@@ -58,6 +58,14 @@ struct NearObjectCliHandler
     HandleMonitorMode() noexcept;
 
     /**
+     * @brief Invoked by the command-line driver when the request is to reset the device.
+     *
+     * @param uwbDevice The resolved uwb device to reset.
+     */
+    virtual void
+    HandleDeviceReset(std::shared_ptr<uwb::UwbDevice> uwbDevice) noexcept;
+
+    /**
     * @brief Invoked by the command-line driver when the request is to get device info.
     * 
     * @param uwbDevice The resolved uwb device to get device info from.

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -64,9 +64,16 @@ UwbDeviceConnector::Reset()
         PLOG_ERROR << "error when sending IOCTL_UWB_DEVICE_RESET, hr=" << std::showbase << std::hex << hr;
         resultPromise.set_exception(std::make_exception_ptr(UwbException(UwbStatusGeneric::Failed)));
         return resultFuture;
+    } else {
+        PLOG_DEBUG << "IOCTL_UWB_DEVICE_RESET succeeded";
+        auto& deviceResetStatus = *reinterpret_cast<UWB_STATUS*>(std::data(deviceResetStatusBuffer));
+        auto uwbStatus = UwbCxDdi::To(deviceResetStatus);
+        if (!IsUwbStatusOk(uwbStatus)) {
+            resultPromise.set_exception(std::make_exception_ptr(UwbException(std::move(uwbStatus))));
+        } else {
+            resultPromise.set_value();
+        }
     }
-
-    resultPromise.set_value();
 
     return resultFuture;
 }


### PR DESCRIPTION
### Type

- [x] Bug fix
- [x] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

This PR adds the device reset command to the nocli tool

### Technical Details

Added "devicereset" sub-command to nocli
Fix the device reset code in UwbDeviceConnector to properly call DeviceIoControl

### Test Results

Device reset succeeds on TestClient driver

### Reviewer Focus

None.

### Future Work

None.

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.