### PR TITLE
Fix preable/preamble typo

### DIFF
--- a/lib/uwb/include/uwb/protocols/fira/UwbConfiguration.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/UwbConfiguration.hxx
@@ -61,7 +61,7 @@ struct UwbConfiguration
         Sp0PhySetNumber = 0x8F,
         Sp1PhySetNumber = 0x90,
         Sp3PhySetNumber = 0x91,
-        PreableCodeIndex = 0x92, // TODO fix the typo here
+        PreambleCodeIndex = 0x92,
         ResultReportConfig = 0x93,
         MacAddressMode = 0x94,
         ControleeShortMacAddress = 0x95,
@@ -98,7 +98,7 @@ struct UwbConfiguration
     static constexpr auto Sp0PhySetNumberDefault = 1;
     static constexpr auto Sp1PhySetNumberDefault = 1;
     static constexpr auto Sp3PhySetNumberDefault = 0;
-    static constexpr auto PreableCodeIndexDefault = 0;
+    static constexpr auto PreambleCodeIndexDefault = 0;
     static constexpr auto MacAddressModeDefault = UwbMacAddressType::Short;
     static constexpr auto KeyRotationRateDefault = 0UL;
     static constexpr auto MacFcsTypeDefault = UwbMacAddressFcsType::Crc16;
@@ -226,7 +226,7 @@ struct UwbConfiguration
     GetSp3PhySetNumber() const noexcept;
 
     std::optional<uint8_t>
-    GetPreableCodeIndex() const noexcept;
+    GetPreambleCodeIndex() const noexcept;
 
     std::unordered_set<uwb::protocol::fira::ResultReportConfiguration>
     GetResultReportConfigurations() const noexcept;
@@ -316,7 +316,7 @@ struct hash<uwb::protocol::fira::UwbConfiguration>
             uwbConfiguration.GetSp0PhySetNumber(),
             uwbConfiguration.GetSp1PhySetNumber(),
             uwbConfiguration.GetSp3PhySetNumber(),
-            uwbConfiguration.GetPreableCodeIndex(),
+            uwbConfiguration.GetPreambleCodeIndex(),
             notstd::hash_range(std::cbegin(resultReportConfigurations), std::cend(resultReportConfigurations)),
             uwbConfiguration.GetMacAddressMode(),
             uwbConfiguration.GetControleeShortMacAddress(),

--- a/lib/uwb/include/uwb/protocols/fira/UwbConfigurationBuilder.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/UwbConfigurationBuilder.hxx
@@ -79,7 +79,7 @@ public:
     SetSp3PhySetNumber(uint8_t sp3PhySetNumber) noexcept;
 
     UwbConfiguration::Builder&
-    SetPreableCodeIndex(uint8_t preambleCodeIndex) noexcept;
+    SetPreambleCodeIndex(uint8_t preambleCodeIndex) noexcept;
 
     UwbConfiguration::Builder&
     AddResultReportConfiguration(uwb::protocol::fira::ResultReportConfiguration resultReportConfiguration) noexcept;
@@ -187,7 +187,7 @@ public:
     Sp3(uint8_t sp3PhySetNumber) noexcept;
 
     UwbConfiguration::Builder&
-    PreableCodeIndex(uint8_t preambleCodeIndex) noexcept;
+    PreambleCodeIndex(uint8_t preambleCodeIndex) noexcept;
 
     /**
      * @brief No-op helper to supply more semantic information while chaining arguments.

--- a/lib/uwb/protocols/fira/UwbConfiguration.cxx
+++ b/lib/uwb/protocols/fira/UwbConfiguration.cxx
@@ -140,9 +140,9 @@ UwbConfiguration::GetSp3PhySetNumber() const noexcept
 }
 
 std::optional<uint8_t>
-UwbConfiguration::GetPreableCodeIndex() const noexcept
+UwbConfiguration::GetPreambleCodeIndex() const noexcept
 {
-    return GetValue<uint8_t>(ParameterTag::PreableCodeIndex);
+    return GetValue<uint8_t>(ParameterTag::PreambleCodeIndex);
 }
 
 std::unordered_set<ResultReportConfiguration>

--- a/lib/uwb/protocols/fira/UwbConfigurationBuilder.cxx
+++ b/lib/uwb/protocols/fira/UwbConfigurationBuilder.cxx
@@ -255,16 +255,16 @@ UwbConfiguration::Builder::Sp3(uint8_t sp3PhySetNumber) noexcept
 }
 
 UwbConfiguration::Builder&
-UwbConfiguration::Builder::SetPreableCodeIndex(uint8_t preambleCodeIndex) noexcept
+UwbConfiguration::Builder::SetPreambleCodeIndex(uint8_t preambleCodeIndex) noexcept
 {
-    m_values[ParameterTag::PreableCodeIndex] = preambleCodeIndex;
+    m_values[ParameterTag::PreambleCodeIndex] = preambleCodeIndex;
     return *this;
 }
 
 UwbConfiguration::Builder&
-UwbConfiguration::Builder::PreableCodeIndex(uint8_t preambleCodeIndex) noexcept
+UwbConfiguration::Builder::PreambleCodeIndex(uint8_t preambleCodeIndex) noexcept
 {
-    return SetPreableCodeIndex(preambleCodeIndex);
+    return SetPreambleCodeIndex(preambleCodeIndex);
 }
 
 UwbConfiguration::Builder&

--- a/tests/unit/uwb/protocols/fira/TestUwbFiraUwbConfigurationBuilder.cxx
+++ b/tests/unit/uwb/protocols/fira/TestUwbFiraUwbConfigurationBuilder.cxx
@@ -27,7 +27,7 @@ constexpr PrfMode PrfModeValue{ PrfMode::Bprf };
 constexpr uint8_t Sp0Value{ 10 };
 constexpr uint8_t Sp1Value{ 20 };
 constexpr uint8_t Sp3Value{ 30 };
-constexpr uint8_t PreableCodeIndexValue{ 25 };
+constexpr uint8_t PreambleCodeIndexValue{ 25 };
 constexpr uwb::UwbMacAddressType UwbMacAddressTypeValue{ uwb::UwbMacAddressType::Extended };
 constexpr uwb::UwbMacAddressFcsType UwbMacAddressFcsTypeValue{ uwb::UwbMacAddressFcsType::Crc32 };
 const uwb::UwbMacAddress UwbMacAddressControleeShortValue{ uwb::UwbMacAddress{ std::array<uint8_t, 2>{ 0x00, 0x01 } } };
@@ -73,7 +73,7 @@ TEST_CASE("uwb configuration objects can be created with builder", "[basic]")
                     .Sp0(test::Sp0Value)
                     .Sp1(test::Sp1Value)
                     .Sp3(test::Sp3Value)
-                .PreableCodeIndex(test::PreableCodeIndexValue)
+                .PreambleCodeIndex(test::PreambleCodeIndexValue)
                 .MacAddress()
                     .Type(test::UwbMacAddressTypeValue)
                     .FcsType(test::UwbMacAddressFcsTypeValue)
@@ -112,7 +112,7 @@ TEST_CASE("uwb configuration objects can be created with builder", "[basic]")
         REQUIRE(uwbConfiguration.GetSp0PhySetNumber() == test::Sp0Value);
         REQUIRE(uwbConfiguration.GetSp1PhySetNumber() == test::Sp1Value);
         REQUIRE(uwbConfiguration.GetSp3PhySetNumber() == test::Sp3Value);
-        REQUIRE(uwbConfiguration.GetPreableCodeIndex() == test::PreableCodeIndexValue);
+        REQUIRE(uwbConfiguration.GetPreambleCodeIndex() == test::PreambleCodeIndexValue);
         REQUIRE(uwbConfiguration.GetMacAddressMode() == test::UwbMacAddressTypeValue);
         REQUIRE(uwbConfiguration.GetMacAddressFcsType() == test::UwbMacAddressFcsTypeValue);
         REQUIRE(uwbConfiguration.GetControleeShortMacAddress() == test::UwbMacAddressControleeShortValue);

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -251,7 +251,7 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App* parent)
     rangeStartApp->add_option("--Sp0PhySetNumber", uwbConfig.sp0PhySetNumber, "uint8_t")->capture_default_str();
     rangeStartApp->add_option("--Sp1PhySetNumber", uwbConfig.sp1PhySetNumber, "uint8_t")->capture_default_str();
     rangeStartApp->add_option("--Sp3PhySetNumber", uwbConfig.sp3PhySetNumber, "uint8_t")->capture_default_str();
-    rangeStartApp->add_option("--PreableCodeIndex", uwbConfig.preableCodeIndex, "uint8_t")->capture_default_str();
+    rangeStartApp->add_option("--PreambleCodeIndex", uwbConfig.preambleCodeIndex, "uint8_t")->capture_default_str();
     rangeStartApp->add_option("--SlotsPerRangingRound", uwbConfig.slotsPerRangingRound, "uint8_t")->capture_default_str();
     rangeStartApp->add_option("--MaxContentionPhaseLength", uwbConfig.maxContentionPhaseLength, "uint8_t")->capture_default_str();
     rangeStartApp->add_option("--SlotDuration", uwbConfig.slotDuration, "uint8_t")->capture_default_str();

--- a/tools/cli/NearObjectCliData.cxx
+++ b/tools/cli/NearObjectCliData.cxx
@@ -78,8 +78,8 @@ UwbConfigurationData::operator UwbConfiguration() const noexcept
     if (sp3PhySetNumber.has_value()) {
         builder.SetSp3PhySetNumber(sp3PhySetNumber.value());
     }
-    if (preableCodeIndex.has_value()) {
-        builder.SetPreableCodeIndex(preableCodeIndex.value());
+    if (preambleCodeIndex.has_value()) {
+        builder.SetPreambleCodeIndex(preambleCodeIndex.value());
     }
     if (macAddressMode.has_value()) {
         builder.SetMacAddressType(macAddressMode.value());

--- a/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
@@ -40,7 +40,7 @@ struct UwbConfigurationData
     std::optional<uint8_t> sp0PhySetNumber;
     std::optional<uint8_t> sp1PhySetNumber;
     std::optional<uint8_t> sp3PhySetNumber;
-    std::optional<uint8_t> preableCodeIndex;
+    std::optional<uint8_t> preambleCodeIndex;
     std::optional<uwb::UwbMacAddressType> macAddressMode;
     std::optional<uwb::UwbMacAddress> controleeShortMacAddress;
     std::optional<uwb::UwbMacAddress> controllerMacAddress;

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbAppConfiguration.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbAppConfiguration.hxx
@@ -92,7 +92,7 @@ const std::unordered_map<::uwb::protocol::fira::UwbConfiguration::ParameterTag, 
     { ::uwb::protocol::fira::UwbConfiguration::ParameterTag::Sp0PhySetNumber, UWB_APP_CONFIG_PARAM_TYPE_PSDU_DATA_RATE }, // TODO related but not directly the psdu data rate
     { ::uwb::protocol::fira::UwbConfiguration::ParameterTag::Sp1PhySetNumber, UWB_APP_CONFIG_PARAM_TYPE_PSDU_DATA_RATE }, // TODO related but not directly the psdu data rate
     { ::uwb::protocol::fira::UwbConfiguration::ParameterTag::Sp3PhySetNumber, UWB_APP_CONFIG_PARAM_TYPE_PSDU_DATA_RATE }, // TODO related but not directly the psdu data rate
-    { ::uwb::protocol::fira::UwbConfiguration::ParameterTag::PreableCodeIndex, UWB_APP_CONFIG_PARAM_TYPE_PREAMBLE_CODE_INDEX },
+    { ::uwb::protocol::fira::UwbConfiguration::ParameterTag::PreambleCodeIndex, UWB_APP_CONFIG_PARAM_TYPE_PREAMBLE_CODE_INDEX },
     { ::uwb::protocol::fira::UwbConfiguration::ParameterTag::ResultReportConfig, UWB_APP_CONFIG_PARAM_TYPE_RESULT_REPORT_CONFIG },
     { ::uwb::protocol::fira::UwbConfiguration::ParameterTag::MacAddressMode, UWB_APP_CONFIG_PARAM_TYPE_MAC_ADDRESS_MODE },
     { ::uwb::protocol::fira::UwbConfiguration::ParameterTag::ControleeShortMacAddress, UWB_APP_CONFIG_PARAM_TYPE_DST_MAC_ADDRESS },


### PR DESCRIPTION
### Type

- [x] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

There is a typo with the spelling of "preamble" as "preable".

### Technical Details

Fixed typo.

### Test Results

Code builds.

### Reviewer Focus

None.

### Future Work

None.

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
