### PR TITLE
Fix SessionIntitialize typo

### DIFF
--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -180,7 +180,7 @@ UwbDeviceConnector::GetSessionCount()
 }
 
 std::future<UwbStatus>
-UwbDeviceConnector::SessionIntitialize(uint32_t sessionId, UwbSessionType sessionType)
+UwbDeviceConnector::SessionInitialize(uint32_t sessionId, UwbSessionType sessionType)
 {
     std::promise<UwbStatus> resultPromise;
     auto resultFuture = resultPromise.get_future();

--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -34,7 +34,7 @@ UwbSession::ConfigureImpl(const ::uwb::protocol::fira::UwbSessionData& uwbSessio
     UwbSessionType sessionType = UwbSessionType::RangingSession;
 
     // Request a new session from the driver.
-    auto sessionInitResultFuture = m_uwbDeviceConnector->SessionIntitialize(sessionId, sessionType);
+    auto sessionInitResultFuture = m_uwbDeviceConnector->SessionInitialize(sessionId, sessionType);
     if (!sessionInitResultFuture.valid()) {
         // TODO: need to signal to upper layer that this failed instead of just returning
         PLOG_ERROR << "failed to initialize session";

--- a/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
@@ -36,7 +36,7 @@ struct IUwbDeviceDdi
 
     // IOCTL_UWB_SESSION_INIT
     virtual std::future<::uwb::protocol::fira::UwbStatus>
-    SessionIntitialize(uint32_t sessionId, ::uwb::protocol::fira::UwbSessionType sessionType) = 0;
+    SessionInitialize(uint32_t sessionId, ::uwb::protocol::fira::UwbSessionType sessionType) = 0;
 
     // IOCTL_UWB_SESSION_DEINIT
     virtual std::future<::uwb::protocol::fira::UwbStatus>

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
@@ -71,7 +71,7 @@ public:
     GetSessionCount() override;
 
     virtual std::future<::uwb::protocol::fira::UwbStatus>
-    SessionIntitialize(uint32_t sessionId, ::uwb::protocol::fira::UwbSessionType sessionType) override;
+    SessionInitialize(uint32_t sessionId, ::uwb::protocol::fira::UwbSessionType sessionType) override;
 
     virtual std::future<::uwb::protocol::fira::UwbStatus>
     SessionDeinitialize(uint32_t sessionId) override;


### PR DESCRIPTION
### Type

- [x] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

The function "SessionIntitialize" has a typo - it should be "SessionInitialize"

### Technical Details

Fixed typo

### Test Results

Code compiles

### Reviewer Focus

None

### Future Work

None

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
