### PR TITLE
Invoke IOCTL_UWB_SET_APP_CONFIG_PARAMS

### DIFF
--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -343,7 +343,7 @@ UwbDeviceConnector::SetApplicationConfigurationParameters(uint32_t sessionId, Uw
     }
 
     auto& setParamsBuffer = applicationConfigurationParameters.DdiBuffer();
-    auto &setParams = applicationConfigurationParameters.DdiParameters();
+    auto& setParams = applicationConfigurationParameters.DdiParameters();
 
     // Allocate memory for the UWB_SET_APP_CONFIG_PARAMS_STATUS structure, and pass this to the driver request
     auto statusSize = offsetof(UWB_SET_APP_CONFIG_PARAMS_STATUS, appConfigParamsStatus[setParams.appConfigParamsCount]);

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -328,6 +328,57 @@ UwbDeviceConnector::SetApplicationConfigurationParameters(uint32_t sessionId, st
     return resultFuture;
 }
 
+std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>>>
+UwbDeviceConnector::SetApplicationConfigurationParameters(uint32_t sessionId, UwbSetAppConfigurationParameters applicationConfigurationParameters)
+{
+    std::promise<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>>> resultPromise;
+    auto resultFuture = resultPromise.get_future();
+    
+    wil::shared_hfile handleDriver;
+    auto hr = OpenDriverHandle(handleDriver, m_deviceName.c_str());
+    if (FAILED(hr)) {
+        PLOG_ERROR << "failed to obtain driver handle for " << m_deviceName << ", hr=" << std::showbase << std::hex << hr;
+        resultPromise.set_exception(std::make_exception_ptr(UwbException(UwbStatusGeneric::Rejected)));
+        return resultFuture;
+    }
+
+    auto& setParamsBuffer = applicationConfigurationParameters.DdiBuffer();
+    auto &setParams = applicationConfigurationParameters.DdiParameters();
+
+    // Allocate memory for the UWB_SET_APP_CONFIG_PARAMS_STATUS structure, and pass this to the driver request
+    auto statusSize = offsetof(UWB_SET_APP_CONFIG_PARAMS_STATUS, appConfigParamsStatus[setParams.appConfigParamsCount]);
+    std::vector<uint8_t> statusBuffer(statusSize);
+    BOOL ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_SET_APP_CONFIG_PARAMS, std::data(setParamsBuffer), std::size(setParamsBuffer), std::data(statusBuffer), statusSize, nullptr, nullptr);
+    if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
+        HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
+        PLOG_ERROR << "error when sending IOCTL_UWB_SET_APP_CONFIG_PARAMS with sessionId " << sessionId << ", hr = " << std::showbase << std::hex << hr;
+        resultPromise.set_exception(std::make_exception_ptr(UwbException(UwbStatusGeneric::Rejected)));
+        return resultFuture;
+    } else {
+        PLOG_DEBUG << "IOCTL_UWB_SET_APP_CONFIG_PARAMS succeeded";
+        auto& uwbSetAppConfigParamsStatus = *reinterpret_cast<UWB_SET_APP_CONFIG_PARAMS_STATUS*>(std::data(statusBuffer));
+        auto uwbStatus = UwbCxDdi::To(uwbSetAppConfigParamsStatus.status);
+        if (!IsUwbStatusOk(uwbStatus)) {
+            resultPromise.set_exception(std::make_exception_ptr(UwbException(std::move(uwbStatus))));
+        } else {
+            // TODO: Could move this logic into its own UwbCxDdi::To() function
+            std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>> appConfigParamsStatusList;
+            for (auto i = 0; i < uwbSetAppConfigParamsStatus.appConfigParamsCount; i++)
+            {
+                auto paramType = UwbCxDdi::To(uwbSetAppConfigParamsStatus.appConfigParamsStatus[i].paramType);
+                auto paramStatus = UwbCxDdi::To(uwbSetAppConfigParamsStatus.appConfigParamsStatus[i].status);
+
+                auto appConfigParamStatus = std::make_tuple(paramType, paramStatus);
+                appConfigParamsStatusList.push_back(appConfigParamStatus);
+            }
+            auto result = std::make_tuple(uwbStatus, std::move(appConfigParamsStatusList));
+            resultPromise.set_value(std::move(result));
+        }
+    }
+
+    return resultFuture;
+}
+
 void
 UwbDeviceConnector::HandleNotifications(wil::shared_hfile handleDriver, std::stop_token stopToken, std::function<void(UwbNotificationData)> onNotification)
 {

--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -43,26 +43,14 @@ UwbSession::ConfigureImpl(const ::uwb::protocol::fira::UwbSessionData& uwbSessio
 
     m_sessionId = sessionId;
 
-    // TODO: convert code below to invoke IOCTL_UWB_SET_APP_CONFIG_PARAMS to use connector
-
-    // // Populate the PUWB_SET_APP_CONFIG_PARAMS
-    // auto setParamsAdaptor = GenerateUwbSetAppConfigParameterDdi(uwbSessionData);
-    // auto &setParamsBuffer = setParamsAdaptor.DdiBuffer();
-    // auto &setParams = setParamsAdaptor.DdiParameters();
-
-    // // Allocate memory for the PUWB_SET_APP_CONFIG_PARAMS_STATUS
-    // auto statusSize = offsetof(UWB_SET_APP_CONFIG_PARAMS_STATUS, appConfigParamsStatus[setParams.appConfigParamsCount]);
-    // auto statusBuffer = std::make_unique<uint8_t[]>(statusSize);
-    // auto &statusHolder = *reinterpret_cast<UWB_SET_APP_CONFIG_PARAMS_STATUS *>(statusBuffer.get());
-    // statusHolder.size = statusSize;
-    // statusHolder.appConfigParamsCount = setParams.appConfigParamsCount;
-
-    // ioResult = DeviceIoControl(m_handleDriver.get(), IOCTL_UWB_SET_APP_CONFIG_PARAMS, std::data(setParamsBuffer), std::size(setParamsBuffer), statusBuffer.get(), statusSize, nullptr, nullptr);
-    // if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
-    //     // TODO: handle this
-    //     HRESULT hr = GetLastError();
-    //     PLOG_ERROR << "could not send params to driver, hr=" << std::showbase << std::hex << hr;
-    // }
+    // Set the application configuration parameters for the session.
+    auto setParamsAdaptor = GenerateUwbSetAppConfigParameterDdi(uwbSessionData);
+    auto setAppConfigParamsFuture = m_uwbDeviceConnector->SetApplicationConfigurationParameters(sessionId, setParamsAdaptor);
+    if (!setAppConfigParamsFuture.valid()) {
+        // TODO: need to signal to upper layer that this failed instead of just returning
+        PLOG_ERROR << "failed to set the application configuration parameters";
+        return;
+    }
 }
 
 void

--- a/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
@@ -70,6 +70,10 @@ struct IUwbDeviceDdi
     virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>>>
     SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> applicationConfigurationParameters) = 0;
 
+    // IOCTL_UWB_SET_APP_CONFIG_PARAMS
+    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>>>
+    SetApplicationConfigurationParameters(uint32_t sessionId, UwbSetAppConfigurationParameters applicationConfigurationParameters) = 0;
+
     // TODO: unspecified IOCTLs below
     // IOCTL_UWB_SET_DEVICE_CONFIG_PARAMS
     // IOCTL_UWB_GET_DEVICE_CONFIG_PARAMS

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
@@ -97,6 +97,9 @@ public:
     virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>>>
     SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> applicationConfigurationParameters) override;
 
+    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>>>
+    SetApplicationConfigurationParameters(uint32_t sessionId, UwbSetAppConfigurationParameters applicationConfigurationParameters) override;
+
 private:
     /**
      * @brief Thread function for handling UWB notifications from the driver.


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [x] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

This PR adds the ability to invoke IOCTL_UWB_SET_APP_CONFIG_PARAMS from the nocli tool.

### Technical Details

Added function overload for UwbDeviceConnector::SetApplicationConfigurationParameters
Added code to invoke IOCTL in overloaded function

### Test Results

Can successfully invoke IOCTL_UWB_SET_APP_CONFIG_PARAMS with the TestClient driver

### Reviewer Focus

None.

### Future Work

There are a few issues with the nocli tool that should be fixed to enhance usability:
- Output of "nocli.exe uwb range start --help" contains several random symbols and the usage of the various options is not clear
- The --help output mentioned above does not describe which app config parameters are mandatory, which should be stated
- Although most of the chosen parameters are shown in the output after running the command, the flags (such as --HoppingMode) do not show

Additional future work includes:
- Testing this command with the mandatory app config params and verifying the response from the TestClient driver. This is an essential next step before working on the StartRanging command.
- Implementing the original SetApplicationConfigurationParameters function. This PR only implements the new overload since that is prioritized at the moment.

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
