### PR TITLE
Add official release workflow

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,6 +2,38 @@ name: Build [CMake]
 
 on:
   workflow_dispatch:
+    inputs:
+      build-types:
+        required: false
+        # Note the string here contains a JSON array. This is later converted to an array using fromJson.
+        default: "[ 'Debug' ]"
+        type: string
+        description: 'The CMake build type (CMAKE_BUILD_TYPE) to run.'
+      analyze-codeql:
+        required: false
+        default: true
+        type: boolean
+        description: 'Peform static analysis with CodeQL'
+      install:
+        required: false
+        default: false
+        type: boolean
+        description: 'Invoke CMake install for the project'
+      package:
+        required: false
+        default: false
+        type: boolean
+        description: 'Invoke CMake CPack for the project'
+      publish:
+        required: false
+        default: false
+        type: boolean
+        description: 'Publish build artifcats'
+      preset-name:
+        required: false
+        default: 'cicd'
+        type: string
+        description: 'The name of the preset to use for all CMake operations (configure, build, test, install, package)'
   workflow_call:
     inputs:
       build-types:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,6 +22,14 @@ on:
         required: false
         default: false
         type: boolean
+      publish:
+        required: false
+        default: false
+        type: boolean
+      preset-name:
+        required: false
+        default: 'cicd'
+        type: string
 
 jobs:
   build:
@@ -32,8 +40,6 @@ jobs:
         os: [ ubuntu-22.04, windows-2022 ]
         build-type: ${{ fromJson(inputs.build-types) }}
     runs-on: ${{ matrix.os }}
-    env:
-      preset-name: cicd
     
     steps:
     - name: Checkout repository
@@ -46,21 +52,28 @@ jobs:
         languages: 'cpp'
 
     - name: CMake Configure
-      run: cmake --preset ${{ env.preset-name }} -DCMAKE_BUILD_TYPE=${{ matrix.build-type }}
+      run: cmake --preset ${{ inputs.preset-name }} -DCMAKE_BUILD_TYPE=${{ matrix.build-type }}
 
     - name: CMake Build
-      run: cmake --build --preset ${{ env.preset-name }} --config ${{ matrix.build-type }}
+      run: cmake --build --preset ${{ inputs.preset-name }} --config ${{ matrix.build-type }}
 
     - name: CMake Test (ctest)
-      run: ctest --preset ${{ env.preset-name }} -C ${{ matrix.build-type }}
+      run: ctest --preset ${{ inputs.preset-name }} -C ${{ matrix.build-type }}
 
     - name: CMake Install
       if: inputs.install == true
-      run: cmake --install --preset ${{ env.preset-name }} --config ${{ matrix.build-type }}
+      run: cmake --build --preset ${{ inputs.preset-name }} --target install --config ${{ matrix.build-type }}
 
     - name: CMake Package (cpack)
       if: inputs.package == true
-      run: cpack --preset ${{ env.preset-name }} -C $${{ matrix.build-type }}
+      run: cpack --preset ${{ inputs.preset-name }} -C ${{ matrix.build-type }}
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
+
+    - name: Publish Artifacts
+      if: inputs.publish == true
+      uses: actions/upload-artifact@v3
+      with:
+        name: release-package-${{ matrix-build-type }}
+        path: ${{ github.workspace }}/nearobject-framework-cmake/out/package/${{ inputs.preset-name }}/*.(.xz|zip)

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -75,5 +75,5 @@ jobs:
       if: inputs.publish == true
       uses: actions/upload-artifact@v3
       with:
-        name: release-package-${{ matrix-build-type }}
+        name: release-package-${{ matrix.build-type }}
         path: ${{ github.workspace }}/nearobject-framework-cmake/out/package/${{ inputs.preset-name }}/*.(.xz|zip)

--- a/.github/workflows/official-release.yml
+++ b/.github/workflows/official-release.yml
@@ -1,0 +1,20 @@
+# Workflow to generate official release builds.
+
+name: Official Release Build
+
+# Run on workflow dispatch to allow manual triggering of the workflow, and run
+# on PRs to the release branches.
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ release/** ]
+
+jobs:
+  build-official-release:
+    name: build
+    uses: ./.github/workflows/cmake.yml
+    with:
+      build-types: "[ 'Debug', 'Release' ]"
+      install: true
+      package: true
+      preset-name: official-release


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [X] Non-functional change
- [ ] Documentation
- [X] Infrastructure

### Goals

Allow preparing an official release from GitHub.

### Technical Details

* Add official release workflow.
* Add `Publish Artifacts` step to re-usable CMake build workflow.
* Move preset name variable to workflow inputs instead of hard-coded as env var.

### Test Results

Replicated official release workflow steps locally and confirmed expected outputs.

### Reviewer Focus

None

### Future Work

* Due to the way artifact upload and download works, the archives published (.tar.xz, .zip) will be double-compressed into a zip. This is ugly and should be avoided.
* The build type (Debug, Release) isn't marked in each of the build artifacts. We need to determine how this can be done. It's possible that this can be solved when combining the artifacts, but this has not yet been decided.

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
