### PR TITLE
Fix --help output for range start

### DIFF
--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -109,20 +109,20 @@ namespace detail
  * corresponding values.
  *
  * @tparam EnumType The type of the enumeration.
- * @return std::map<std::string, int>
+ * @return std::unordered_map<std::string, EnumType>
  */
 template <typename EnumType>
 // clang-format off
 requires std::is_enum_v<EnumType>
-const std::unordered_map<std::string, int>
+const std::unordered_map<std::string, EnumType>
 CreateEnumerationStringMap() noexcept
 // clang-format on
 {
     const auto& reverseMap = magic_enum::enum_entries<EnumType>();
-    std::unordered_map<std::string, int> map;
+    std::unordered_map<std::string, EnumType> map;
 
     for (const auto& [enumValue, enumName] : reverseMap) {
-        map.emplace(enumName, static_cast<int>(enumValue));
+        map.emplace(enumName, enumValue);
     }
 
     return map;
@@ -148,13 +148,15 @@ AddEnumOption(CLI::App* app, std::optional<EnumType>& assignTo)
 {
     std::string optionName{ std::string("--").append(magic_enum::enum_type_name<EnumType>()) };
 
-    const auto& map = CreateEnumerationStringMap<EnumType>();
+    const auto map = CreateEnumerationStringMap<EnumType>();
     std::ostringstream enumUsage;
 
     auto it = std::cbegin(map);
-    enumUsage << "value in { " << it->second << "(" << it->first << ")";
-    for (it = std::next(std::cbegin(map)); it != std::cend(map); ++it) {
-        enumUsage << ", " << it->second << "(" << it->first << ")";
+    const auto& [name, value] = *it;
+    enumUsage << "value in { " << static_cast<int>(value) << "(" << name << ")";
+    for (it = std::next(std::cbegin(map)); it != std::cend(map); std::advance(it, 1)) {
+        const auto& [name, value] = *it;
+        enumUsage << ", " << static_cast<int>(value) << "(" << name << ")";
     }
     enumUsage << " }";
 


### PR DESCRIPTION
### Type

- [x] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

This PR fixes a bug with the nocli tool where the output of "nocli.exe uwb range start --help" would print out random symbols for enum values of type uint8_t.

### Technical Details

Because the code that prints the enum values is in the CLI11 library, we have no control over it and cannot fix the problem if we supply it uint8_t enum values. Therefore, this PR eliminates the call to CLI::CheckedTransformer() and creates a string with the enum usage to be printed as the option description.

### Test Results

The output is clean and has no random symbols.

### Reviewer Focus

None.

### Future Work

By nature of std::unordered_map, there is no guarantee in the order in which the enum values are printed when using --help. This doesn't actually matter but it would be nice to have values printed in order (e.g. for --Channel: C5, C6, C8, ...). However, simply switching to std::map doesn't work because of situations where numbers are represented as strings (e.g. 10 would come before 5).

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
