### PR TITLE
Change preset-name input argument to choice type for cmake build workflow_dispatch

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -32,8 +32,16 @@ on:
       preset-name:
         required: true
         default: 'cicd'
-        type: string
-        description: 'CMake preset to use for all CMake operations (configure, build, test, install, package)'
+        type: choice
+        options:
+          - 'dev'
+          - 'dev-vcpkg'
+          - 'dev-driver'
+          - 'vcpkg-dev'
+          - 'vcpkg-release'
+          - 'cicd'
+          - 'official-release'
+        description: 'The name of the preset to use for all CMake operations (configure, build, test, install, package)'
   workflow_call:
     inputs:
       build-types:


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [X] Infrastructure

### Goals

Limit preset names used int he cmake build workflow to valid presets.

### Technical Details

* Change `preset-name` input argument from free-form string to `choice` type, listing out the existing, valid preset names.

### Test Results

None

### Reviewer Focus

None

### Future Work

None

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
