### PR TITLE
Fix nocli help text

### DIFF
--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -93,7 +93,7 @@ std::unique_ptr<CLI::App>
 NearObjectCli::CreateParser() noexcept
 {
     // top-level command
-    auto app = std::make_unique<CLI::App>("nocli", "A command line tool to assist with all things nearobject");
+    auto app = std::make_unique<CLI::App>("A command line tool to assist with all things nearobject", "nocli");
     app->require_subcommand();
 
     // sub-commands
@@ -354,7 +354,7 @@ NearObjectCli::AddSubcommandUwbRawGetDeviceInfo(CLI::App* parent)
         if (!uwbDevice) {
             std::cerr << "no device found" << std::endl;
             return;
-        }      
+        }
         if (!uwbDevice->Initialize()) {
             std::cerr << "device not initialized" << std::endl;
         }


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Ensure `nocli` tool help text is correct.

### Technical Details

* Swap order of args passed to `CLI11::App` ctor which expects the app description first, then the app name.

### Test Results

* Ran the tool and verified the output now looks correct.
Before:
```
C:\src\nearobject-framework-cmake\out\install\official-release\bin>nocli.exe --help
nocli
Usage: A command line tool to assist with all things nearobject [OPTIONS] SUBCOMMAND
```

After
```
C:\src\nearobject-framework-cmake\out\install\official-release\bin>nocli.exe --help
A command line tool to assist with all things nearobject
Usage: nocli [OPTIONS] SUBCOMMAND
```

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
