### PR TITLE
Enable overlapped I/O for in IOCTL_UWB_NOTIFICATION in UWB simulator driver 

### DIFF
--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -413,7 +413,8 @@ UwbDeviceConnector::HandleNotifications(std::stop_token stopToken)
                     if (!LOG_IF_WIN32_BOOL_FALSE(GetOverlappedResult(handleDriver.get(), &m_notificationOverlapped, &bytesRequired, TRUE /* wait */))) {
                         lastError = GetLastError();
                         HRESULT hr = HRESULT_FROM_WIN32(lastError);
-                        PLOG_ERROR << "error waiting for IOCTL_UWB_NOTIFICATION completion, hr=" << std::showbase << std::hex << hr;
+                        PLOG(lastError == ERROR_OPERATION_ABORTED ? plog::debug : plog::error)
+                            << "error waiting for IOCTL_UWB_NOTIFICATION completion, hr=" << std::showbase << std::hex << hr;
                         break; // for({1,2})
                     }
                 } else if (lastError == ERROR_INSUFFICIENT_BUFFER) {

--- a/windows/drivers/uwb/simulator/IUwbSimulatorDdiCallbacksLrp.hxx
+++ b/windows/drivers/uwb/simulator/IUwbSimulatorDdiCallbacksLrp.hxx
@@ -79,11 +79,11 @@ struct IUwbSimulatorDdiCallbacksLrp
 
     /**
      * @brief Get the Application Configuration Parameters object
-     * 
-     * @param sessionId 
-     * @param applicationConfigurationParameterTypes 
-     * @param applicationConfigurationParameters 
-     * @return UwbStatus 
+     *
+     * @param sessionId
+     * @param applicationConfigurationParameterTypes
+     * @param applicationConfigurationParameters
+     * @return UwbStatus
      */
     virtual UwbStatus
     GetApplicationConfigurationParameters(uint32_t sessionId, const std::vector<UwbApplicationConfigurationParameterType> &applicationConfigurationParameterTypes, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> &applicationConfigurationParameters) = 0;
@@ -176,14 +176,13 @@ struct IUwbSimulatorDdiCallbacksLrp
     SessionGetRangingCount(uint32_t sessionId, uint32_t &rangingCount) = 0;
 
     /**
-     * @brief 
-     * 
-     * @param notificationData 
-     * @param notificationDataSize 
-     * @return NTSTATUS 
+     * @brief
+     *
+     * @param notificationData
+     * @return NTSTATUS
      */
     virtual NTSTATUS
-    UwbNotification(UwbNotificationData &notificationData, std::size_t &notificationDataSize) = 0;
+    UwbNotification(UwbNotificationData &notificationData) = 0;
 };
 } // namespace windows::devices::uwb::simulator
 

--- a/windows/drivers/uwb/simulator/IUwbSimulatorDdiCallbacksLrp.hxx
+++ b/windows/drivers/uwb/simulator/IUwbSimulatorDdiCallbacksLrp.hxx
@@ -176,12 +176,14 @@ struct IUwbSimulatorDdiCallbacksLrp
     SessionGetRangingCount(uint32_t sessionId, uint32_t &rangingCount) = 0;
 
     /**
-     * @brief
-     *
-     * @param notificationData
+     * @brief 
+     * 
+     * @param notificationData 
+     * @param notificationDataSize 
+     * @return NTSTATUS 
      */
     virtual NTSTATUS
-    UwbNotification(UwbNotificationData &notificationData) = 0;
+    UwbNotification(UwbNotificationData &notificationData, std::size_t &notificationDataSize) = 0;
 };
 } // namespace windows::devices::uwb::simulator
 

--- a/windows/drivers/uwb/simulator/UwbSimulator.vcxproj
+++ b/windows/drivers/uwb/simulator/UwbSimulator.vcxproj
@@ -14,6 +14,7 @@
     <ClCompile Include="UwbSimulatorDdiHandlerLrp.cxx" />
     <ClCompile Include="UwbSimulatorDriver.cxx" />
     <ClCompile Include="UwbSimulatorDdiCallbacks.cxx" />
+    <ClCompile Include="UwbSimulatorIoEventQueue.cxx" />
     <ClCompile Include="UwbSimulatorIoQueue.cxx" />
     <ClCompile Include="UwbSimulatorDevice.cxx" />
     <ClCompile Include="UwbSimulatorDeviceFile.cxx" />
@@ -31,6 +32,7 @@
     <ClInclude Include="UwbCxLrpDevice.h" />
     <ClInclude Include="IUwbSimulatorDdiCallbacksLrp.hxx" />
     <ClInclude Include="UwbSimulatorDdiCallbacks.hxx" />
+    <ClInclude Include="UwbSimulatorIoEventQueue.hxx" />
     <ClInclude Include="UwbSimulatorIoQueue.hxx" />
     <ClInclude Include="UwbSimulatorDevice.hxx" />
     <ClInclude Include="UwbSimulatorDeviceFile.hxx" />

--- a/windows/drivers/uwb/simulator/UwbSimulator.vcxproj.filters
+++ b/windows/drivers/uwb/simulator/UwbSimulator.vcxproj.filters
@@ -48,12 +48,6 @@
     <ClInclude Include="include\UwbSimulatorDdi.h">
       <Filter>Header Files\Public</Filter>
     </ClInclude>
-    <ClInclude Include="UwbSimulatorDdiCallbacksLrp.hxx">
-      <Filter>Header Files\Public</Filter>
-    </ClInclude>
-    <ClInclude Include="UwbSimulatorDdiCallbacksLrpNoop.hxx">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="UwbCxLrpDevice.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -63,22 +57,31 @@
     <ClInclude Include="UwbSimulatorDdiHandler.hxx">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="UwbSimulatorDdiHandlerLrp.hxx">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="UwbSimulatorDispatchEntry.hxx">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="UwbSimulatorSession.hxx">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="UwbSimulatorDdiHandlerSimulator.hxx">
+    <ClInclude Include="IUwbSimulator.hxx">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="UwbSimulatorDdiCallbacksSimulator.hxx">
-      <Filter>Header Files\Public</Filter>
+    <ClInclude Include="IUwbSimulatorDdiCallbacksSimulator.hxx">
+      <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="UwbSimulatorDdiCallbacksSimulatorImpl.hxx">
+    <ClInclude Include="IUwbSimulatorDdiHandler.hxx">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IUwbSimulatorDdiCallbacksLrp.hxx">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="UwbSimulatorDdiCallbacks.hxx">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IUwbSimulatorSession.hxx">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="UwbSimulatorIoEventQueue.hxx">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
@@ -95,19 +98,19 @@
     <ClCompile Include="UwbSimulatorTracelogging.cxx">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="UwbSimulatorDdiCallbacksLrpNoop.cxx">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="UwbSimulatorDriver.cxx">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="UwbSimulatorDdiHandlerLrp.cxx">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="UwbSimulatorDdiHandlerSimulator.cxx">
+    <ClCompile Include="UwbSimulatorDdiCallbacks.cxx">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="UwbSimulatorDdiCallbacksSimulatorImpl.cxx">
+    <ClCompile Include="UwbSimulatorSession.cxx">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="UwbSimulatorIoEventQueue.cxx">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
@@ -353,60 +353,23 @@ UwbSimulatorDdiCallbacks::SessionGetRangingCount(uint32_t sessionId, uint32_t &r
 }
 
 NTSTATUS
-UwbSimulatorDdiCallbacks::UwbNotification(UwbNotificationData &notificationData, std::size_t &notificationDataSize)
-{  
-    std::size_t outputBufferSizeRequired = 0;
-    std::optional<UwbNotificationData> notificationDataOpt;
+UwbSimulatorDdiCallbacks::UwbNotification(UwbNotificationData & /*notificationData*/)
+{
+    TraceLoggingWrite(
+        UwbSimulatorTraceloggingProvider,
+        "UwbNotification",
+        TraceLoggingLevel(TRACE_LEVEL_VERBOSE),
+        TraceLoggingString("Wait", "Action"));
 
-    auto *ioEventQueue = m_deviceFile->GetIoEventQueue();
-    NTSTATUS status = ioEventQueue->GetNextQueuedRequest(notificationDataOpt, outputBufferSizeRequired);
-    if (!NT_SUCCESS(status)) {
-        if (status == STATUS_NO_MORE_ENTRIES) {
-            // Pend request
-            WDFREQUEST request; // = TODO
-            // alternatively, we could expect the handler to pend the request instead
-            ioEventQueue->PendRequest(request, notificationDataSize);
-            return STATUS_PENDING;
-        }
-    } else {
-        notificationData = std::move(notificationDataOpt.value());
-    }
+    NTSTATUS status = STATUS_NOT_IMPLEMENTED;
 
-    //// Acquire the notification lock to ensure the notification proimise can be safely inspected and updated.
-    //std::unique_lock notificationLock{ m_notificationGate };
-    //if (m_notificationPromise.has_value()) {
-    //    // pre-existing promise, this should not happen.
-    //    TraceLoggingWrite(
-    //        UwbSimulatorTraceloggingProvider,
-    //        "UwbNotification",
-    //        TraceLoggingLevel(TRACE_LEVEL_WARNING),
-    //        TraceLoggingString("Ignore", "Action"));
-    //    return STATUS_ALREADY_REGISTERED;
-    //}
+    TraceLoggingWrite(
+        UwbSimulatorTraceloggingProvider,
+        "UwbNotification",
+        TraceLoggingLevel(TRACE_LEVEL_VERBOSE),
+        TraceLoggingString("WaitComplete", "Action"));
 
-    //// Create a new promise whose shared state will be updated when a notification is raised.
-    //auto notificationFuture = m_notificationPromise.emplace().get_future();
-
-    //// Release the lock since the shared data (promise) has been created and future obtained.
-    //notificationLock.unlock();
-
-    //TraceLoggingWrite(
-    //    UwbSimulatorTraceloggingProvider,
-    //    "UwbNotification",
-    //    TraceLoggingLevel(TRACE_LEVEL_VERBOSE),
-    //    TraceLoggingString("Wait", "Action"));
-
-    //// Lock is now released; synchronously wait indefinitely for the shared state to be updated.
-    //notificationFuture.wait();
-    //notificationData = notificationFuture.get();
-
-    //TraceLoggingWrite(
-    //    UwbSimulatorTraceloggingProvider,
-    //    "UwbNotification",
-    //    TraceLoggingLevel(TRACE_LEVEL_VERBOSE),
-    //    TraceLoggingString("WaitComplete", "Action"));
-
-    return STATUS_SUCCESS;
+    return status;
 }
 
 UwbSimulatorCapabilities

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
@@ -19,6 +19,7 @@
 
 #include "IUwbSimulatorDdiCallbacksLrp.hxx"
 #include "IUwbSimulatorDdiCallbacksSimulator.hxx"
+#include "UwbSimulatorDeviceFile.hxx"
 #include "UwbSimulatorSession.hxx"
 
 #include <uwb/protocols/fira/UwbApplicationConfiguration.hxx>
@@ -31,7 +32,7 @@ struct UwbSimulatorDdiCallbacks :
     public IUwbSimulatorDdiCallbacksLrp,
     public IUwbSimulatorDdiCallbacksSimulator
 {
-    UwbSimulatorDdiCallbacks();
+    UwbSimulatorDdiCallbacks(UwbSimulatorDeviceFile *deviceFile);
 
     // IUwbSimulatorDdiCallbacksLrp
 
@@ -81,7 +82,7 @@ struct UwbSimulatorDdiCallbacks :
     SessionGetRangingCount(uint32_t sessionId, uint32_t &rangingCount) override;
 
     virtual NTSTATUS
-    UwbNotification(UwbNotificationData &notificationData) override;
+    UwbNotification(UwbNotificationData &notificationData, std::size_t &notificationDataSize) override;
 
     // IUwbSimulatorDdiCallbacksSimulator
 
@@ -136,6 +137,7 @@ private:
 
 private:
     UwbSimulatorCapabilities m_simulatorCapabilities{};
+    UwbSimulatorDeviceFile *m_deviceFile;
 };
 } // namespace windows::devices::uwb::simulator
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
@@ -82,7 +82,7 @@ struct UwbSimulatorDdiCallbacks :
     SessionGetRangingCount(uint32_t sessionId, uint32_t &rangingCount) override;
 
     virtual NTSTATUS
-    UwbNotification(UwbNotificationData &notificationData, std::size_t &notificationDataSize) override;
+    UwbNotification(UwbNotificationData &notificationData) override;
 
     // IUwbSimulatorDdiCallbacksSimulator
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
@@ -3,7 +3,6 @@
 #define UWB_SIMULATOR_DDI_CALLBACKS_HXX
 
 #include <cstdint>
-#include <future>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -130,10 +129,6 @@ private:
     // Session state and associated lock that protects it.
     std::shared_mutex m_sessionsGate;
     std::unordered_map<uint32_t, UwbSimulatorSession> m_sessions{};
-
-    // Notification promise and associated lock that protects it.
-    std::mutex m_notificationGate;
-    std::optional<std::promise<UwbNotificationData>> m_notificationPromise;
 
 private:
     UwbSimulatorCapabilities m_simulatorCapabilities{};

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.hxx
@@ -12,6 +12,7 @@
 
 #include "IUwbSimulatorDdiHandler.hxx"
 #include "UwbSimulatorDdiCallbacks.hxx"
+#include "UwbSimulatorDeviceFile.hxx"
 #include "UwbSimulatorDispatchEntry.hxx"
 
 namespace windows::devices::uwb::simulator
@@ -20,7 +21,12 @@ class UwbSimulatorDdiHandler :
     public IUwbSimulatorDdiHandler
 {
 public:
-    explicit UwbSimulatorDdiHandler(WDFFILEOBJECT wdfFile);
+    /**
+     * @brief Construct a new UwbSimulatorDdiHandler object.
+     * 
+     * @param deviceFile The file object context for this handler. 
+     */
+    explicit UwbSimulatorDdiHandler(UwbSimulatorDeviceFile *deviceFile);
 
     /**
      * @brief Indicates whether the specified i/o control code is handled by
@@ -123,7 +129,7 @@ private:
     static const std::initializer_list<windows::devices::uwb::simulator::UwbSimulatorDispatchEntry<UwbSimulatorDdiHandler>> Dispatch;
 
 private:
-    WDFFILEOBJECT m_wdfFile;
+    UwbSimulatorDeviceFile *m_deviceFile;
     std::unique_ptr<windows::devices::uwb::simulator::UwbSimulatorDdiCallbacks> m_callbacks;
 };
 } // namespace windows::devices::uwb::simulator

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.cxx
@@ -448,7 +448,7 @@ UwbSimulatorDdiHandler::OnUwbNotification(WDFREQUEST request, std::span<uint8_t>
     std::optional<UwbNotificationData> uwbNotificationData;
     auto *ioEventQueue = m_deviceFile->GetIoEventQueue();
     NTSTATUS status = ioEventQueue->HandleNotificationRequest(request, uwbNotificationData, outputBufferSize);
-    if (NT_SUCCESS(status)) {
+    if (status == STATUS_SUCCESS) {
         // Convert neutral type to DDI output type, and copy to output buffer.
         auto notificationData = UwbCxDdi::From(uwbNotificationData.value());
         std::memcpy(std::data(outputBuffer), std::data(std::data(notificationData)), outputBufferSize);

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.cxx
@@ -500,8 +500,8 @@ UwbSimulatorDdiHandler::OnUwbSimulatorTriggerSessionEvent(WDFREQUEST request, st
     return status;
 }
 
-UwbSimulatorDdiHandler::UwbSimulatorDdiHandler(WDFFILEOBJECT wdfFile) :
-    m_wdfFile(wdfFile),
+UwbSimulatorDdiHandler::UwbSimulatorDdiHandler(UwbSimulatorDeviceFile *deviceFile) :
+    m_deviceFile(deviceFile),
     m_callbacks(std::make_unique<UwbSimulatorDdiCallbacks>())
 {
 }

--- a/windows/drivers/uwb/simulator/UwbSimulatorDevice.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDevice.cxx
@@ -172,7 +172,7 @@ UwbSimulatorDevice::OnFileCreate(WDFDEVICE device, WDFREQUEST request, WDFFILEOB
     auto uwbSimulatorFile = new (uwbSimulatorFileBuffer) UwbSimulatorDeviceFile(file);
     auto uwbSimulatorFileStatus = uwbSimulatorFile->Initialize();
     if (uwbSimulatorFileStatus == STATUS_SUCCESS) {
-        auto uwbSimulatorHandler = std::make_unique<UwbSimulatorDdiHandler>(file);
+        auto uwbSimulatorHandler = std::make_unique<UwbSimulatorDdiHandler>(uwbSimulatorFile);
         uwbSimulatorFile->RegisterHandler(std::move(uwbSimulatorHandler));
     } else {
         uwbSimulatorFile->~UwbSimulatorDeviceFile();

--- a/windows/drivers/uwb/simulator/UwbSimulatorDevice.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDevice.cxx
@@ -169,15 +169,16 @@ UwbSimulatorDevice::OnFileCreate(WDFDEVICE device, WDFREQUEST request, WDFFILEOB
         TraceLoggingPointer(file, "File"));
 
     auto uwbSimulatorFileBuffer = GetUwbSimulatorFile(file);
-    auto uwbSimulatorFile [[maybe_unused]] = new (uwbSimulatorFileBuffer) UwbSimulatorDeviceFile(file);
-    auto uwbSimulatorHandler = std::make_unique<UwbSimulatorDdiHandler>(file);
-    uwbSimulatorFile->RegisterHandler(std::move(uwbSimulatorHandler));
+    auto uwbSimulatorFile = new (uwbSimulatorFileBuffer) UwbSimulatorDeviceFile(file);
+    auto uwbSimulatorFileStatus = uwbSimulatorFile->Initialize();
+    if (uwbSimulatorFileStatus == STATUS_SUCCESS) {
+        auto uwbSimulatorHandler = std::make_unique<UwbSimulatorDdiHandler>(file);
+        uwbSimulatorFile->RegisterHandler(std::move(uwbSimulatorHandler));
+    } else {
+        uwbSimulatorFile->~UwbSimulatorDeviceFile();
+    }
 
-    // TODO: Here, uwbSimulatorFile should be associated with the DDI it is responsible for handling.
-    // It could make sense for it to use the pimpl idiom since the storage for the class is pre-allocated
-    // by the driver framework, polymorphism can't be used.
-
-    WdfRequestComplete(request, STATUS_SUCCESS);
+    WdfRequestComplete(request, uwbSimulatorFileStatus);
 }
 
 void

--- a/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.cxx
@@ -12,6 +12,18 @@ UwbSimulatorDeviceFile::UwbSimulatorDeviceFile(WDFFILEOBJECT wdfFile) :
     m_wdfFile(wdfFile)
 {}
 
+WDFFILEOBJECT
+UwbSimulatorDeviceFile::GetWdfFile() const noexcept
+{
+    return m_wdfFile;
+}
+
+UwbSimulatorIoEventQueue *
+UwbSimulatorDeviceFile::GetIoEventQueue() noexcept
+{
+    return m_ioEventQueue;
+}
+
 NTSTATUS
 UwbSimulatorDeviceFile::Initialize()
 {

--- a/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.cxx
@@ -3,6 +3,7 @@
 #include <iterator>
 
 #include "UwbSimulatorDeviceFile.hxx"
+#include "UwbSimulatorIoEventQueue.hxx"
 #include "UwbSimulatorTracelogging.hxx"
 
 using windows::devices::uwb::simulator::IUwbSimulatorDdiHandler;
@@ -10,6 +11,49 @@ using windows::devices::uwb::simulator::IUwbSimulatorDdiHandler;
 UwbSimulatorDeviceFile::UwbSimulatorDeviceFile(WDFFILEOBJECT wdfFile) :
     m_wdfFile(wdfFile)
 {}
+
+NTSTATUS
+UwbSimulatorDeviceFile::Initialize()
+{
+    // Create a manual dispatch queue for event handling.
+    WDF_IO_QUEUE_CONFIG queueConfig;
+    WDF_IO_QUEUE_CONFIG_INIT(&queueConfig, WdfIoQueueDispatchManual);
+    queueConfig.PowerManaged = WdfFalse;
+
+    // Set the parent to this file such that the queue's lifetime is tied to it.
+    WDF_OBJECT_ATTRIBUTES queueAttributes;
+    queueAttributes.ParentObject = m_wdfFile;
+    WDF_OBJECT_ATTRIBUTES_INIT_CONTEXT_TYPE(&queueAttributes, UwbSimulatorIoEventQueue);
+
+    WDFQUEUE wdfQueue;
+    WDFDEVICE wdfDevice = WdfFileObjectGetDevice(m_wdfFile);
+    NTSTATUS status = WdfIoQueueCreate(wdfDevice, &queueConfig, &queueAttributes, &wdfQueue);
+    if (!NT_SUCCESS(status)) {
+        TraceLoggingWrite(
+            UwbSimulatorTraceloggingProvider,
+            "WdfIoQueueCreate failed",
+            TraceLoggingLevel(TRACE_LEVEL_FATAL),
+            TraceLoggingNTStatus(status));
+        return status;
+    }
+
+    // Construct a new UwbSimulatorIoEventQueue instance using the WDF pre-allocated buffer.
+    auto ioEventQueueBuffer = GetUwbSimulatorIoEventQueue(wdfQueue);
+    auto ioEventQueue = new (ioEventQueueBuffer) UwbSimulatorIoEventQueue(wdfQueue);
+    if (ioEventQueue == nullptr) {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    status = ioEventQueue->Initialize();
+    if (!NT_SUCCESS(status)) {
+        ioEventQueue->~UwbSimulatorIoEventQueue();
+        return status;
+    }
+
+    m_ioEventQueue = ioEventQueue;
+
+    return status;
+}
 
 void
 UwbSimulatorDeviceFile::RegisterHandler(std::unique_ptr<IUwbSimulatorDdiHandler> handler)
@@ -47,6 +91,11 @@ UwbSimulatorDeviceFile::OnWdfRequestCancel(WDFREQUEST request)
 void
 UwbSimulatorDeviceFile::OnDestroy()
 {
+    if (m_ioEventQueue != nullptr) {
+        m_ioEventQueue->Uninitialize();
+        m_ioEventQueue->~UwbSimulatorIoEventQueue();
+        m_ioEventQueue = nullptr;
+    }
 }
 
 void

--- a/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.hxx
@@ -10,6 +10,7 @@
 #include <wdf.h>
 
 #include "IUwbSimulatorDdiHandler.hxx"
+#include "UwbSimulatorIoEventQueue.hxx"
 
 /**
  * @brief Device driver open file abstraction.
@@ -18,6 +19,14 @@ class UwbSimulatorDeviceFile
 {
 public:
     explicit UwbSimulatorDeviceFile(WDFFILEOBJECT wdfFile);
+
+    /**
+     * @brief Initializes the file object for use.
+     *
+     * @return NTSTATUS
+     */
+    NTSTATUS
+    Initialize();
 
     /**
      * @brief Register a DDI handler with this file instance.
@@ -63,6 +72,7 @@ private:
 
 private:
     WDFFILEOBJECT m_wdfFile;
+    UwbSimulatorIoEventQueue *m_ioEventQueue{ nullptr };
     std::vector<std::unique_ptr<windows::devices::uwb::simulator::IUwbSimulatorDdiHandler>> m_ddiHandlers{};
 };
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.hxx
@@ -51,6 +51,17 @@ public:
     NTSTATUS
     OnRequest(WDFREQUEST request, ULONG ioControlCode, size_t inputBufferLength, size_t outputBufferLength);
 
+    /**
+     * @brief Get the associated wdf file handle.
+     * 
+     * @return WDFFILEOBJECT 
+     */
+    WDFFILEOBJECT
+    GetWdfFile() const noexcept;
+
+    UwbSimulatorIoEventQueue*
+    GetIoEventQueue() noexcept;
+
 public:
     static EVT_WDF_OBJECT_CONTEXT_DESTROY OnWdfDestroy;
     static EVT_WDF_REQUEST_CANCEL OnWdfRequestCancel;

--- a/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.cxx
@@ -65,6 +65,10 @@ UwbSimulatorIoEventQueue::HandleNotificationRequest(WDFREQUEST request, std::opt
         }
     } else {
         status = WdfRequestForwardToIoQueue(request, m_wdfQueue);
+        if (!NT_SUCCESS(status)) {
+            // TODO: log
+        }
+        status = STATUS_PENDING;
     }
 
     WdfWaitLockRelease(m_wdfQueueLock);

--- a/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.cxx
@@ -1,0 +1,33 @@
+/**
+ * @file UwbSimulatorIoEventQueue.cxx
+ * @brief This file contains the queue entry points and callbacks.
+ *
+ * @copyright Copyright (c) 2023
+ */
+
+#include <memory>
+
+#include <windows.h>
+
+#include "UwbSimulatorIoEventQueue.hxx"
+#include "UwbSimulatorTracelogging.hxx"
+
+UwbSimulatorIoEventQueue::UwbSimulatorIoEventQueue(WDFQUEUE wdfQueue) :
+    m_wdfQueue(wdfQueue)
+{}
+
+UwbSimulatorIoEventQueue::~UwbSimulatorIoEventQueue()
+{
+}
+
+NTSTATUS
+UwbSimulatorIoEventQueue::Initialize()
+{
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS
+UwbSimulatorIoEventQueue::Uninitialize()
+{
+    return STATUS_SUCCESS;
+}

--- a/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.cxx
@@ -45,7 +45,7 @@ UwbSimulatorIoEventQueue::Uninitialize()
 }
 
 NTSTATUS
-UwbSimulatorIoEventQueue::HandleNotificationRequest(WDFREQUEST request, std::optional<UwbNotificationData> notificationDataOpt, std::size_t &outputBufferSize)
+UwbSimulatorIoEventQueue::HandleNotificationRequest(WDFREQUEST request, std::optional<UwbNotificationData> &notificationDataOpt, std::size_t &outputBufferSize)
 {
     NTSTATUS status = WdfWaitLockAcquire(m_wdfQueueLock, nullptr);
     if (!NT_SUCCESS(status)) {
@@ -59,7 +59,7 @@ UwbSimulatorIoEventQueue::HandleNotificationRequest(WDFREQUEST request, std::opt
         if (outputBufferSize < outputBufferSizeRequired) {
             status = STATUS_BUFFER_TOO_SMALL;
         } else {
-            notificationData = std::move(notificationData);
+            notificationDataOpt = std::move(notificationData);
             m_notificationQueue.pop();
             status = STATUS_SUCCESS;
         }

--- a/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.cxx
@@ -11,6 +11,15 @@
 
 #include "UwbSimulatorIoEventQueue.hxx"
 #include "UwbSimulatorTracelogging.hxx"
+#include <windows/devices/uwb/UwbCxAdapterDdiLrp.hxx>
+
+using ::uwb::protocol::fira::UwbNotificationData;
+
+/**
+ * @brief Namespace alias to reduce typing but preserve clarity regarding DDI
+ * conversion.
+ */
+namespace UwbCxDdi = windows::devices::uwb::ddi::lrp;
 
 UwbSimulatorIoEventQueue::UwbSimulatorIoEventQueue(WDFQUEUE wdfQueue) :
     m_wdfQueue(wdfQueue)
@@ -20,14 +29,69 @@ UwbSimulatorIoEventQueue::~UwbSimulatorIoEventQueue()
 {
 }
 
+WDFQUEUE
+UwbSimulatorIoEventQueue::GetWdfQueue() const noexcept
+{
+    return m_wdfQueue;
+}
+
 NTSTATUS
 UwbSimulatorIoEventQueue::Initialize()
 {
-    return STATUS_SUCCESS;
+    WDF_OBJECT_ATTRIBUTES lockAttributes{};
+    WDF_OBJECT_ATTRIBUTES_INIT(&lockAttributes);
+    lockAttributes.ParentObject = m_wdfQueue;
+
+    NTSTATUS status = WdfWaitLockCreate(&lockAttributes, &m_wdfQueueLock);
+    return status;
 }
 
 NTSTATUS
 UwbSimulatorIoEventQueue::Uninitialize()
 {
     return STATUS_SUCCESS;
+}
+
+NTSTATUS
+UwbSimulatorIoEventQueue::PendRequest(WDFREQUEST request, std::size_t outputBufferSize)
+{
+    NTSTATUS status;
+    status = WdfWaitLockAcquire(m_wdfQueueLock, nullptr);
+    if (!NT_SUCCESS(status)) {
+        return status;
+    }
+
+    status = WdfRequestForwardToIoQueue(request, m_wdfQueue);
+    if (NT_SUCCESS(status)) {
+        m_pendingRequestOutputBufferSize = outputBufferSize;
+    }
+
+    WdfWaitLockRelease(m_wdfQueueLock);
+    return status;
+}
+
+NTSTATUS
+UwbSimulatorIoEventQueue::GetNextQueuedRequest(std::optional<UwbNotificationData> notificationDataOpt, std::size_t &outputBufferSize)
+{
+    NTSTATUS status = WdfWaitLockAcquire(m_wdfQueueLock, nullptr);
+    if (NT_SUCCESS(status)) {
+        if (!m_notificationQueue.empty()) {
+            auto &notificationData = m_notificationQueue.front();
+            auto converted = UwbCxDdi::From(notificationData);
+            auto outputBufferSizeRequired = converted.size();
+            if (outputBufferSize < outputBufferSizeRequired) {
+                status = STATUS_BUFFER_TOO_SMALL;
+            } else {
+                notificationData = std::move(notificationData);
+                m_notificationQueue.pop();
+            }
+        } else {
+            status = STATUS_NO_MORE_ENTRIES;
+            // Forward request onto queue
+        }
+    }
+
+    WdfWaitLockRelease(m_wdfQueueLock);
+    
+    return status;
 }

--- a/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.hxx
@@ -10,12 +10,15 @@
 
 #include <cstddef>
 #include <memory>
+#include <optional>
+#include <queue>
 
 #include <windows.h>
 
 #include <wdf.h>
 
 #include "IUwbSimulatorDdiCallbacksLrp.hxx"
+#include <uwb/protocols/fira/FiraDevice.hxx>
 
 /**
  * @brief Per-event-queue context object.
@@ -48,8 +51,20 @@ public:
     NTSTATUS
     Uninitialize();
 
+    WDFQUEUE
+    GetWdfQueue() const noexcept;
+
+    NTSTATUS
+    PendRequest(WDFREQUEST request, std::size_t outputBufferSize);
+
+    NTSTATUS
+    GetNextQueuedRequest(std::optional<::uwb::protocol::fira::UwbNotificationData> notificationData, std::size_t &outputBufferSize);
+
 private:
     WDFQUEUE m_wdfQueue;
+    WDFWAITLOCK m_wdfQueueLock{ nullptr };
+    std::optional<std::size_t> m_pendingRequestOutputBufferSize;
+    std::queue<::uwb::protocol::fira::UwbNotificationData> m_notificationQueue;
 };
 
 WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(UwbSimulatorIoEventQueue, GetUwbSimulatorIoEventQueue)

--- a/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.hxx
@@ -1,0 +1,57 @@
+/**
+ * @file UwbSimulatorIoEventQueue.hxx
+ * @brief This file contains the event queue entry points and callbacks.
+ *
+ * @copyright Copyright (c) 2023
+ */
+
+#ifndef UWB_SIMULATOR_IO_EVENT_QUEUE_HXX
+#define UWB_SIMULATOR_IO_EVENT_QUEUE_HXX
+
+#include <cstddef>
+#include <memory>
+
+#include <windows.h>
+
+#include <wdf.h>
+
+#include "IUwbSimulatorDdiCallbacksLrp.hxx"
+
+/**
+ * @brief Per-event-queue context object.
+ */
+class UwbSimulatorIoEventQueue
+{
+public:
+    /**
+     * @brief Construct a new UwbSimulatorIoEventQueue object.
+     *
+     * @param wdfQueue
+     */
+    explicit UwbSimulatorIoEventQueue(WDFQUEUE wdfQueue);
+
+    ~UwbSimulatorIoEventQueue();
+
+    /**
+     * @brief
+     *
+     * @return NTSTATUS
+     */
+    NTSTATUS
+    Initialize();
+
+    /**
+     * @brief
+     *
+     * @return NTSTATUS
+     */
+    NTSTATUS
+    Uninitialize();
+
+private:
+    WDFQUEUE m_wdfQueue;
+};
+
+WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(UwbSimulatorIoEventQueue, GetUwbSimulatorIoEventQueue)
+
+#endif // UWB_SIMULATOR_IO_EVENT_QUEUE_HXX

--- a/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.hxx
@@ -67,7 +67,7 @@ public:
      * @return NTSTATUS
      */
     NTSTATUS
-    HandleNotificationRequest(WDFREQUEST request, std::optional<::uwb::protocol::fira::UwbNotificationData> notificationData, std::size_t &outputBufferSize);
+    HandleNotificationRequest(WDFREQUEST request, std::optional<::uwb::protocol::fira::UwbNotificationData> &notificationData, std::size_t &outputBufferSize);
 
     /**
      * @brief Push new notification request data onto the queue.

--- a/windows/drivers/uwb/simulator/UwbSimulatorIoQueue.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorIoQueue.cxx
@@ -1,5 +1,5 @@
 /**
- * @file Queue.cxx
+ * @file UwbSimulatorIoQueue.cxx
  * @brief This file contains the queue entry points and callbacks.
  *
  * @copyright Copyright (c) 2022


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [x] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Allow clients to handle uwb notifications from the simulator driver to be handled asynchronously.

### Technical Details

* Add a manual dispatch WDF queue for handling uwb notification events; today, this includes `UwbNotificationData`.
* Add dedicated object `UwbSimulatorDeviceFile` representing a `WDFFILEOBJECT`. and assign such instances to the WDF context slot.
* 
### Test Results

Ran the `nocli.exe uwb raw getdeviceinfo` with the following expected output, showing the wait on `GetOverlappedResult` was canceled (`0x800703e3 == ERROR_OPERATION_ABORTED`):

```
get device info
Initialize
GetDeviceInformation
IOCTL_UWB_GET_DEVICE_INFO attempt #1 with 24-byte buffer
IOCTL_UWB_NOTIFICATION attempt #1 with 0-byte buffer
IOCTL_UWB_GET_DEVICE_INFO succeeded
FiRa Uci v0.0.0, FiRa Uci Test v0.0.0, FiRa MAC v0.0.0, FiRa PHY v0.0.0
error waiting for IOCTL_UWB_NOTIFICATION completion, hr=0x800703e3
```

Additional testing is needed to validate the notification data itself is returned when provided by the driver. This will be done separately.

### Reviewer Focus

Consider whether there are missing pieces from handling the `WDFREQUEST` and whether any additional code is necessary to properly manage the lifetime of the `WDFQUEUE` dedicated to handling notifications.

### Future Work

* The internal structures for handling the new I/O event queue are passed around as raw pointers. We need to consider whether this is always safe. The current intention is that a raw pointer is only stored when it is provided by the object which owns the containing instance. This needs to be validated in case there are any asynchronous operations that could access state outside of this constraint.
* The client code uses `GetOverlappedResult()` with its `bWait` parameter set to `TRUE`. This isn't true asynchronous behavior and should be replaced as such. This will be done with a general purpose I/O execution class supporting both sync and async I/O.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
