### PR TITLE
Invoke IOCTL_UWB_START_RANGING_SESSION

### DIFF
--- a/lib/uwb/UwbSession.cxx
+++ b/lib/uwb/UwbSession.cxx
@@ -46,8 +46,8 @@ void
 UwbSession::StartRanging()
 {
     PLOG_VERBOSE << "start ranging";
-    bool rangingActiveExpected = false;
-    const bool wasRangingActive = m_rangingActive.compare_exchange_weak(rangingActiveExpected, true);
+    bool rangingActiveUnexpected = true;
+    const bool wasRangingActive = m_rangingActive.compare_exchange_weak(rangingActiveUnexpected, true);
     if (wasRangingActive) {
         return;
     }
@@ -59,8 +59,8 @@ void
 UwbSession::StopRanging()
 {
     PLOG_VERBOSE << "stop ranging";
-    bool rangingActiveExpected = true;
-    const bool wasRangingActive = m_rangingActive.compare_exchange_weak(rangingActiveExpected, false);
+    bool rangingActiveUnexpected = false;
+    const bool wasRangingActive = m_rangingActive.compare_exchange_weak(rangingActiveUnexpected, false);
     if (!wasRangingActive) {
         return;
     }

--- a/lib/uwb/UwbSession.cxx
+++ b/lib/uwb/UwbSession.cxx
@@ -47,8 +47,8 @@ UwbSession::StartRanging()
 {
     PLOG_VERBOSE << "start ranging";
     bool rangingActiveExpected = false;
-    const bool wasNotRangingActive = m_rangingActive.compare_exchange_weak(rangingActiveExpected, true);
-    if (wasNotRangingActive) {
+    const bool wasRangingInactive = m_rangingActive.compare_exchange_weak(rangingActiveExpected, true);
+    if (wasRangingInactive) {
         StartRangingImpl();
     }
 }

--- a/lib/uwb/UwbSession.cxx
+++ b/lib/uwb/UwbSession.cxx
@@ -46,23 +46,21 @@ void
 UwbSession::StartRanging()
 {
     PLOG_VERBOSE << "start ranging";
-    bool rangingActiveUnexpected = true;
-    const bool wasRangingActive = m_rangingActive.compare_exchange_weak(rangingActiveUnexpected, true);
-    if (wasRangingActive) {
-        return;
+    bool rangingActiveExpected = false;
+    const bool wasNotRangingActive = m_rangingActive.compare_exchange_weak(rangingActiveExpected, true);
+    if (wasNotRangingActive) {
+        StartRangingImpl();
     }
-
-    StartRangingImpl();
 }
 
 void
 UwbSession::StopRanging()
 {
     PLOG_VERBOSE << "stop ranging";
-    bool rangingActiveUnexpected = false;
-    const bool wasRangingActive = m_rangingActive.compare_exchange_weak(rangingActiveUnexpected, false);
-    if (!wasRangingActive) {
-        return;
+    bool rangingActiveExpected = true;
+    const bool wasRangingActive = m_rangingActive.compare_exchange_weak(rangingActiveExpected, false);
+    if (wasRangingActive) {
+        //StopRangingImpl();
     }
 }
 


### PR DESCRIPTION
### Type

- [x] Bug fix
- [ ] Feature addition
- [x] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

This PR adds code to invoke IOCTL_UWB_START_RANGING_SESSION.

### Technical Details

- Invoke IOCTL_UWB_START_RANGING_SESSION in UwbDeviceConnector.
- Fix m_rangingActive logic in UwbSession.

### Test Results

Code builds; IOCTL is invoked in nocli with "nocli.exe uwb range start" command.

### Reviewer Focus

None.

### Future Work

Needs additional testing once this IOCTL is handled in the TestClient driver.

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
