### PR TITLE
Expose workflow_dispatch input arguments in the GitHub Actions UI 

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -4,33 +4,33 @@ on:
   workflow_dispatch:
     inputs:
       build-types:
-        required: false
+        required: true
         # Note the string here contains a JSON array. This is later converted to an array using fromJson.
         default: "[ 'Debug' ]"
         type: string
         description: 'The CMake build type (CMAKE_BUILD_TYPE) to run.'
       analyze-codeql:
-        required: false
+        required: true
         default: true
         type: boolean
         description: 'Peform static analysis with CodeQL'
       install:
-        required: false
+        required: true
         default: false
         type: boolean
         description: 'Invoke CMake install for the project'
       package:
-        required: false
+        required: true
         default: false
         type: boolean
         description: 'Invoke CMake CPack for the project'
       publish-artifacts:
-        required: false
+        required: true
         default: false
         type: boolean
         description: 'Publish build artifcats'
       preset-name:
-        required: false
+        required: true
         default: 'cicd'
         type: string
         description: 'The name of the preset to use for all CMake operations (configure, build, test, install, package)'


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [X] Infrastructure

### Goals

Ensure the cmake reusable workflow input arguments show up in the GitHub Actions UI.

### Technical Details

* Mark all the input arguments as `required: true` since this seems to be needed for them to show up in the UI.

### Test Results

N/A

### Reviewer Focus

None

### Future Work

None

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
