### PR TITLE
Allow constexpr UwbMacAddress construction

### DIFF
--- a/lib/uwb/UwbMacAddress.cxx
+++ b/lib/uwb/UwbMacAddress.cxx
@@ -10,53 +10,6 @@
 
 using namespace uwb;
 
-UwbMacAddress::UwbMacAddress() :
-    UwbMacAddress(ShortType{ 0x00, 0x00 })
-{}
-
-UwbMacAddress::UwbMacAddress(const UwbMacAddress& other) :
-    m_length(other.m_length),
-    m_type(other.m_type),
-    m_value(other.m_value)
-{
-    // Note that the view span (m_view) cannot be directly copied from the other
-    // instance because that view refers to its own address storage. Hence, the
-    // view is explicitly initialized here.
-    InitializeView();
-}
-
-UwbMacAddress&
-UwbMacAddress::operator=(UwbMacAddress other)
-{
-    // Note that this implementation of operator= uses a copy of another
-    // instance, whereas the typical implementation takes a const reference.
-    // This value-based version is used to ensure copy-elision occurs, avoiding
-    // the need to create a temporary when using the standard copy-and-swap
-    // idiom.
-    Swap(other);
-    return *this;
-}
-
-void
-UwbMacAddress::InitializeView()
-{
-    // clang-format off
-    std::visit([&](auto&& value) {
-        m_view = { std::begin(value), std::end(value) };
-    }, m_value);
-    // clang-format on
-}
-
-void
-UwbMacAddress::Swap(UwbMacAddress& other) noexcept
-{
-    std::swap(this->m_type, other.m_type);
-    std::swap(this->m_length, other.m_length);
-    std::swap(this->m_value, other.m_value);
-    InitializeView();
-    other.InitializeView();
-}
-
 UwbMacAddressType
 UwbMacAddress::GetType() const noexcept
 {

--- a/lib/uwb/include/uwb/UwbMacAddress.hxx
+++ b/lib/uwb/include/uwb/UwbMacAddress.hxx
@@ -406,7 +406,9 @@ private:
     {
         std::swap(this->m_type, other.m_type);
         std::swap(this->m_length, other.m_length);
-        std::swap(this->m_value, other.m_value);
+        auto tmpValue = std::move(other.m_value);
+        other.m_value = std::move(this->m_value);
+        this->m_value = std::move(tmpValue);
         InitializeView();
         other.InitializeView();
     }

--- a/lib/uwb/include/uwb/UwbMacAddress.hxx
+++ b/lib/uwb/include/uwb/UwbMacAddress.hxx
@@ -275,8 +275,7 @@ private:
      * @return std::span<const uint8_t>
      */
     template <size_t Length>
-    std::span<const uint8_t>
-    constexpr UwbMacAddressView(UwbMacAddress& uwbMacAddress)
+    std::span<const uint8_t> constexpr UwbMacAddressView(UwbMacAddress& uwbMacAddress)
     {
         auto& value = UwbMacAddressValue<Length>(uwbMacAddress);
         return { std::begin(value), std::end(value) };
@@ -342,7 +341,7 @@ public:
     /**
      * @brief Construct a new, randomly generated UwbMacAddress object based on
      * runtime provided arguments.
-     * 
+     *
      * @param type The type of random address to generate.
      * @return UwbMacAddress The randomly generated address value.
      */


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Allow `UwbMacAddress` instances to be created as `constexpr`.

### Technical Details

* Convert constructors and helper functions in their dependency chain to use `constexpr`. Unfortunately this requires moving the code from the source file to the header to allow the compiler to see the `constexpr` definitions during code generation.

### Test Results

All unit tests pass on both Linux and Windows.

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
