### PR TITLE
Enable publishing artifacts on official release workflow

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -24,7 +24,7 @@ on:
         default: false
         type: boolean
         description: 'Invoke CMake CPack for the project'
-      publish:
+      publish-artifacts:
         required: false
         default: false
         type: boolean
@@ -54,7 +54,7 @@ on:
         required: false
         default: false
         type: boolean
-      publish:
+      publish-artifacts:
         required: false
         default: false
         type: boolean
@@ -104,7 +104,7 @@ jobs:
       uses: github/codeql-action/analyze@v2
 
     - name: Publish Artifacts
-      if: inputs.publish == true
+      if: inputs.publish-artifacts == true
       uses: actions/upload-artifact@v3
       with:
         name: release-package-${{ matrix.build-type }}

--- a/.github/workflows/official-release.yml
+++ b/.github/workflows/official-release.yml
@@ -17,4 +17,5 @@ jobs:
       build-types: "[ 'Debug', 'Release' ]"
       install: true
       package: true
+      publish-artifacts: true
       preset-name: official-release


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [X] Infrastructure

### Goals

Ensure artifacts from the official release build are published.

### Technical Details

* Rename `publish` CMake input argument to `publish-artifacts` for better clarity.
* Set `publish-artifacts` to `true` when calling the cmake workflow from the official release workflow.

### Test Results

N/A

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
