### PR TITLE
Use overlapped I/O for IOCTL_UWB_NOTIFICATION calls

### DIFF
--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -82,11 +82,8 @@ NearObjectCli::GetRangeStopApp() noexcept
 std::shared_ptr<uwb::UwbDevice>
 NearObjectCli::GetUwbDevice() noexcept
 {
-    if (m_uwbDevice == nullptr) {
-        m_uwbDevice = m_cliHandler->ResolveUwbDevice(*m_cliData);
-    }
-
-    return m_uwbDevice;
+    auto uwbDevice = m_cliHandler->ResolveUwbDevice(*m_cliData);
+    return std::move(uwbDevice);
 }
 
 std::unique_ptr<CLI::App>

--- a/tools/cli/include/nearobject/cli/NearObjectCli.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCli.hxx
@@ -198,9 +198,6 @@ private:
     std::shared_ptr<NearObjectCliData> m_cliData;
     std::shared_ptr<NearObjectCliHandler> m_cliHandler;
 
-    // Resolved device instance, if applicable to the selected command.
-    std::shared_ptr<uwb::UwbDevice> m_uwbDevice;
-
     std::unique_ptr<CLI::App> m_cliApp;
     // The following are helper references to the subcommands of m_cliApp, the memory is managed by CLI11.
     CLI::App* m_uwbApp;

--- a/tools/cli/include/nearobject/cli/NearObjectCli.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCli.hxx
@@ -6,8 +6,8 @@
 #include <memory>
 
 #include <CLI/CLI.hpp>
-#include <nearobject/cli/NearObjectCliHandler.hxx>
 #include <nearobject/cli/NearObjectCliData.hxx>
+#include <nearobject/cli/NearObjectCliHandler.hxx>
 #include <uwb/UwbDevice.hxx>
 
 namespace nearobject::cli
@@ -74,10 +74,10 @@ public:
     GetRangeApp() noexcept;
 
     /**
-    * @brief Get the app object associated with the "uwb raw" sub-command.
-    *
-    * @return CLI::App&
-    */
+     * @brief Get the app object associated with the "uwb raw" sub-command.
+     *
+     * @return CLI::App&
+     */
     CLI::App&
     GetRawApp() noexcept;
 
@@ -108,7 +108,7 @@ private:
      *  2. Device name as specified on the command line.
      *  3. Default device name (first device found).
      *
-     * @return std::shared_ptr<uwb::UwbDevice> 
+     * @return std::shared_ptr<uwb::UwbDevice>
      */
     std::shared_ptr<uwb::UwbDevice>
     GetUwbDevice() noexcept;
@@ -132,10 +132,10 @@ private:
     AddSubcommandUwb(CLI::App* parent);
 
     /**
-     * @brief Add the 'uwb monitor' sub-command. 
-     * 
+     * @brief Add the 'uwb monitor' sub-command.
+     *
      * @param parent The parent app to add the command to.
-     * @return CLI::App* 
+     * @return CLI::App*
      */
     CLI::App*
     AddSubcommandUwbMonitor(CLI::App* parent);
@@ -150,11 +150,11 @@ private:
     AddSubcommandUwbRange(CLI::App* parent);
 
     /**
-    * @brief Add the 'uwb raw' sub-command.
-    *
-    * @param parent The parent app to add the command to.
-    * @return CLI::App*
-    */
+     * @brief Add the 'uwb raw' sub-command.
+     *
+     * @param parent The parent app to add the command to.
+     * @return CLI::App*
+     */
     CLI::App*
     AddSubcommandUwbRaw(CLI::App* parent);
 
@@ -178,7 +178,7 @@ private:
 
     /**
      * @brief Add the 'uwb raw devicereset' sub-command.
-     * 
+     *
      * @param parent The parent app to add the command to.
      * @return CLI::App*
      */
@@ -186,11 +186,11 @@ private:
     AddSubcommandUwbRawDeviceReset(CLI::App* parent);
 
     /**
-    * @brief Add the 'uwb raw getdeviceinfo' sub-command.
-    *
-    * @param parent The parent app to add the command to.
-    * @return CLI::App*
-    */
+     * @brief Add the 'uwb raw getdeviceinfo' sub-command.
+     *
+     * @param parent The parent app to add the command to.
+     * @return CLI::App*
+     */
     CLI::App*
     AddSubcommandUwbRawGetDeviceInfo(CLI::App* parent);
 

--- a/windows/devices/util/DevicePresenceMonitor.cxx
+++ b/windows/devices/util/DevicePresenceMonitor.cxx
@@ -2,8 +2,8 @@
 #include <filesystem>
 #include <sstream>
 
-#include <windows/devices/DevicePresenceMonitor.hxx>
 #include <windows/devices/DeviceEnumerator.hxx>
+#include <windows/devices/DevicePresenceMonitor.hxx>
 
 #include <plog/Log.h>
 
@@ -95,9 +95,9 @@ void
 DevicePresenceMonitor::Start()
 {
     if (m_enumerateInitialDevicesOnStart) {
-        for (auto &[deviceGuid, _] : m_deviceGuids) {
+        for (const auto &[deviceGuid, _] : m_deviceGuids) {
             auto deviceNames = DeviceEnumerator::GetDeviceInterfaceClassInstanceNames(deviceGuid);
-            for (auto& deviceName : deviceNames) {
+            for (auto &deviceName : deviceNames) {
                 m_callback(deviceGuid, DevicePresenceEvent::Arrived, std::move(deviceName));
             }
         }

--- a/windows/devices/util/DevicePresenceMonitor.cxx
+++ b/windows/devices/util/DevicePresenceMonitor.cxx
@@ -3,17 +3,19 @@
 #include <sstream>
 
 #include <windows/devices/DevicePresenceMonitor.hxx>
+#include <windows/devices/DeviceEnumerator.hxx>
 
 #include <plog/Log.h>
 
 using namespace windows::devices;
 
-DevicePresenceMonitor::DevicePresenceMonitor(const GUID &deviceGuid, std::function<void(const GUID &deviceGuid, DevicePresenceEvent presenceEvent, std::string deviceName)> callback) noexcept :
-    DevicePresenceMonitor(std::vector<GUID>{ deviceGuid }, std::move(callback))
+DevicePresenceMonitor::DevicePresenceMonitor(const GUID &deviceGuid, std::function<void(const GUID &deviceGuid, DevicePresenceEvent presenceEvent, std::string deviceName)> callback, bool enumerateInitialDevicesOnStart) noexcept :
+    DevicePresenceMonitor(std::vector<GUID>{ deviceGuid }, std::move(callback), enumerateInitialDevicesOnStart)
 {}
 
-DevicePresenceMonitor::DevicePresenceMonitor(std::vector<GUID> deviceGuids, std::function<void(const GUID &deviceGuid, DevicePresenceEvent presenceEvent, std::string deviceName)> callback) noexcept :
-    m_callback(std::move(callback))
+DevicePresenceMonitor::DevicePresenceMonitor(std::vector<GUID> deviceGuids, std::function<void(const GUID &deviceGuid, DevicePresenceEvent presenceEvent, std::string deviceName)> callback, bool enumerateInitialDevicesOnStart) noexcept :
+    m_callback(std::move(callback)),
+    m_enumerateInitialDevicesOnStart(enumerateInitialDevicesOnStart)
 {
     for (auto &deviceGuid : deviceGuids) {
         m_deviceGuids.insert({ std::move(deviceGuid), unique_hcmnotification{} });
@@ -92,6 +94,15 @@ DevicePresenceMonitor::OnDeviceInterfaceNotificationCallback(HCMNOTIFICATION hcm
 void
 DevicePresenceMonitor::Start()
 {
+    if (m_enumerateInitialDevicesOnStart) {
+        for (auto &[deviceGuid, _] : m_deviceGuids) {
+            auto deviceNames = DeviceEnumerator::GetDeviceInterfaceClassInstanceNames(deviceGuid);
+            for (auto& deviceName : deviceNames) {
+                m_callback(deviceGuid, DevicePresenceEvent::Arrived, std::move(deviceName));
+            }
+        }
+    }
+
     RegisterForDeviceClassNotifications();
 }
 

--- a/windows/devices/util/include/windows/devices/DevicePresenceMonitor.hxx
+++ b/windows/devices/util/include/windows/devices/DevicePresenceMonitor.hxx
@@ -42,16 +42,18 @@ public:
      * @param deviceGuid The GUID of the device to monitor for presence changes.
      * @param callback The callback function to invoke when a device presence
      * change event occurs.
+     * @param enumerateInitialDevicesOnStart Flag to indicate whether pre-existing devices should be enumerated on start.
      */
-    explicit DevicePresenceMonitor(const GUID& deviceGuid, std::function<void(const GUID& deviceGuid, DevicePresenceEvent presenceEvent, std::string deviceName)> callback) noexcept;
+    explicit DevicePresenceMonitor(const GUID& deviceGuid, std::function<void(const GUID& deviceGuid, DevicePresenceEvent presenceEvent, std::string deviceName)> callback, bool enumerateInitialDevicesOnStart = false) noexcept;
 
     /**
      * @brief Construct a new Device Presence Monitor object
      *
      * @param deviceGuids A list of deveice guids to monitor for presence changes.
      * @param callback The callback function to invoke when a device presence change event occurs.
+     * @param enumerateInitialDevicesOnStart Flag to indicate whether pre-existing devices should be enumerated on start.
      */
-    explicit DevicePresenceMonitor(std::vector<GUID> deviceGuids, std::function<void(const GUID& deviceGuid, DevicePresenceEvent presenceEvent, std::string deviceName)> callback) noexcept;
+    explicit DevicePresenceMonitor(std::vector<GUID> deviceGuids, std::function<void(const GUID& deviceGuid, DevicePresenceEvent presenceEvent, std::string deviceName)> callback, bool enumerateInitialDevicesOnStart = false) noexcept;
 
     /**
      * @brief Exception thrown when there is an error starting the monitor.
@@ -145,6 +147,7 @@ private:
 private:
     std::function<void(const GUID& deviceGuid, DevicePresenceEvent presenceEvent, std::string deviceName)> m_callback;
     std::unordered_map<GUID, unique_hcmnotification> m_deviceGuids{};
+    bool m_enumerateInitialDevicesOnStart{ false };
 };
 } // namespace windows::devices
 

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -400,13 +400,6 @@ UwbDeviceConnector::HandleNotifications(std::stop_token stopToken)
     std::vector<uint8_t> uwbNotificationDataBuffer{};
     auto handleDriver = m_notificationHandleDriver;
 
-    // TODO: the below loop invokes the IOCTL synchronously, blocking on a
-    // result. There is no known way to cancel the blocking call on the client
-    // side; as such, even when stop is requested on the stop token, it cannot
-    // be evaluated since the blocking call won't be interrupted.
-    //
-    // The correct solution here is to open the handle in overlapped mode, and
-    // make a non-blocking call. This is not trivial, so will be done later.
     while (!stopToken.stop_requested()) {
         m_notificationOverlapped = {};
         for (const auto i : std::ranges::iota_view{ 1, 2 }) {

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -36,6 +36,11 @@ UwbDeviceConnector::UwbDeviceConnector(std::string deviceName) :
     m_deviceName(std::move(deviceName))
 {}
 
+UwbDeviceConnector::~UwbDeviceConnector()
+{
+    NotificationListenerStop();
+}
+
 const std::string&
 UwbDeviceConnector::DeviceName() const noexcept
 {
@@ -389,10 +394,11 @@ UwbDeviceConnector::SetApplicationConfigurationParameters(uint32_t sessionId, Uw
 }
 
 void
-UwbDeviceConnector::HandleNotifications(wil::shared_hfile handleDriver, std::stop_token stopToken)
+UwbDeviceConnector::HandleNotifications(std::stop_token stopToken)
 {
-    std::vector<uint8_t> uwbNotificationDataBuffer{};
     DWORD bytesRequired = 0;
+    std::vector<uint8_t> uwbNotificationDataBuffer{};
+    auto handleDriver = m_notificationHandleDriver;
 
     // TODO: the below loop invokes the IOCTL synchronously, blocking on a
     // result. There is no known way to cancel the blocking call on the client
@@ -402,20 +408,30 @@ UwbDeviceConnector::HandleNotifications(wil::shared_hfile handleDriver, std::sto
     // The correct solution here is to open the handle in overlapped mode, and
     // make a non-blocking call. This is not trivial, so will be done later.
     while (!stopToken.stop_requested()) {
+        m_notificationOverlapped = {};
         for (const auto i : std::ranges::iota_view{ 1, 2 }) {
             uwbNotificationDataBuffer.resize(bytesRequired);
             PLOG_DEBUG << "IOCTL_UWB_NOTIFICATION attempt #" << i << " with " << std::size(uwbNotificationDataBuffer) << "-byte buffer";
-            BOOL ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_NOTIFICATION, nullptr, 0, std::data(uwbNotificationDataBuffer), std::size(uwbNotificationDataBuffer), &bytesRequired, nullptr);
+            BOOL ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_NOTIFICATION, nullptr, 0, std::data(uwbNotificationDataBuffer), std::size(uwbNotificationDataBuffer), &bytesRequired, &m_notificationOverlapped);
             if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
                 DWORD lastError = GetLastError();
-                // Treat all errors other than insufficient buffer size as fatal.
-                if (lastError != ERROR_INSUFFICIENT_BUFFER) {
+                if (lastError == ERROR_IO_PENDING) {
+                    // I/O has been pended, wait for it synchronously
+                    if (!LOG_IF_WIN32_BOOL_FALSE(GetOverlappedResult(handleDriver.get(), &m_notificationOverlapped, &bytesRequired, TRUE /* wait */))) {
+                        lastError = GetLastError();
+                        HRESULT hr = HRESULT_FROM_WIN32(lastError);
+                        PLOG_ERROR << "error waiting for IOCTL_UWB_NOTIFICATION completion, hr=" << std::showbase << std::hex << hr;
+                        break; // for({1,2})
+                    }
+                } else if (lastError == ERROR_INSUFFICIENT_BUFFER) {
+                    // Attempt to retry the ioctl with the appropriate buffer size, which is now held in bytesRequired.
+                    continue;
+                // Treat all other errors as fatal.
+                } else {
                     HRESULT hr = HRESULT_FROM_WIN32(lastError);
                     PLOG_ERROR << "error when sending IOCTL_UWB_NOTIFICATION, hr=" << std::showbase << std::hex << hr;
-                    break;
+                    break; // for({1,2})
                 }
-                // Attempt to retry the ioctl with the appropriate buffer size, which is now held in bytesRequired.
-                continue;
             }
 
             // Convert to neutral type and process the notification.
@@ -573,15 +589,16 @@ UwbDeviceConnector::DispatchCallbacks(::uwb::protocol::fira::UwbNotificationData
 bool
 UwbDeviceConnector::NotificationListenerStart()
 {
-    wil::shared_hfile handleDriver;
-    auto hr = OpenDriverHandle(handleDriver, m_deviceName.c_str());
+    wil::shared_hfile notificationHandleDriver;
+    auto hr = OpenDriverHandle(notificationHandleDriver, m_deviceName.c_str(), true);
     if (FAILED(hr)) {
         PLOG_ERROR << "failed to obtain driver handle for " << m_deviceName << ", hr=" << hr;
         return false;
     }
 
-    m_notificationThread = std::jthread([this, handleDriver = std::move(handleDriver)](std::stop_token stopToken) {
-        HandleNotifications(std::move(handleDriver), stopToken);
+    m_notificationHandleDriver = std::move(notificationHandleDriver);
+    m_notificationThread = std::jthread([this](std::stop_token stopToken) {
+        HandleNotifications(std::move(stopToken));
     });
 
     return true;
@@ -590,6 +607,7 @@ UwbDeviceConnector::NotificationListenerStart()
 void
 UwbDeviceConnector::NotificationListenerStop()
 {
+    LOG_IF_WIN32_BOOL_FALSE(CancelIoEx(m_notificationHandleDriver.get(), &m_notificationOverlapped));
     m_notificationThread.request_stop();
 }
 

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -238,7 +238,7 @@ UwbDeviceConnector::SessionDeinitialize(uint32_t sessionId)
 {
     std::promise<UwbStatus> resultPromise;
     auto resultFuture = resultPromise.get_future();
-    
+
     wil::shared_hfile handleDriver;
     auto hr = OpenDriverHandle(handleDriver, m_deviceName.c_str());
     if (FAILED(hr)) {
@@ -419,8 +419,8 @@ UwbDeviceConnector::HandleNotifications(std::stop_token stopToken)
                 } else if (lastError == ERROR_INSUFFICIENT_BUFFER) {
                     // Attempt to retry the ioctl with the appropriate buffer size, which is now held in bytesRequired.
                     continue;
-                // Treat all other errors as fatal.
                 } else {
+                    // Treat all other errors as fatal.
                     HRESULT hr = HRESULT_FROM_WIN32(lastError);
                     PLOG_ERROR << "error when sending IOCTL_UWB_NOTIFICATION, hr=" << std::showbase << std::hex << hr;
                     break; // for({1,2})

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
@@ -89,7 +89,7 @@ public:
     RegisterDeviceEventCallbacks(std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbacks> callbacks);
 
     /**
-     * @brief De-registers the callback associated with the 
+     * @brief De-registers the callback associated with the
      * If you pass in a token that is no longer valid, this function does nothing
      *
      * @param token

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
@@ -37,6 +37,11 @@ public:
     explicit UwbDeviceConnector(std::string deviceName);
 
     /**
+     * @brief Destroy the Uwb Device Connector object
+     */
+    ~UwbDeviceConnector();
+
+    /**
      * @brief Get the name of this device.
      *
      * @return const std::string&
@@ -140,12 +145,11 @@ private:
     /**
      * @brief Thread function for handling UWB notifications from the driver.
      *
-     * @param handleDriver The handle to the driver to use for listening for notifications.
      * @param stopToken The token used to request the notification loop to stop.
      * @param onNotification The callback function to invoke for each notification.
      */
     void
-    HandleNotifications(wil::shared_hfile handleDriver, std::stop_token stopToken);
+    HandleNotifications(std::stop_token stopToken);
 
     /**
      * @brief Responsible for calling the relevant registered callbacks for the uwbNotificationData
@@ -176,6 +180,8 @@ private:
     std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbacks> m_deviceEventCallbacks;
     std::string m_deviceName{};
     std::jthread m_notificationThread;
+    wil::shared_hfile m_notificationHandleDriver;
+    OVERLAPPED m_notificationOverlapped;
 };
 } // namespace windows::devices::uwb
 

--- a/windows/tools/nocli/Main.cxx
+++ b/windows/tools/nocli/Main.cxx
@@ -6,6 +6,8 @@
 
 #include <CLI/CLI.hpp>
 
+#include <windows/devices/uwb/UwbDevice.hxx>
+
 #include "NearObjectCliDataWindows.hxx"
 #include "NearObjectCliHandlerWindows.hxx"
 

--- a/windows/tools/nocli/NearObjectCliHandlerWindows.cxx
+++ b/windows/tools/nocli/NearObjectCliHandlerWindows.cxx
@@ -88,7 +88,7 @@ ResolveUwbDevice(const nearobject::cli::NearObjectCliDataWindows& cliData)
         return nullptr;
     }
 
-    return std::make_unique<windows::devices::uwb::UwbDevice>(deviceName);
+    return std::make_shared<windows::devices::uwb::UwbDevice>(deviceName);
 }
 } // namespace detail
 

--- a/windows/tools/nocli/NearObjectCliHandlerWindows.cxx
+++ b/windows/tools/nocli/NearObjectCliHandlerWindows.cxx
@@ -104,44 +104,50 @@ NearObjectCliHandlerWindows::ResolveUwbDevice(const nearobject::cli::NearObjectC
 }
 
 void
+NearObjectCliHandlerWindows::OnDeviceArrived(const std::string& deviceName)
+{
+    auto uwbDevice = std::make_unique<windows::devices::uwb::UwbDevice>(deviceName);
+    if (!uwbDevice) {
+        PLOG_ERROR << "Failed to instantiate UWB device with name " << deviceName;
+        return;
+    }
+
+    uwbDevice->Initialize();
+    m_uwbDevices.push_back(std::move(uwbDevice));
+}
+
+void
+NearObjectCliHandlerWindows::OnDeviceDeparted(const std::string& deviceName)
+{
+    auto numErased = std::erase_if(m_uwbDevices, [&](const auto& uwbDevice) {
+        return uwbDevice->DeviceName() == deviceName;
+    });
+    if (numErased == 0) {
+        PLOG_WARNING << "UWB device with name " << deviceName << " not found; ignoring removal event";
+    }
+}
+
+void
 NearObjectCliHandlerWindows::HandleMonitorMode() noexcept
 try {
-    // TODO: this should probably be moved into its own function
+    DevicePresenceMonitor presenceMonitor(
+        windows::devices::uwb::InterfaceClassUwb, [&](auto&& deviceGuid, auto&& presenceEvent, auto&& deviceName) {
+            const auto presenceEventName = magic_enum::enum_name(presenceEvent);
+            PLOG_INFO << deviceName << " " << presenceEventName << std::endl;
 
-    // Keep a container of known devices. Once initialized,
-    std::vector<std::unique_ptr<windows::devices::uwb::UwbDevice>> uwbDevices{};
-
-    DevicePresenceMonitor presenceMonitor(windows::devices::uwb::InterfaceClassUwb, [&](auto&& deviceGuid, auto&& presenceEvent, auto&& deviceName) {
-        const auto presenceEventName = magic_enum::enum_name(presenceEvent);
-        PLOG_INFO << deviceName << " " << presenceEventName << std::endl;
-
-        switch (presenceEvent) {
-        case DevicePresenceEvent::Arrived: {
-            auto uwbDevice = std::make_unique<windows::devices::uwb::UwbDevice>(deviceName);
-            if (!uwbDevice) {
-                PLOG_ERROR << "Failed to instantiate UWB device with name " << deviceName;
-                return;
+            switch (presenceEvent) {
+            case DevicePresenceEvent::Arrived:
+                OnDeviceArrived(deviceName);
+                break;
+            case DevicePresenceEvent::Departed:
+                OnDeviceDeparted(deviceName);
+                break;
+            default:
+                PLOG_ERROR << "Ignoring unknown presence event";
+                break;
             }
-
-            uwbDevice->Initialize();
-            uwbDevices.push_back(std::move(uwbDevice));
-            break;
-        }
-        case DevicePresenceEvent::Departed: {
-            auto numErased = std::erase_if(uwbDevices, [&](const auto& uwbDevice) {
-                return uwbDevice->DeviceName() == deviceName;
-            });
-            if (numErased == 0) {
-                PLOG_WARNING << "UWB device with name " << deviceName << " not found; ignoring removal event";
-            }
-            break;
-        }
-        default: {
-            PLOG_ERROR << "Ignoring unknown presence event";
-            break;
-        }
-        }
-    });
+        },
+        /* enumerateInitialDevicesOnStart = */ true);
 
     presenceMonitor.Start();
 

--- a/windows/tools/nocli/NearObjectCliHandlerWindows.hxx
+++ b/windows/tools/nocli/NearObjectCliHandlerWindows.hxx
@@ -3,10 +3,17 @@
 #define NEAR_OBEJCT_CLI_HANDLER_WINDOWS_HXX
 
 #include <memory>
+#include <string>
+#include <vector>
 
 #include <nearobject/cli/NearObjectCliHandler.hxx>
 #include <nearobject/cli/NearObjectCliData.hxx>
 #include <uwb/UwbDevice.hxx>
+
+namespace windows::devices::uwb
+{
+class UwbDevice;
+} // namespace windows::devices::uwb
 
 namespace nearobject::cli
 {
@@ -18,6 +25,16 @@ struct NearObjectCliHandlerWindows :
 
     void
     HandleMonitorMode() noexcept override;
+
+private:
+    void
+    OnDeviceArrived(const std::string& deviceName);
+
+    void
+    OnDeviceDeparted(const std::string& deviceName);
+
+private:
+    std::vector<std::unique_ptr<windows::devices::uwb::UwbDevice>> m_uwbDevices;
 };
 } // namespace nearobject::cli
 

--- a/windows/tools/nocli/NearObjectCliHandlerWindows.hxx
+++ b/windows/tools/nocli/NearObjectCliHandlerWindows.hxx
@@ -6,8 +6,8 @@
 #include <string>
 #include <vector>
 
-#include <nearobject/cli/NearObjectCliHandler.hxx>
 #include <nearobject/cli/NearObjectCliData.hxx>
+#include <nearobject/cli/NearObjectCliHandler.hxx>
 #include <uwb/UwbDevice.hxx>
 
 namespace windows::devices::uwb


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [x] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Allow event notification processing in the DDI connector to be interrupted/canceled.

### Technical Details

* Replace basic synchronous I/O with overlapped I/O + direct waiting via `GetOverlappedResult()` for `IOCTL_UWB_NOTIFICATION` calls in `UwbDeviceConnector`.
* Omit storing a `UwbDevice` pointer as CLI state as it prevents clean shutdown.
* Add feature for `DevicePresenceMonitor` to enumerate currently present devices on start.

### Test Results

* Ran `nocli.exe uwb raw getdeviceinfo` with simulator driver and verified `UwbDeviceConnector` is destructed and _requests_ to cancel the I/O. See note in `Future Work` section about why the I/O is _not_ canceled with the simulator driver, but should work with the official driver which does support cancelable, overlapped I/O.

### Reviewer Focus

None

### Future Work

* The simulator driver does not yet support overlapped I/O, so this needs to be implemented. Consequently, the `IOCTL_UWB_NOTIFICATION` code when invoked via `nocli` with the simulator driver will still wait indefinitely.
* The current use of overlapped i/o for `IOCTL_UWB_NOTIFICATION` has a race condition where if the I/O completes but another thread calls `NotificationListenerStop()`, `CancelIoEx` will be provided an invalid `OVERLAPPED` pointer. This is not worth fixing since all of this code will be replaced by a general purpose I/O helper class that facilitates both sync + async I/O using i/o completion ports, and the race condition will be very difficult to exercise given the current codebase and usage.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
