### PR TITLE
Improve workflow input argument descriptions

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -3,12 +3,6 @@ name: Build [CMake]
 on:
   workflow_dispatch:
     inputs:
-      build-types:
-        required: true
-        # Note the string here contains a JSON array. This is later converted to an array using fromJson.
-        default: "[ 'Debug' ]"
-        type: string
-        description: 'The CMake build type (CMAKE_BUILD_TYPE) to run.'
       analyze-codeql:
         required: true
         default: true
@@ -28,12 +22,18 @@ on:
         required: true
         default: false
         type: boolean
-        description: 'Publish build artifcats'
+        description: 'Publish build artifacts'
+      build-types:
+        required: true
+        # Note the string here contains a JSON array. This is later converted to an array using fromJson.
+        default: "[ 'Debug' ]"
+        type: string
+        description: 'The CMake build types (CMAKE_BUILD_TYPE) to run (must be encoded as a JSON array)'
       preset-name:
         required: true
         default: 'cicd'
         type: string
-        description: 'The name of the preset to use for all CMake operations (configure, build, test, install, package)'
+        description: 'CMake preset to use for all CMake operations (configure, build, test, install, package)'
   workflow_call:
     inputs:
       build-types:

--- a/.github/workflows/official-release.yml
+++ b/.github/workflows/official-release.yml
@@ -1,6 +1,6 @@
 # Workflow to generate official release builds.
 
-name: Official Release Build
+name: Build [Official Release]
 
 # Run on workflow dispatch to allow manual triggering of the workflow, and run
 # on PRs to the release branches.
@@ -15,6 +15,7 @@ jobs:
     uses: ./.github/workflows/cmake.yml
     with:
       build-types: "[ 'Debug', 'Release' ]"
+      analyze-codeql: true
       install: true
       package: true
       publish-artifacts: true


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [X] Infrastructure

### Goals

Improve clarity of cmake workflow input arguments.

### Technical Details

* Update descriptions of a few arguments.
* Re-order arguments such that all booleans come first, then strings.
* Re-name official build workflow run name to match existing naming pattern for build workflows.

### Test Results

N/A

### Reviewer Focus

None

### Future Work

None

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
