### PR TITLE
Append cmake configuration to cpack package file name

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -26,7 +26,7 @@ on:
       build-types:
         required: true
         # Note the string here contains a JSON array. This is later converted to an array using fromJson.
-        default: "[ 'Debug' ]"
+        default: "[ 'debug' ]"
         type: string
         description: 'The CMake build types (CMAKE_BUILD_TYPE) to run (must be encoded as a JSON array)'
       preset-name:
@@ -47,7 +47,7 @@ on:
       build-types:
         required: false
         # Note the string here contains a JSON array. This is later converted to an array using fromJson.
-        default: "[ 'Debug' ]"
+        default: "[ 'debug' ]"
         type: string
         description: 'The CMake build type (CMAKE_BUILD_TYPE) to run.'
       analyze-codeql:

--- a/.github/workflows/official-release.yml
+++ b/.github/workflows/official-release.yml
@@ -14,7 +14,7 @@ jobs:
     name: build
     uses: ./.github/workflows/cmake.yml
     with:
-      build-types: "[ 'Debug', 'Release' ]"
+      build-types: "[ 'debug', 'release' ]"
       analyze-codeql: true
       install: true
       package: true

--- a/cmake/cpack.cmake
+++ b/cmake/cpack.cmake
@@ -1,8 +1,19 @@
 
 # Metadata related varaibles.
-set(CPACK_PACKAGE_NAME "nearobjectframework")
 set(CPACK_PACKAGE_VENDOR "Microsoft")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Near Object Framework - A framework for interacting with short-range devices")
+
+# Append the build type to the package file name. Solution taken from Craig
+# Scott in https://gitlab.kitware.com/cmake/cmake/-/issues/10940.
+if(CMAKE_GENERATOR STREQUAL Xcode OR
+   CMAKE_GENERATOR MATCHES "^Visual Studio.*")
+    # Multi-config generator, so we don't know the build config right now.
+    # Delay evaluation of the build config until CPack runs.
+    set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}-\${CPACK_BUILD_CONFIG}")
+else()
+    # We know the build config now, so use it directly
+    set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}-${CMAKE_BUILD_TYPE}")
+endif()
 
 # Package configuration.
 set(CPACK_NSIS OFF)
@@ -10,6 +21,6 @@ set(CPACK_BINARY_NSIS OFF)
 set(CPACK_ZIP ON)
 set(CPACK_BINARY_ZIP ON)
 set(CPACK_BINARY_TXZ ON)
-set(CPACK_SOURCE_ZIP ON)  
+set(CPACK_SOURCE_ZIP ON)
 
 include(CPack)


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [X] Infrastructure

### Goals

Ensure published artifacts describe the build configuration they contain.

### Technical Details

* Append the build type to the cpack package file name.
* Use lower case names when specifying build configurations.

### Test Results

Ran cpack locally and verified file names have the build configuration appended.

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
