### PR TITLE
Invoke SessionInit and SessionDeinit

### DIFF
--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -292,6 +292,9 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App* parent)
             std::cerr << "no device found" << std::endl;
             return;
         }
+        if (!uwbDevice->Initialize()) {
+            std::cerr << "device not initialized" << std::endl;
+        }
 
         m_cliHandler->HandleStartRanging(uwbDevice, m_cliData->SessionData);
     });

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -239,8 +239,7 @@ UwbDeviceConnector::SessionDeinitialize(uint32_t sessionId)
     UWB_STATUS status;
 
     // Determine the amount of memory required for the UWB_SESSION_DEINIT from the driver.
-    DWORD bytesRequired = 0;
-    BOOL ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_SESSION_DEINIT, const_cast<UWB_SESSION_DEINIT*>(&sessionDeinit), sizeof sessionDeinit, &status, sizeof status, &bytesRequired, nullptr);
+    BOOL ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_SESSION_DEINIT, const_cast<UWB_SESSION_DEINIT*>(&sessionDeinit), sizeof sessionDeinit, &status, sizeof status, nullptr, nullptr);
     if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
         // TODO: need to do something different here
         HRESULT hr = HRESULT_FROM_WIN32(GetLastError());

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -188,7 +188,8 @@ UwbDeviceConnector::SessionInitialize(uint32_t sessionId, UwbSessionType session
     wil::shared_hfile handleDriver;
     auto hr = OpenDriverHandle(handleDriver, m_deviceName.c_str());
     if (FAILED(hr)) {
-        PLOG_ERROR << "failed to obtain driver handle for " << m_deviceName << ", hr=" << hr;
+        PLOG_ERROR << "failed to obtain driver handle for " << m_deviceName << ", hr=" << std::showbase << std::hex << hr;
+        resultPromise.set_exception(std::make_exception_ptr(UwbException(UwbStatusGeneric::Rejected)));
         return resultFuture;
     }
 
@@ -202,9 +203,9 @@ UwbDeviceConnector::SessionInitialize(uint32_t sessionId, UwbSessionType session
     // Determine the amount of memory required for the UWB_SESSION_INIT from the driver.
     BOOL ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_SESSION_INIT, const_cast<UWB_SESSION_INIT*>(&sessionInit), sizeof sessionInit, &status, sizeof status, nullptr, nullptr);
     if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
-        // TODO: need to do something different here
         HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
-        PLOG_ERROR << "error when sending IOCTL_UWB_SESSION_INIT, hr=" << std::showbase << std::hex << hr;
+        PLOG_ERROR << "error when sending IOCTL_UWB_SESSION_INIT for session id " << sessionId << ", hr=" << std::showbase << std::hex << hr;
+        resultPromise.set_exception(std::make_exception_ptr(UwbException(UwbStatusGeneric::Rejected)));
         return resultFuture;
     } else {
         PLOG_DEBUG << "IOCTL_UWB_SESSION_INIT succeeded";
@@ -228,7 +229,8 @@ UwbDeviceConnector::SessionDeinitialize(uint32_t sessionId)
     wil::shared_hfile handleDriver;
     auto hr = OpenDriverHandle(handleDriver, m_deviceName.c_str());
     if (FAILED(hr)) {
-        PLOG_ERROR << "failed to obtain driver handle for " << m_deviceName << ", hr=" << hr;
+        PLOG_ERROR << "failed to obtain driver handle for " << m_deviceName << ", hr=" << std::showbase << std::hex << hr;
+        resultPromise.set_exception(std::make_exception_ptr(UwbException(UwbStatusGeneric::Rejected)));
         return resultFuture;
     }
 
@@ -243,7 +245,8 @@ UwbDeviceConnector::SessionDeinitialize(uint32_t sessionId)
     if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
         // TODO: need to do something different here
         HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
-        PLOG_ERROR << "error when sending IOCTL_UWB_SESSION_DEINIT, hr=" << std::showbase << std::hex << hr;
+        PLOG_ERROR << "error when sending IOCTL_UWB_SESSION_DEINIT for session id " << sessionId << ", hr=" << std::showbase << std::hex << hr;
+        resultPromise.set_exception(std::make_exception_ptr(UwbException(UwbStatusGeneric::Rejected)));
         return resultFuture;
     } else {
         PLOG_DEBUG << "IOCTL_UWB_SESSION_DEINIT succeeded";

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -200,7 +200,6 @@ UwbDeviceConnector::SessionInitialize(uint32_t sessionId, UwbSessionType session
     };
     UWB_STATUS status;
 
-    // Determine the amount of memory required for the UWB_SESSION_INIT from the driver.
     BOOL ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_SESSION_INIT, const_cast<UWB_SESSION_INIT*>(&sessionInit), sizeof sessionInit, &status, sizeof status, nullptr, nullptr);
     if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
         HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
@@ -240,10 +239,8 @@ UwbDeviceConnector::SessionDeinitialize(uint32_t sessionId)
     };
     UWB_STATUS status;
 
-    // Determine the amount of memory required for the UWB_SESSION_DEINIT from the driver.
     BOOL ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_SESSION_DEINIT, const_cast<UWB_SESSION_DEINIT*>(&sessionDeinit), sizeof sessionDeinit, &status, sizeof status, nullptr, nullptr);
     if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
-        // TODO: need to do something different here
         HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
         PLOG_ERROR << "error when sending IOCTL_UWB_SESSION_DEINIT for session id " << sessionId << ", hr=" << std::showbase << std::hex << hr;
         resultPromise.set_exception(std::make_exception_ptr(UwbException(UwbStatusGeneric::Rejected)));


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [x] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

This PR adds the ability for the device connector to invoke the SessionInit and SessionDeinit IOCTLs. This allows a ranging session to be initialized from the nocli tool.

### Technical Details

Added code to invoke SessionInit and SessionDeinit IOCTLs. Also added code to initialize uwb device in the nocli "range start" subcommand.

### Test Results

Can successfully initialize a session using the TestClient driver. Have not tested de-initialize, but the code is nearly identical, so I don't foresee any issues.

### Reviewer Focus

None.

### Future Work

I would like to have the nocli tool require a SessionId for the session config/ranging commands rather than make it optional.

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
