### PR TITLE
Add neutral <-> DDI adapter conversion functions for UWB_APP_CONFIG_PARAM

### DIFF
--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -571,6 +571,9 @@ struct UwbApplicationConfigurationParameter
 {
     UwbApplicationConfigurationParameterType Type;
     UwbApplicationConfigurationParameterValue Value;
+
+    bool
+    operator==(const UwbApplicationConfigurationParameter&) const noexcept = default;
 };
 
 struct UwbMulticastListStatus

--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -491,7 +491,7 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
     {
         // UWB_APP_CONFIG_PARAM_TYPE_HOPPING_MODE
         constexpr bool hoppingMode = true;
-        const UwbApplicationConfigurationParameter parameterHoppingMode = {
+        constexpr UwbApplicationConfigurationParameter parameterHoppingMode = {
             .Type = UwbApplicationConfigurationParameterType::HoppingMode,
             .Value = hoppingMode,  
         };
@@ -513,7 +513,7 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
     {
         // UWB_APP_CONFIG_PARAM_TYPE_SLOT_DURATION
         constexpr uint16_t slotDuration{ 0xAB };
-        const UwbApplicationConfigurationParameter parameterSlotDuration = {
+        constexpr UwbApplicationConfigurationParameter parameterSlotDuration = {
             .Type = UwbApplicationConfigurationParameterType::SlotDuration,
             .Value = slotDuration,  
         };
@@ -524,7 +524,7 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
     {
         // UWB_APP_CONFIG_PARAM_TYPE_RANGING_INTERVAL
         constexpr uint32_t rangingInterval{ 0xABCD };
-        const UwbApplicationConfigurationParameter parameterRangingInterval = {
+        constexpr UwbApplicationConfigurationParameter parameterRangingInterval = {
             .Type = UwbApplicationConfigurationParameterType::RangingInterval,
             .Value = rangingInterval,  
         };
@@ -535,11 +535,21 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
     {
         // UWB_APP_CONFIG_PARAM_TYPE_AOA_RESULT_REQ
         constexpr AoAResult aoaResult{ AoAResult::Enable };
-        const UwbApplicationConfigurationParameter parameterAoaResult = {
+        constexpr UwbApplicationConfigurationParameter parameterAoaResult = {
             .Type = UwbApplicationConfigurationParameterType::AoAResultRequest,
             .Value = aoaResult,  
         };
         test::ValidateRoundtrip(parameterAoaResult);
     }
 
+    SECTION("UwbApplicationConfigurationParameter std::array<uint8_t, N> variant is stable")
+    {
+        // UWB_APP_CONFIG_PARAM_TYPE_STATIC_STS_IV
+        constexpr std::array<uint8_t, StaticStsInitializationVectorLength> staticStsInitializationVector{ 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF };
+        constexpr UwbApplicationConfigurationParameter parameterstaticStsInitializationVector = {
+            .Type = UwbApplicationConfigurationParameterType::StaticStsIv,
+            .Value = staticStsInitializationVector,  
+        };
+        test::ValidateRoundtrip(parameterstaticStsInitializationVector);
+    }
 }

--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -486,4 +486,60 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
         const UwbNotificationData uwbNotificationDataRangingData{ uwbRangingData };
         test::ValidateRoundtrip(uwbNotificationDataRangingData);
     }
+
+    SECTION("UwbApplicationConfigurationParameter bool variant is stable")
+    {
+        // UWB_APP_CONFIG_PARAM_TYPE_HOPPING_MODE
+        constexpr bool hoppingMode = true;
+        const UwbApplicationConfigurationParameter parameterHoppingMode = {
+            .Type = UwbApplicationConfigurationParameterType::HoppingMode,
+            .Value = hoppingMode,  
+        };
+        test::ValidateRoundtrip(parameterHoppingMode);
+    }
+
+    SECTION("UwbApplicationConfigurationParameter uint8_t variant is stable")
+    {
+        // UWB_APP_CONFIG_PARAM_TYPE_NUMBER_OF_CONTROLEES
+        constexpr uint8_t numberOfControlees{ 100 };
+        constexpr UwbApplicationConfigurationParameter parameterNumberOfControlees = {
+            .Type = UwbApplicationConfigurationParameterType::NumberOfControlees,
+            .Value = numberOfControlees,  
+        };
+        test::ValidateRoundtrip(parameterNumberOfControlees);
+    }
+
+    SECTION("UwbApplicationConfigurationParameter uint16_t variant is stable")
+    {
+        // UWB_APP_CONFIG_PARAM_TYPE_SLOT_DURATION
+        constexpr uint16_t slotDuration{ 0xAB };
+        const UwbApplicationConfigurationParameter parameterSlotDuration = {
+            .Type = UwbApplicationConfigurationParameterType::SlotDuration,
+            .Value = slotDuration,  
+        };
+        test::ValidateRoundtrip(parameterSlotDuration);
+    }
+
+    SECTION("UwbApplicationConfigurationParameter uint32_t variant is stable")
+    {
+        // UWB_APP_CONFIG_PARAM_TYPE_RANGING_INTERVAL
+        constexpr uint32_t rangingInterval{ 0xABCD };
+        const UwbApplicationConfigurationParameter parameterRangingInterval = {
+            .Type = UwbApplicationConfigurationParameterType::RangingInterval,
+            .Value = rangingInterval,  
+        };
+        test::ValidateRoundtrip(parameterRangingInterval);
+    }
+
+    SECTION("UwbApplicationConfigurationParameter enum class variant is stable")
+    {
+        // UWB_APP_CONFIG_PARAM_TYPE_AOA_RESULT_REQ
+        constexpr AoAResult aoaResult{ AoAResult::Enable };
+        const UwbApplicationConfigurationParameter parameterAoaResult = {
+            .Type = UwbApplicationConfigurationParameterType::AoAResultRequest,
+            .Value = aoaResult,  
+        };
+        test::ValidateRoundtrip(parameterAoaResult);
+    }
+
 }

--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -493,7 +493,7 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
         constexpr bool hoppingMode = true;
         constexpr UwbApplicationConfigurationParameter parameterHoppingMode = {
             .Type = UwbApplicationConfigurationParameterType::HoppingMode,
-            .Value = hoppingMode,  
+            .Value = hoppingMode,
         };
         test::ValidateRoundtrip(parameterHoppingMode);
     }
@@ -504,7 +504,7 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
         constexpr uint8_t numberOfControlees{ 100 };
         constexpr UwbApplicationConfigurationParameter parameterNumberOfControlees = {
             .Type = UwbApplicationConfigurationParameterType::NumberOfControlees,
-            .Value = numberOfControlees,  
+            .Value = numberOfControlees,
         };
         test::ValidateRoundtrip(parameterNumberOfControlees);
     }
@@ -515,7 +515,7 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
         constexpr uint16_t slotDuration{ 0xAB };
         constexpr UwbApplicationConfigurationParameter parameterSlotDuration = {
             .Type = UwbApplicationConfigurationParameterType::SlotDuration,
-            .Value = slotDuration,  
+            .Value = slotDuration,
         };
         test::ValidateRoundtrip(parameterSlotDuration);
     }
@@ -526,7 +526,7 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
         constexpr uint32_t rangingInterval{ 0xABCD };
         constexpr UwbApplicationConfigurationParameter parameterRangingInterval = {
             .Type = UwbApplicationConfigurationParameterType::RangingInterval,
-            .Value = rangingInterval,  
+            .Value = rangingInterval,
         };
         test::ValidateRoundtrip(parameterRangingInterval);
     }
@@ -537,7 +537,7 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
         constexpr AoAResult aoaResult{ AoAResult::Enable };
         constexpr UwbApplicationConfigurationParameter parameterAoaResult = {
             .Type = UwbApplicationConfigurationParameterType::AoAResultRequest,
-            .Value = aoaResult,  
+            .Value = aoaResult,
         };
         test::ValidateRoundtrip(parameterAoaResult);
     }
@@ -548,7 +548,7 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
         constexpr std::array<uint8_t, StaticStsInitializationVectorLength> staticStsInitializationVector{ 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF };
         constexpr UwbApplicationConfigurationParameter parameterstaticStsInitializationVector = {
             .Type = UwbApplicationConfigurationParameterType::StaticStsIv,
-            .Value = staticStsInitializationVector,  
+            .Value = staticStsInitializationVector,
         };
         test::ValidateRoundtrip(parameterstaticStsInitializationVector);
     }

--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -563,4 +563,15 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
         };
         test::ValidateRoundtrip(parameterUwbMacAddressShort);
     }
+
+    SECTION("UwbApplicationConfigurationParameter ::uwb::UwbMacAddress (extended type)")
+    {
+        // UWB_APP_CONFIG_PARAM_TYPE_DEVICE_MAC_ADDRESS
+        constexpr ::uwb::UwbMacAddress uwbMacAddressExtended(std::array<uint8_t, ::uwb::UwbMacAddressLength::Extended>{ 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF });
+        constexpr UwbApplicationConfigurationParameter parameterUwbMacAddressExtended = {
+            .Type = UwbApplicationConfigurationParameterType::DeviceMacAddress,
+            .Value = std::move(uwbMacAddressExtended),
+        };
+        test::ValidateRoundtrip(parameterUwbMacAddressExtended);
+    }
 }

--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -546,10 +546,21 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
     {
         // UWB_APP_CONFIG_PARAM_TYPE_STATIC_STS_IV
         constexpr std::array<uint8_t, StaticStsInitializationVectorLength> staticStsInitializationVector{ 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF };
-        constexpr UwbApplicationConfigurationParameter parameterstaticStsInitializationVector = {
+        constexpr UwbApplicationConfigurationParameter parameterStaticStsInitializationVector = {
             .Type = UwbApplicationConfigurationParameterType::StaticStsIv,
             .Value = staticStsInitializationVector,
         };
-        test::ValidateRoundtrip(parameterstaticStsInitializationVector);
+        test::ValidateRoundtrip(parameterStaticStsInitializationVector);
+    }
+
+    SECTION("UwbApplicationConfigurationParameter ::uwb::UwbMacAddress (short type)")
+    {
+        // UWB_APP_CONFIG_PARAM_TYPE_DEVICE_MAC_ADDRESS
+        constexpr ::uwb::UwbMacAddress uwbMacAddressShort(std::array<uint8_t, ::uwb::UwbMacAddressLength::Short>{ 0xAA, 0xBB });
+        constexpr UwbApplicationConfigurationParameter parameterUwbMacAddressShort = {
+            .Type = UwbApplicationConfigurationParameterType::DeviceMacAddress,
+            .Value = std::move(uwbMacAddressShort),
+        };
+        test::ValidateRoundtrip(parameterUwbMacAddressShort);
     }
 }

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -548,6 +548,22 @@ windows::devices::uwb::ddi::lrp::From(const UwbNotificationData &uwbNotification
     return std::move(*notificationDataWrapper);
 }
 
+UwbApplicationConfigurationParameterWrapper
+windows::devices::uwb::ddi::lrp::From([[maybe_unused]] const UwbApplicationConfigurationParameter &uwbApplicationConfigurationParameter)
+{
+    UwbApplicationConfigurationParameterWrapper applicationConfigurationParameterWrapper{ 1 /* FIXME */};
+    // TODO
+    return applicationConfigurationParameterWrapper;
+}
+
+UwbApplicationConfigurationParametersWrapper
+windows::devices::uwb::ddi::lrp::From([[maybe_unused]] const std::vector<UwbApplicationConfigurationParameterValue> &uwbApplicationConfigurationParameters)
+{
+    UwbApplicationConfigurationParametersWrapper applicationConfigurationParametersWrapper{ 1 /* FIXME */};
+    // TODO
+    return applicationConfigurationParametersWrapper;
+}
+
 namespace detail
 {
 /**
@@ -1150,4 +1166,206 @@ windows::devices::uwb::ddi::lrp::To(const UWB_NOTIFICATION_DATA &notificationDat
 
     PLOG_WARNING << "unknown UwbNotificationData type encountered; returning default constructed instance";
     return UwbNotificationData{};
+}
+
+UwbApplicationConfigurationParameter
+windows::devices::uwb::ddi::lrp::To([[maybe_unused]] const UWB_APP_CONFIG_PARAM& applicationConfigurationParameter)
+{
+    UwbApplicationConfigurationParameter uwbApplicationConfigurationParameter{
+        .Type = To(applicationConfigurationParameter.paramType)
+    };
+
+    switch (applicationConfigurationParameter.paramType) {
+    case UWB_APP_CONFIG_PARAM_TYPE_HOPPING_MODE:
+        // TODO: convert to bool
+        break;
+    // uint8_t direct encoding
+    case UWB_APP_CONFIG_PARAM_TYPE_NUMBER_OF_CONTROLEES: // uint8_t 
+    case UWB_APP_CONFIG_PARAM_TYPE_PREAMBLE_CODE_INDEX:
+    case UWB_APP_CONFIG_PARAM_TYPE_SFD_ID: 
+    case UWB_APP_CONFIG_PARAM_TYPE_SLOTS_PER_RR: 
+    case UWB_APP_CONFIG_PARAM_TYPE_RESPONDER_SLOT_INDEX: 
+    case UWB_APP_CONFIG_PARAM_TYPE_KEY_ROTATION_RATE: 
+    case UWB_APP_CONFIG_PARAM_TYPE_SESSION_PRIORITY: 
+    case UWB_APP_CONFIG_PARAM_TYPE_NUMBER_OF_STS_SEGMENTS: 
+    case UWB_APP_CONFIG_PARAM_TYPE_BLOCK_STRIDE_LENGTH: 
+    case UWB_APP_CONFIG_PARAM_TYPE_IN_BAND_TERMINATION_ATTEMPT_COUNT:
+        // TODO: convert to uint8_t
+        break;
+    case UWB_APP_CONFIG_PARAM_TYPE_SLOT_DURATION:
+    case UWB_APP_CONFIG_PARAM_TYPE_RANGE_DATA_NTF_PROXIMITY_NEAR:
+    case UWB_APP_CONFIG_PARAM_TYPE_RANGE_DATA_NTF_PROXIMITY_FAR:
+    case UWB_APP_CONFIG_PARAM_TYPE_VENDOR_ID:
+    case UWB_APP_CONFIG_PARAM_TYPE_MAX_RR_RETRY:
+    case UWB_APP_CONFIG_PARAM_TYPE_MAX_NUMBER_OF_MEASUREMENTS:
+        // TODO: convert to uint16_t
+    case UWB_APP_CONFIG_PARAM_TYPE_RANGING_INTERVAL:
+    case UWB_APP_CONFIG_PARAM_TYPE_STS_INDEX:
+    case UWB_APP_CONFIG_PARAM_TYPE_UWB_INITIATION_TIME: 
+    case UWB_APP_CONFIG_PARAM_TYPE_SUB_SESSION_ID:
+        // TODO: convert to uint32_t
+        break;
+    case UWB_APP_CONFIG_PARAM_TYPE_AOA_RESULT_REQ: {
+        AoAResult value{};
+        // TOOD: convert
+        uwbApplicationConfigurationParameter.Value = std::move(value);
+        break;
+    }
+    case UWB_APP_CONFIG_PARAM_TYPE_BPRF_PHR_DATA_RATE: {
+        BprfPhrDataRate value{};
+        // TODO: convert
+        uwbApplicationConfigurationParameter.Value = std::move(value);
+        break;
+    }
+    case UWB_APP_CONFIG_PARAM_TYPE_CHANNEL_NUMBER: {
+        Channel value{};
+        // TODO: convert
+        uwbApplicationConfigurationParameter.Value = std::move(value);
+        break;
+    }
+    case UWB_APP_CONFIG_PARAM_TYPE_DEVICE_ROLE: {
+        DeviceRole value{};
+        // TODO: convert
+        uwbApplicationConfigurationParameter.Value = std::move(value);
+        break;
+    }
+    case UWB_APP_CONFIG_PARAM_TYPE_DEVICE_TYPE: {
+        DeviceType value{};
+        // TODO: convert
+        uwbApplicationConfigurationParameter.Value = std::move(value);
+        break;
+    }
+    case UWB_APP_CONFIG_PARAM_TYPE_KEY_ROTATION: {
+        KeyRotation value{};
+        // TODO: convert
+        uwbApplicationConfigurationParameter.Value = std::move(value);
+        break;
+    }
+    case UWB_APP_CONFIG_PARAM_TYPE_MULTI_NODE_MODE: {
+        MultiNodeMode value{};
+        // TODO: convert
+        uwbApplicationConfigurationParameter.Value = std::move(value);
+        break;
+    }
+    case UWB_APP_CONFIG_PARAM_TYPE_PREAMBLE_DURATION: {
+        PreambleDuration value{};
+        // TODO: convert
+        uwbApplicationConfigurationParameter.Value = std::move(value);
+        break;
+    }
+    case UWB_APP_CONFIG_PARAM_TYPE_PRF_MODE: {
+        PrfMode value{};
+        // TODO: convert
+        uwbApplicationConfigurationParameter.Value = std::move(value);
+        break;
+    }
+    case UWB_APP_CONFIG_PARAM_TYPE_PSDU_DATA_RATE: {
+        PsduDataRate value{};
+        // TODO: convert
+        uwbApplicationConfigurationParameter.Value = std::move(value);
+        break;
+    }
+    case UWB_APP_CONFIG_PARAM_TYPE_RANGE_DATA_NTF_CONFIG: {
+        RangeDataNotificationConfiguration value{};
+        // TODO: convert
+        uwbApplicationConfigurationParameter.Value = std::move(value);
+        break;
+    }
+    case UWB_APP_CONFIG_PARAM_TYPE_RANGING_ROUND_USAGE: {
+        RangingRoundUsage value{};
+        // TODO: convert
+        uwbApplicationConfigurationParameter.Value = std::move(value);
+        break;
+    }
+    case UWB_APP_CONFIG_PARAM_TYPE_RANGING_TIME_STRUCT: {
+        RangingMode value{};
+        // TODO: convert
+        uwbApplicationConfigurationParameter.Value = std::move(value);
+        break;
+    }
+    case UWB_APP_CONFIG_PARAM_TYPE_RANGING_ROUND_CONTROL: {
+        RangingRoundControl value{};
+        // TODO: convert
+        uwbApplicationConfigurationParameter.Value = std::move(value);
+        break;
+    }
+    case UWB_APP_CONFIG_PARAM_TYPE_RESULT_REPORT_CONFIG: {
+        ResultReportConfiguration value{};
+        // TODO: convert
+        uwbApplicationConfigurationParameter.Value = std::move(value);
+        break;
+    }
+    case UWB_APP_CONFIG_PARAM_TYPE_SCHEDULED_MODE: {
+        SchedulingMode value{};
+        // TODO: convert
+        uwbApplicationConfigurationParameter.Value = std::move(value);
+        break;
+    }
+    case UWB_APP_CONFIG_PARAM_TYPE_STS_CONFIG: {
+        StsConfiguration value{};
+        // TODO: convert
+        uwbApplicationConfigurationParameter.Value = std::move(value);
+        break;
+    }
+    case UWB_APP_CONFIG_PARAM_TYPE_STS_LENGTH: {
+        StsLength value{};
+        // TODO: convert
+        uwbApplicationConfigurationParameter.Value = std::move(value);
+        break;
+    }
+    case UWB_APP_CONFIG_PARAM_TYPE_RFRAME_CONFIG: {
+        StsPacketConfiguration value{};
+        // TODO: convert
+        uwbApplicationConfigurationParameter.Value = std::move(value);
+        break;
+    }
+    case UWB_APP_CONFIG_PARAM_TYPE_TX_ADAPTIVE_PAYLOAD_POWER: {
+        TxAdaptivePayloadPower value{};
+        // TODO: convert
+        uwbApplicationConfigurationParameter.Value = std::move(value);
+        break;
+    }
+    case UWB_APP_CONFIG_PARAM_TYPE_DEVICE_MAC_ADDRESS: {
+        ::uwb::UwbMacAddress value{};
+        // TODO: convert
+        uwbApplicationConfigurationParameter.Value = std::move(value);
+        break;
+    }
+    case UWB_APP_CONFIG_PARAM_TYPE_MAC_FCS_TYPE: {
+        ::uwb::UwbMacAddressFcsType value{};
+        // TODO: convert
+        uwbApplicationConfigurationParameter.Value = std::move(value);
+        break;
+    }
+    case UWB_APP_CONFIG_PARAM_TYPE_MAC_ADDRESS_MODE: {
+        ::uwb::UwbMacAddressType value{};
+        // TODO: convert
+        uwbApplicationConfigurationParameter.Value = std::move(value);
+        break;
+    }
+    case UWB_APP_CONFIG_PARAM_TYPE_STATIC_STS_IV: {
+        std::array<uint8_t, StaticStsInitializationVectorLength> value{};
+        // TODO: convert
+        uwbApplicationConfigurationParameter.Value = std::move(value);
+        break;
+    }
+    case UWB_APP_CONFIG_PARAM_TYPE_DST_MAC_ADDRESS: {
+        std::unordered_set<::uwb::UwbMacAddress> value{};
+        // TODO: convert
+        uwbApplicationConfigurationParameter.Value = std::move(value);
+        break;
+    }
+    default:
+        PLOG_ERROR << "unknown uwb application configuration parameter type encountered, type=" << std::showbase << std::hex << notstd::to_underlying(applicationConfigurationParameter.paramType);
+        break;
+    }
+
+    return uwbApplicationConfigurationParameter;
+}
+
+std::vector<UwbApplicationConfigurationParameter>
+windows::devices::uwb::ddi::lrp::To([[maybe_unused]] const UWB_APP_CONFIG_PARAMS &applicationConfigurationParameters)
+{
+    // TODO
+    return {};
 }

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -1210,7 +1210,7 @@ template <typename T>
 requires std::is_enum_v<T>
 void
 // clang-format on
-ConvertUwbApplicatiuonConfigurationParameterEnumeration(const UWB_APP_CONFIG_PARAM &applicationConfigurationParameter, UwbApplicationConfigurationParameter &uwbApplicationConfigurationParameter)
+ConvertUwbApplicationConfigurationParameterEnumeration(const UWB_APP_CONFIG_PARAM &applicationConfigurationParameter, UwbApplicationConfigurationParameter &uwbApplicationConfigurationParameter)
 {
     T value{};
     using U = std::underlying_type_t<decltype(value)>;
@@ -1232,7 +1232,7 @@ template <typename T>
 requires std::is_integral_v<T>
 void
 // clang-format on
-ConvertUwbApplicatiuonConfigurationParameterIntegral(const UWB_APP_CONFIG_PARAM &applicationConfigurationParameter, UwbApplicationConfigurationParameter &uwbApplicationConfigurationParameter)
+ConvertUwbApplicationConfigurationParameterIntegral(const UWB_APP_CONFIG_PARAM &applicationConfigurationParameter, UwbApplicationConfigurationParameter &uwbApplicationConfigurationParameter)
 {
     T value;
     const T *valuePointer = reinterpret_cast<const T *>(&applicationConfigurationParameter.paramValue[0]);
@@ -1250,7 +1250,7 @@ windows::devices::uwb::ddi::lrp::To(const UWB_APP_CONFIG_PARAM &applicationConfi
 
     switch (applicationConfigurationParameter.paramType) {
     case UWB_APP_CONFIG_PARAM_TYPE_HOPPING_MODE:
-        detail::ConvertUwbApplicatiuonConfigurationParameterIntegral<bool>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
+        detail::ConvertUwbApplicationConfigurationParameterIntegral<bool>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
         break;
     // uint8_t direct encodings
     case UWB_APP_CONFIG_PARAM_TYPE_NUMBER_OF_CONTROLEES:
@@ -1263,7 +1263,7 @@ windows::devices::uwb::ddi::lrp::To(const UWB_APP_CONFIG_PARAM &applicationConfi
     case UWB_APP_CONFIG_PARAM_TYPE_NUMBER_OF_STS_SEGMENTS:
     case UWB_APP_CONFIG_PARAM_TYPE_BLOCK_STRIDE_LENGTH:
     case UWB_APP_CONFIG_PARAM_TYPE_IN_BAND_TERMINATION_ATTEMPT_COUNT:
-        detail::ConvertUwbApplicatiuonConfigurationParameterIntegral<uint8_t>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
+        detail::ConvertUwbApplicationConfigurationParameterIntegral<uint8_t>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
         break;
     // uint16_t direct encodings
     case UWB_APP_CONFIG_PARAM_TYPE_SLOT_DURATION:
@@ -1272,74 +1272,74 @@ windows::devices::uwb::ddi::lrp::To(const UWB_APP_CONFIG_PARAM &applicationConfi
     case UWB_APP_CONFIG_PARAM_TYPE_VENDOR_ID:
     case UWB_APP_CONFIG_PARAM_TYPE_MAX_RR_RETRY:
     case UWB_APP_CONFIG_PARAM_TYPE_MAX_NUMBER_OF_MEASUREMENTS:
-        detail::ConvertUwbApplicatiuonConfigurationParameterIntegral<uint16_t>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
+        detail::ConvertUwbApplicationConfigurationParameterIntegral<uint16_t>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
         break;
     // uint32_t direct encodings
     case UWB_APP_CONFIG_PARAM_TYPE_RANGING_INTERVAL:
     case UWB_APP_CONFIG_PARAM_TYPE_STS_INDEX:
     case UWB_APP_CONFIG_PARAM_TYPE_UWB_INITIATION_TIME:
     case UWB_APP_CONFIG_PARAM_TYPE_SUB_SESSION_ID:
-        detail::ConvertUwbApplicatiuonConfigurationParameterIntegral<uint32_t>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
+        detail::ConvertUwbApplicationConfigurationParameterIntegral<uint32_t>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
         break;
     case UWB_APP_CONFIG_PARAM_TYPE_AOA_RESULT_REQ:
-        detail::ConvertUwbApplicatiuonConfigurationParameterEnumeration<AoAResult>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
+        detail::ConvertUwbApplicationConfigurationParameterEnumeration<AoAResult>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
         break;
     case UWB_APP_CONFIG_PARAM_TYPE_BPRF_PHR_DATA_RATE:
-        detail::ConvertUwbApplicatiuonConfigurationParameterEnumeration<BprfPhrDataRate>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
+        detail::ConvertUwbApplicationConfigurationParameterEnumeration<BprfPhrDataRate>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
         break;
     case UWB_APP_CONFIG_PARAM_TYPE_CHANNEL_NUMBER:
-        detail::ConvertUwbApplicatiuonConfigurationParameterEnumeration<Channel>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
+        detail::ConvertUwbApplicationConfigurationParameterEnumeration<Channel>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
         break;
     case UWB_APP_CONFIG_PARAM_TYPE_DEVICE_ROLE:
-        detail::ConvertUwbApplicatiuonConfigurationParameterEnumeration<DeviceRole>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
+        detail::ConvertUwbApplicationConfigurationParameterEnumeration<DeviceRole>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
         break;
     case UWB_APP_CONFIG_PARAM_TYPE_DEVICE_TYPE:
-        detail::ConvertUwbApplicatiuonConfigurationParameterEnumeration<DeviceType>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
+        detail::ConvertUwbApplicationConfigurationParameterEnumeration<DeviceType>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
         break;
     case UWB_APP_CONFIG_PARAM_TYPE_KEY_ROTATION:
-        detail::ConvertUwbApplicatiuonConfigurationParameterEnumeration<KeyRotation>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
+        detail::ConvertUwbApplicationConfigurationParameterEnumeration<KeyRotation>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
         break;
     case UWB_APP_CONFIG_PARAM_TYPE_MULTI_NODE_MODE:
-        detail::ConvertUwbApplicatiuonConfigurationParameterEnumeration<MultiNodeMode>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
+        detail::ConvertUwbApplicationConfigurationParameterEnumeration<MultiNodeMode>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
         break;
     case UWB_APP_CONFIG_PARAM_TYPE_PREAMBLE_DURATION:
-        detail::ConvertUwbApplicatiuonConfigurationParameterEnumeration<PreambleDuration>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
+        detail::ConvertUwbApplicationConfigurationParameterEnumeration<PreambleDuration>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
         break;
     case UWB_APP_CONFIG_PARAM_TYPE_PRF_MODE:
-        detail::ConvertUwbApplicatiuonConfigurationParameterEnumeration<PrfMode>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
+        detail::ConvertUwbApplicationConfigurationParameterEnumeration<PrfMode>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
         break;
     case UWB_APP_CONFIG_PARAM_TYPE_PSDU_DATA_RATE:
-        detail::ConvertUwbApplicatiuonConfigurationParameterEnumeration<PsduDataRate>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
+        detail::ConvertUwbApplicationConfigurationParameterEnumeration<PsduDataRate>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
         break;
     case UWB_APP_CONFIG_PARAM_TYPE_RANGE_DATA_NTF_CONFIG:
-        detail::ConvertUwbApplicatiuonConfigurationParameterEnumeration<RangeDataNotificationConfiguration>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
+        detail::ConvertUwbApplicationConfigurationParameterEnumeration<RangeDataNotificationConfiguration>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
         break;
     case UWB_APP_CONFIG_PARAM_TYPE_RANGING_ROUND_USAGE:
-        detail::ConvertUwbApplicatiuonConfigurationParameterEnumeration<RangingRoundUsage>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
+        detail::ConvertUwbApplicationConfigurationParameterEnumeration<RangingRoundUsage>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
         break;
     case UWB_APP_CONFIG_PARAM_TYPE_RANGING_TIME_STRUCT:
-        detail::ConvertUwbApplicatiuonConfigurationParameterEnumeration<RangingMode>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
+        detail::ConvertUwbApplicationConfigurationParameterEnumeration<RangingMode>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
         break;
     case UWB_APP_CONFIG_PARAM_TYPE_RANGING_ROUND_CONTROL:
-        detail::ConvertUwbApplicatiuonConfigurationParameterEnumeration<RangingRoundControl>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
+        detail::ConvertUwbApplicationConfigurationParameterEnumeration<RangingRoundControl>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
         break;
     case UWB_APP_CONFIG_PARAM_TYPE_RESULT_REPORT_CONFIG:
-        detail::ConvertUwbApplicatiuonConfigurationParameterEnumeration<ResultReportConfiguration>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
+        detail::ConvertUwbApplicationConfigurationParameterEnumeration<ResultReportConfiguration>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
         break;
     case UWB_APP_CONFIG_PARAM_TYPE_SCHEDULED_MODE:
-        detail::ConvertUwbApplicatiuonConfigurationParameterEnumeration<SchedulingMode>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
+        detail::ConvertUwbApplicationConfigurationParameterEnumeration<SchedulingMode>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
         break;
     case UWB_APP_CONFIG_PARAM_TYPE_STS_CONFIG:
-        detail::ConvertUwbApplicatiuonConfigurationParameterEnumeration<StsConfiguration>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
+        detail::ConvertUwbApplicationConfigurationParameterEnumeration<StsConfiguration>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
         break;
     case UWB_APP_CONFIG_PARAM_TYPE_STS_LENGTH:
-        detail::ConvertUwbApplicatiuonConfigurationParameterEnumeration<StsLength>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
+        detail::ConvertUwbApplicationConfigurationParameterEnumeration<StsLength>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
         break;
     case UWB_APP_CONFIG_PARAM_TYPE_RFRAME_CONFIG:
-        detail::ConvertUwbApplicatiuonConfigurationParameterEnumeration<StsPacketConfiguration>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
+        detail::ConvertUwbApplicationConfigurationParameterEnumeration<StsPacketConfiguration>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
         break;
     case UWB_APP_CONFIG_PARAM_TYPE_TX_ADAPTIVE_PAYLOAD_POWER:
-        detail::ConvertUwbApplicatiuonConfigurationParameterEnumeration<TxAdaptivePayloadPower>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
+        detail::ConvertUwbApplicationConfigurationParameterEnumeration<TxAdaptivePayloadPower>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
         break;
     case UWB_APP_CONFIG_PARAM_TYPE_DEVICE_MAC_ADDRESS: {
         ::uwb::UwbMacAddress value{};
@@ -1363,10 +1363,10 @@ windows::devices::uwb::ddi::lrp::To(const UWB_APP_CONFIG_PARAM &applicationConfi
         break;
     }
     case UWB_APP_CONFIG_PARAM_TYPE_MAC_FCS_TYPE:
-        detail::ConvertUwbApplicatiuonConfigurationParameterEnumeration<::uwb::UwbMacAddressFcsType>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
+        detail::ConvertUwbApplicationConfigurationParameterEnumeration<::uwb::UwbMacAddressFcsType>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
         break;
     case UWB_APP_CONFIG_PARAM_TYPE_MAC_ADDRESS_MODE:
-        detail::ConvertUwbApplicatiuonConfigurationParameterEnumeration<::uwb::UwbMacAddressType>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
+        detail::ConvertUwbApplicationConfigurationParameterEnumeration<::uwb::UwbMacAddressType>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
         break;
     case UWB_APP_CONFIG_PARAM_TYPE_STATIC_STS_IV: {
         std::array<uint8_t, StaticStsInitializationVectorLength> value{};

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -571,6 +571,14 @@ windows::devices::uwb::ddi::lrp::From(const UwbApplicationConfigurationParameter
             UWB_APP_CONFIG_PARAM &applicationConfigurationParameter = applicationConfigurationParameterWrapper->value();
             applicationConfigurationParameter.paramLength = argSize;
             std::memcpy(&applicationConfigurationParameter.paramValue[0], &arg, sizeof arg);
+        } else if constexpr (std::is_same_v<T, ::uwb::UwbMacAddress>) {
+            const auto value = arg.GetValue();
+            const auto argSize = std::size(value);
+            totalSize += argSize - 1;
+            applicationConfigurationParameterWrapper = std::make_unique<UwbApplicationConfigurationParameterWrapper>(totalSize);
+            UWB_APP_CONFIG_PARAM &applicationConfigurationParameter = applicationConfigurationParameterWrapper->value();
+            applicationConfigurationParameter.paramLength = argSize;
+            std::memcpy(&applicationConfigurationParameter.paramValue[0], std::data(value), std::size(value));
         } else {
             throw std::runtime_error("unknown UwbApplicationConfigurationParameter variant value encountered");
         }
@@ -1348,12 +1356,14 @@ windows::devices::uwb::ddi::lrp::To(const UWB_APP_CONFIG_PARAM &applicationConfi
             ::uwb::UwbMacAddress::ShortType data{};
             std::memcpy(std::data(data), &applicationConfigurationParameter.paramValue[0], std::size(data));
             value = ::uwb::UwbMacAddress(std::move(data));
+            uwbApplicationConfigurationParameter.Value = std::move(value);
             break;
         }
         case ::uwb::UwbMacAddressLength::Extended: {
             ::uwb::UwbMacAddress::ExtendedType data{};
             std::memcpy(std::data(data), &applicationConfigurationParameter.paramValue[0], std::size(data));
             value = ::uwb::UwbMacAddress(std::move(data));
+            uwbApplicationConfigurationParameter.Value = std::move(value);
             break;
         }
         default:

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -1199,11 +1199,11 @@ namespace detail
 {
 /**
  * @brief Converts a UWB_APP_CONFIG_PARAM value containing data mapping to a enum-class neutral type.
- * 
+ *
  * @tparam T The enum class type to convert to.
  * @param applicationConfigurationParameter The parameter to convert from.
  * @param uwbApplicationConfigurationParameter The wrapper to convert to.
- * @return requires 
+ * @return requires
  */
 template <typename T>
 // clang-format off
@@ -1221,11 +1221,11 @@ ConvertUwbApplicatiuonConfigurationParameterEnumeration(const UWB_APP_CONFIG_PAR
 
 /**
  * @brief Converts a UWB_APP_CONFIG_PARAM value containing data mapping to an integral type.
- * 
+ *
  * @tparam T The integral type to convert to.
- * @param applicationConfigurationParameter 
- * @param uwbApplicationConfigurationParameter 
- * @return requires 
+ * @param applicationConfigurationParameter
+ * @param uwbApplicationConfigurationParameter
+ * @return requires
  */
 template <typename T>
 // clang-format off

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -564,7 +564,7 @@ windows::devices::uwb::ddi::lrp::From(const UwbApplicationConfigurationParameter
             UWB_APP_CONFIG_PARAM &applicationConfigurationParameter = applicationConfigurationParameterWrapper->value();
             applicationConfigurationParameter.paramLength = argSize;
             std::memcpy(&applicationConfigurationParameter.paramValue[0], &uvalue, sizeof uvalue);
-        } else if constexpr (std::is_integral_v<T>) {
+        } else if constexpr (std::is_integral_v<T> || std::is_same_v<T, std::array<uint8_t, StaticStsInitializationVectorLength>>) {
             constexpr auto argSize = sizeof(T);
             totalSize += argSize - 1;
             applicationConfigurationParameterWrapper = std::make_unique<UwbApplicationConfigurationParameterWrapper>(totalSize);
@@ -1355,7 +1355,7 @@ windows::devices::uwb::ddi::lrp::To(const UWB_APP_CONFIG_PARAM &applicationConfi
         break;
     case UWB_APP_CONFIG_PARAM_TYPE_STATIC_STS_IV: {
         std::array<uint8_t, StaticStsInitializationVectorLength> value{};
-        // TODO: convert
+        std::memcpy(std::data(value), &applicationConfigurationParameter.paramValue[0], sizeof value);
         uwbApplicationConfigurationParameter.Value = std::move(value);
         break;
     }

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -1253,7 +1253,7 @@ windows::devices::uwb::ddi::lrp::To(const UWB_APP_CONFIG_PARAM &applicationConfi
         detail::ConvertUwbApplicatiuonConfigurationParameterIntegral<bool>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
         break;
     // uint8_t direct encodings
-    case UWB_APP_CONFIG_PARAM_TYPE_NUMBER_OF_CONTROLEES: // uint8_t
+    case UWB_APP_CONFIG_PARAM_TYPE_NUMBER_OF_CONTROLEES:
     case UWB_APP_CONFIG_PARAM_TYPE_PREAMBLE_CODE_INDEX:
     case UWB_APP_CONFIG_PARAM_TYPE_SFD_ID:
     case UWB_APP_CONFIG_PARAM_TYPE_SLOTS_PER_RR:

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -265,7 +265,7 @@ From(const ::uwb::protocol::fira::UwbApplicationConfigurationParameter &uwbAppli
 using UwbApplicationConfigurationParametersWrapper = notstd::flextype_wrapper<UWB_APP_CONFIG_PARAMS>;
 
 /**
- * @brief
+ * @brief Converts a vector of UwbApplicationConfigurationParameter to UWB_APP_CONFIG_PARAMS.
  *
  * @param uwbApplicationConfigurationParameters
  * @return UwbApplicationConfigurationParametersWrapper

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -2,6 +2,8 @@
 #ifndef UWB_CX_ADAPTER_DDI_LRP_HXX
 #define UWB_CX_ADAPTER_DDI_LRP_HXX
 
+#include <vector>
+
 #include <notstd/flextype_wrapper.hxx>
 
 #include <uwb/protocols/fira/FiraDevice.hxx>
@@ -249,6 +251,28 @@ using UwbNotificationDataWrapper = notstd::flextype_wrapper<UWB_NOTIFICATION_DAT
 UwbNotificationDataWrapper
 From(const ::uwb::protocol::fira::UwbNotificationData &uwbNotificationData);
 
+using UwbApplicationConfigurationParameterWrapper = notstd::flextype_wrapper<UWB_APP_CONFIG_PARAM>;
+
+/**
+ * @brief Converts UwbApplicationConfigurationParameter to UWB_APP_CONFIG_PARAM.
+ * 
+ * @param uwbApplicationConfigurationParameterValue 
+ * @return UwbApplicationConfigurationParameterWrapper 
+ */
+UwbApplicationConfigurationParameterWrapper
+From(const ::uwb::protocol::fira::UwbApplicationConfigurationParameter &uwbApplicationConfigurationParameterValue);
+
+using UwbApplicationConfigurationParametersWrapper = notstd::flextype_wrapper<UWB_APP_CONFIG_PARAMS>;
+
+/**
+ * @brief 
+ * 
+ * @param uwbApplicationConfigurationParameters 
+ * @return UwbApplicationConfigurationParametersWrapper 
+ */
+UwbApplicationConfigurationParametersWrapper
+From(const std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameterValue> &uwbApplicationConfigurationParameters);
+
 /**
  * @brief Converts UWB_DEVICE_CAPABILITIES to UwbCapability.
  *
@@ -463,6 +487,24 @@ To(const UWB_RANGING_DATA &rangingData);
  */
 ::uwb::protocol::fira::UwbNotificationData
 To(const UWB_NOTIFICATION_DATA &notificationData);
+
+/**
+ * @brief Converts UWB_APP_CONFIG_PARAM to UwbApplicationConfigurationParameter.
+ * 
+ * @param applicationConfigurationParameter 
+ * @return ::uwb::protocol::fira::UwbApplicationConfigurationParameter 
+ */
+::uwb::protocol::fira::UwbApplicationConfigurationParameter
+To(const UWB_APP_CONFIG_PARAM &applicationConfigurationParameter);
+
+/**
+ * @brief Converts UWB_APP_CONFIG_PARAMS to a vector of UwbApplicationConfigurationParameter.
+ * 
+ * @param applicationConfigurationParameters 
+ * @return std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> 
+ */
+std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter>
+To(const UWB_APP_CONFIG_PARAMS &applicationConfigurationParameters);
 
 } // namespace windows::devices::uwb::ddi::lrp
 

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -255,9 +255,9 @@ using UwbApplicationConfigurationParameterWrapper = notstd::flextype_wrapper<UWB
 
 /**
  * @brief Converts UwbApplicationConfigurationParameter to UWB_APP_CONFIG_PARAM.
- * 
- * @param uwbApplicationConfigurationParameterValue 
- * @return UwbApplicationConfigurationParameterWrapper 
+ *
+ * @param uwbApplicationConfigurationParameterValue
+ * @return UwbApplicationConfigurationParameterWrapper
  */
 UwbApplicationConfigurationParameterWrapper
 From(const ::uwb::protocol::fira::UwbApplicationConfigurationParameter &uwbApplicationConfigurationParameterValue);
@@ -265,10 +265,10 @@ From(const ::uwb::protocol::fira::UwbApplicationConfigurationParameter &uwbAppli
 using UwbApplicationConfigurationParametersWrapper = notstd::flextype_wrapper<UWB_APP_CONFIG_PARAMS>;
 
 /**
- * @brief 
- * 
- * @param uwbApplicationConfigurationParameters 
- * @return UwbApplicationConfigurationParametersWrapper 
+ * @brief
+ *
+ * @param uwbApplicationConfigurationParameters
+ * @return UwbApplicationConfigurationParametersWrapper
  */
 UwbApplicationConfigurationParametersWrapper
 From(const std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameterValue> &uwbApplicationConfigurationParameters);
@@ -490,18 +490,18 @@ To(const UWB_NOTIFICATION_DATA &notificationData);
 
 /**
  * @brief Converts UWB_APP_CONFIG_PARAM to UwbApplicationConfigurationParameter.
- * 
- * @param applicationConfigurationParameter 
- * @return ::uwb::protocol::fira::UwbApplicationConfigurationParameter 
+ *
+ * @param applicationConfigurationParameter
+ * @return ::uwb::protocol::fira::UwbApplicationConfigurationParameter
  */
 ::uwb::protocol::fira::UwbApplicationConfigurationParameter
 To(const UWB_APP_CONFIG_PARAM &applicationConfigurationParameter);
 
 /**
  * @brief Converts UWB_APP_CONFIG_PARAMS to a vector of UwbApplicationConfigurationParameter.
- * 
- * @param applicationConfigurationParameters 
- * @return std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> 
+ *
+ * @param applicationConfigurationParameters
+ * @return std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter>
  */
 std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter>
 To(const UWB_APP_CONFIG_PARAMS &applicationConfigurationParameters);


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Allow `UWB_APP_CONFIG_PARAM` to be converted to and from its corresponding neutral type `UwbApplicationConfigurationParameter`.

### Technical Details

* Add `To` and `From` neutral <-> DDI adapter conversion functions and unit tests.
* Add default-implemented `operator==()` for `UwbApplicationConfigurationParameter`.

### Test Results

* All unit tests pass on Linux and Windows.

### Reviewer Focus

* Consider whether the interpretation of the `UWB_APP_CONFIG_PARAM_TYPE_DEVICE_MAC_ADDRESS` parameter type is correct. It was assumed that the raw address information is provided in the `paramValue` array (eg. `uint8_t data[2]` and `uint8_t data[8]` for short and extended types respectively).

### Future Work

* The conversion function for `UWB_APP_CONFIG_PARAM_TYPE_DST_MAC_ADDRESS` is not implemented yet since we haven't yet figured out a way to decode the parameter value because the address type is not specified in the pure UCI encoding. If UwbCx encoded it exactly in this way, we'll have no way of knowing the address type. Probably it makes sense to prepend the array of addresses with the corresponding `UWB_APP_CONFIG_PARAM_TYPE_MAC_ADDRESS_MODE` value.
* The `UWB_APP_CONFIG_PARAMS` (collection) DDI type needs conversion functions added as well. These will likely be adapter from the existing code @forwardpointer already wrote for the DDI specific wrappers.
* Remove the DDI specific wrappers for `UWB_APP_CONFIG_PARAM` and `UWB_APP_CONFIG_PARAMS`.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
