### PR TITLE
Prepare source tree for release, part 2

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -14,6 +14,14 @@ on:
         required: false
         default: true
         type: boolean
+      install:
+        required: false
+        default: false
+        type: boolean
+      package:
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   build:
@@ -23,7 +31,9 @@ jobs:
       matrix:
         os: [ ubuntu-22.04, windows-2022 ]
         build-type: ${{ fromJson(inputs.build-types) }}
-    runs-on: ${{ matrix.os }} 
+    runs-on: ${{ matrix.os }}
+    env:
+      preset-name: cicd
     
     steps:
     - name: Checkout repository
@@ -36,14 +46,21 @@ jobs:
         languages: 'cpp'
 
     - name: CMake Configure
-      run: cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ matrix.build-type }}
+      run: cmake --preset ${{ env.preset-name }} -DCMAKE_BUILD_TYPE=${{ matrix.build-type }}
 
     - name: CMake Build
-      run: cmake --build ${{ github.workspace }}/build --config ${{ matrix.build-type }}
+      run: cmake --build --preset ${{ env.preset-name }} --config ${{ matrix.build-type }}
 
     - name: CMake Test (ctest)
-      working-directory: ${{ github.workspace }}/build
-      run: ctest -C ${{ matrix.build-types }}
+      run: ctest --preset $${ env.preset-name }} -C ${{ matrix.build-type }}
+
+    - name: CMake Install
+      if: inputs.install == true
+      run: cmake --install --preset ${{ env.preset-name }} --config ${{ matrix.build-type }}
+
+    - name: CMake Package (cpack)
+      if: inputs.package == true
+      run: cpack --preset ${{ env.preset-name }} -C $${{ matrix.build-type }}
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -52,7 +52,7 @@ jobs:
       run: cmake --build --preset ${{ env.preset-name }} --config ${{ matrix.build-type }}
 
     - name: CMake Test (ctest)
-      run: ctest --preset $${ env.preset-name }} -C ${{ matrix.build-type }}
+      run: ctest --preset ${{ env.preset-name }} -C ${{ matrix.build-type }}
 
     - name: CMake Install
       if: inputs.install == true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,10 +116,7 @@ include(CheckPIESupported)
 include(CTest)
 include(GNUInstallDirs)
 include(FetchContent)
-
-if (NOF_OFFICIAL_RELEASE)
-  include(cmake/cpack.cmake)
-endif()
+include(cmake/cpack.cmake)
 
 # Set external dependency target versions.
 set(VERSION_NLOHMANN_JSON 3.11.2)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -175,5 +175,21 @@
                 "outputOnFailure": true
             }
         }
+    ],
+    "packagePresets": [
+        {
+            "name": "official-release",
+            "displayName": "Official Release",
+            "configurePreset": "official-release",
+            "packageName": "nearobjectframework",
+            "vendorName": "Microsoft",
+            "generators": [
+                "TXZ",
+                "ZIP"
+            ],
+            "variables": {
+                "CPACK_PACKAGE_DIRECTORY": "${sourceParentDir}/${sourceDirName}-cmake/out/package/${presetName}"
+            }
+        }
     ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -46,7 +46,8 @@
             "hidden": true,
             "displayName": "Out of source build",
             "description": "Configure to build outside of the source tree",
-            "binaryDir": "${sourceParentDir}/${sourceDirName}-cmake/out/build/${presetName}"
+            "binaryDir": "${sourceParentDir}/${sourceDirName}-cmake/out/build/${presetName}",
+            "installDir": "${sourceParentDir}/${sourceDirName}-cmake/out/install/${presetName}"
         },
         {
             "name": "dev-base",
@@ -90,7 +91,7 @@
         },
         {
             "name": "dev-driver",
-            "displayName": "Development (driver)",
+            "displayName": "Development (simulator driver)",
             "description": "Development for the simulator driver",
             "inherits": [
                 "os-windows",
@@ -133,13 +134,20 @@
             }
         },
         {
-            "name": "official-release",
-            "displayName": "Offcial Release",
-            "description": "official release build",
-            "installDir": "${sourceParentDir}/${sourceDirName}-cmake/out/install/${presetName}",
+            "name": "cicd",
+            "displayName": "CI/CD",
+            "description": "Continuous integration and continuous delivery (CI/CD) based build",
             "inherits": [
                 "dev-vcpkg",
                 "out-of-source-build"
+            ]
+        },
+        {
+            "name": "official-release",
+            "displayName": "Offcial Release",
+            "description": "Official release build",
+            "inherits": [
+                "cicd"
             ],
             "cacheVariables": {
                 "NOF_OFFICIAL_RELEASE": true
@@ -165,31 +173,94 @@
         {
             "name": "driver",
             "configurePreset": "dev-driver"
+        },
+        {
+            "name": "cicd",
+            "configurePreset": "cicd"
+        },
+        {
+            "name": "official-release",
+            "configurePreset": "official-release"
         }
     ],
     "testPresets": [
         {
-            "name": "dev",
-            "configurePreset": "dev",
+            "name": "test-common",
+            "hidden": true,
             "output": {
                 "outputOnFailure": true
             }
+        },
+        {
+            "name": "dev",
+            "configurePreset": "dev",
+            "inherits": [
+                "test-common"
+            ]
+        },
+        {
+            "name": "cicd",
+            "configurePreset": "cicd",
+            "inherits": [
+                "test-common"
+            ]
+        },
+        {
+            "name": "official-release",
+            "configurePreset": "official-release",
+            "inherits": [
+                "test-common"
+            ]
         }
     ],
     "packagePresets": [
         {
-            "name": "official-release",
-            "displayName": "Official Release",
-            "configurePreset": "official-release",
+            "name": "package-metadata",
+            "hidden": true,
             "packageName": "nearobjectframework",
-            "vendorName": "Microsoft",
+            "vendorName": "microsoft"
+        },
+        {
+            "name": "package-generators",
+            "hidden": true,
             "generators": [
                 "TXZ",
                 "ZIP"
-            ],
+            ]
+        },
+        {
+            "name": "package-common",
+            "hidden": true,
+            "description": "Settings common to all packaging presets",
+            "inherits": [
+                "package-metadata",
+                "package-generators"
+            ]
+        },
+        {
+            "name": "package-out-of-source",
+            "hidden": true,
             "variables": {
                 "CPACK_PACKAGE_DIRECTORY": "${sourceParentDir}/${sourceDirName}-cmake/out/package/${presetName}"
             }
+        },
+        {
+            "name": "cicd",
+            "displayName": "CI/CD",
+            "configurePreset": "cicd",
+            "inherits": [
+                "package-common",
+                "package-out-of-source"
+            ]
+        },
+        {
+            "name": "official-release",
+            "displayName": "Official Release",
+            "configurePreset": "official-release",
+            "inherits": [
+                "package-common",
+                "package-out-of-source"
+            ]
         }
     ]
 }


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [X] Non-functional change
- [ ] Documentation
- [X] Infrastructure

### Goals

Allow the project source tree to be built for an CI/CD and offciail release using CMake presets.

### Technical Details

* Add configure, build, test, and packaging presets for CI/CD.
* Add `install` and `package` inputs and associated build steps to CMake workflow action.
* Update GitHub CMake workflow action to use the `cicd` CMake preset for configure, build, test, install, and packaging steps.
* Enable CPack for all builds, not just when `NOF_OFFICIAL_BUILD` is set.
* Refactor presets to de-duplicate `installDir` and `binaryDir` settings.
* Fix typo in CMake workflow action test step (`build-types` -> `build-type`).
* Set all available CPack options in package preset (generators, vendor name, package name).

### Test Results

Ran CMake workflow steps locally and verified they all work.

### Reviewer Focus

None

### Future Work

* A workflow for creating a release build still needs to be authored.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
