### PR TITLE
Use UwbApplicationConfigurationParameter in place of IUwbAppConfigurationParameter

### DIFF
--- a/tests/unit/windows/CMakeLists.txt
+++ b/tests/unit/windows/CMakeLists.txt
@@ -6,7 +6,6 @@ target_sources(nearobject-test-windows
         ${CMAKE_CURRENT_LIST_DIR}/Main.cxx
         ${CMAKE_CURRENT_LIST_DIR}/TestNearObjectDeviceDiscoveryAgentUwb.cxx 
         ${CMAKE_CURRENT_LIST_DIR}/TestNotStd.cxx
-        ${CMAKE_CURRENT_LIST_DIR}/TestUwbAppConfiguration.cxx
         ${CMAKE_CURRENT_LIST_DIR}/TestUwbCxAdapterDdiLrpConversion.cxx 
 )
 

--- a/windows/devices/uwb/CMakeLists.txt
+++ b/windows/devices/uwb/CMakeLists.txt
@@ -5,13 +5,11 @@ set(UWBCXADAPTER_DIR_PUBLIC_INCLUDE_PREFIX ${UWBCXADAPTER_DIR_PUBLIC_INCLUDE}/wi
 
 target_sources(windev-uwb-cx-adapter
     PRIVATE
-        ${CMAKE_CURRENT_LIST_DIR}/UwbAppConfiguration.cxx
         ${CMAKE_CURRENT_LIST_DIR}/UwbCxAdapter.cxx
         ${CMAKE_CURRENT_LIST_DIR}/UwbCxAdapterDdiLrp.cxx
         ${CMAKE_CURRENT_LIST_DIR}/UwbDeviceConnector.cxx
     PUBLIC
         ${UWBCXADAPTER_DIR_PUBLIC_INCLUDE_PREFIX}/IUwbDeviceDdi.hxx
-        ${UWBCXADAPTER_DIR_PUBLIC_INCLUDE_PREFIX}/UwbAppConfiguration.hxx
         ${UWBCXADAPTER_DIR_PUBLIC_INCLUDE_PREFIX}/UwbCxAdapter.hxx
         ${UWBCXADAPTER_DIR_PUBLIC_INCLUDE_PREFIX}/UwbCxAdapterDdiLrp.hxx
         ${UWBCXADAPTER_DIR_PUBLIC_INCLUDE_PREFIX}/UwbDeviceConnector.hxx
@@ -36,7 +34,6 @@ target_link_libraries(windev-uwb-cx-adapter
 
 list(APPEND UWBCXADAPTER_PUBLIC_HEADERS
     ${UWBCXADAPTER_DIR_PUBLIC_INCLUDE_PREFIX}/IUwbDeviceDdi.hxx
-    ${UWBCXADAPTER_DIR_PUBLIC_INCLUDE_PREFIX}/UwbAppConfiguration.hxx
     ${UWBCXADAPTER_DIR_PUBLIC_INCLUDE_PREFIX}/UwbCxAdapter.hxx
     ${UWBCXADAPTER_DIR_PUBLIC_INCLUDE_PREFIX}/UwbCxAdapterDdiLrp.hxx
     ${UWBCXADAPTER_DIR_PUBLIC_INCLUDE_PREFIX}/UwbDeviceConnector.hxx

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -322,10 +322,10 @@ UwbDeviceConnector::SessionUpdateControllerMulticastList(uint32_t sessionId, Uwb
     return resultFuture;
 }
 
-std::future<std::tuple<UwbStatus, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>>>>
+std::future<std::tuple<UwbStatus, std::vector<UwbApplicationConfigurationParameter>>>
 UwbDeviceConnector::GetApplicationConfigurationParameters(uint32_t sessionId, std::vector<UwbApplicationConfigurationParameterType> applicationConfigurationParameterTypes)
 {
-    std::promise<std::tuple<UwbStatus, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>>>> promiseResult;
+    std::promise<std::tuple<UwbStatus,  std::vector<UwbApplicationConfigurationParameter>>> promiseResult;
     auto resultFuture = promiseResult.get_future();
     // TODO: invoke IOCTL_UWB_GET_APP_CONFIG_PARAMS
 
@@ -333,7 +333,7 @@ UwbDeviceConnector::GetApplicationConfigurationParameters(uint32_t sessionId, st
 }
 
 std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>>>
-UwbDeviceConnector::SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> applicationConfigurationParameters)
+UwbDeviceConnector::SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> applicationConfigurationParameters)
 {
     std::promise<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>>> resultPromise;
     auto resultFuture = resultPromise.get_future();

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -339,56 +339,44 @@ UwbDeviceConnector::SetApplicationConfigurationParameters(uint32_t sessionId, st
     auto resultFuture = resultPromise.get_future();
     // TODO: invoke IOCTL_UWB_SET_APP_CONFIG_PARAMS
 
-    return resultFuture;
-}
+    // 
+    // Old code that used the original one-off UwbSetAppConfigurationParameters wrapper. 
+    // TODO: Once this is implemented, delete the commented out code.
+    //
 
-std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>>>
-UwbDeviceConnector::SetApplicationConfigurationParameters(uint32_t sessionId, UwbSetAppConfigurationParameters applicationConfigurationParameters)
-{
-    std::promise<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>>> resultPromise;
-    auto resultFuture = resultPromise.get_future();
-    
-    wil::shared_hfile handleDriver;
-    auto hr = OpenDriverHandle(handleDriver, m_deviceName.c_str());
-    if (FAILED(hr)) {
-        PLOG_ERROR << "failed to obtain driver handle for " << m_deviceName << ", hr=" << std::showbase << std::hex << hr;
-        resultPromise.set_exception(std::make_exception_ptr(UwbException(UwbStatusGeneric::Rejected)));
-        return resultFuture;
-    }
+    // auto& setParamsBuffer = applicationConfigurationParameters.DdiBuffer();
+    // auto& setParams = applicationConfigurationParameters.DdiParameters();
 
-    auto& setParamsBuffer = applicationConfigurationParameters.DdiBuffer();
-    auto& setParams = applicationConfigurationParameters.DdiParameters();
+    // // Allocate memory for the UWB_SET_APP_CONFIG_PARAMS_STATUS structure, and pass this to the driver request
+    // auto statusSize = offsetof(UWB_SET_APP_CONFIG_PARAMS_STATUS, appConfigParamsStatus[setParams.appConfigParamsCount]);
+    // std::vector<uint8_t> statusBuffer(statusSize);
+    // BOOL ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_SET_APP_CONFIG_PARAMS, std::data(setParamsBuffer), std::size(setParamsBuffer), std::data(statusBuffer), statusSize, nullptr, nullptr);
+    // if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
+    //     HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
+    //     PLOG_ERROR << "error when sending IOCTL_UWB_SET_APP_CONFIG_PARAMS with sessionId " << sessionId << ", hr = " << std::showbase << std::hex << hr;
+    //     resultPromise.set_exception(std::make_exception_ptr(UwbException(UwbStatusGeneric::Rejected)));
+    //     return resultFuture;
+    // } else {
+    //     PLOG_DEBUG << "IOCTL_UWB_SET_APP_CONFIG_PARAMS succeeded";
+    //     auto& uwbSetAppConfigParamsStatus = *reinterpret_cast<UWB_SET_APP_CONFIG_PARAMS_STATUS*>(std::data(statusBuffer));
+    //     auto uwbStatus = UwbCxDdi::To(uwbSetAppConfigParamsStatus.status);
+    //     if (!IsUwbStatusOk(uwbStatus)) {
+    //         resultPromise.set_exception(std::make_exception_ptr(UwbException(std::move(uwbStatus))));
+    //     } else {
+    //         // TODO: Could move this logic into its own UwbCxDdi::To() function
+    //         std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>> appConfigParamsStatusList;
+    //         for (auto i = 0; i < uwbSetAppConfigParamsStatus.appConfigParamsCount; i++)
+    //         {
+    //             auto paramType = UwbCxDdi::To(uwbSetAppConfigParamsStatus.appConfigParamsStatus[i].paramType);
+    //             auto paramStatus = UwbCxDdi::To(uwbSetAppConfigParamsStatus.appConfigParamsStatus[i].status);
 
-    // Allocate memory for the UWB_SET_APP_CONFIG_PARAMS_STATUS structure, and pass this to the driver request
-    auto statusSize = offsetof(UWB_SET_APP_CONFIG_PARAMS_STATUS, appConfigParamsStatus[setParams.appConfigParamsCount]);
-    std::vector<uint8_t> statusBuffer(statusSize);
-    BOOL ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_SET_APP_CONFIG_PARAMS, std::data(setParamsBuffer), std::size(setParamsBuffer), std::data(statusBuffer), statusSize, nullptr, nullptr);
-    if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
-        HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
-        PLOG_ERROR << "error when sending IOCTL_UWB_SET_APP_CONFIG_PARAMS with sessionId " << sessionId << ", hr = " << std::showbase << std::hex << hr;
-        resultPromise.set_exception(std::make_exception_ptr(UwbException(UwbStatusGeneric::Rejected)));
-        return resultFuture;
-    } else {
-        PLOG_DEBUG << "IOCTL_UWB_SET_APP_CONFIG_PARAMS succeeded";
-        auto& uwbSetAppConfigParamsStatus = *reinterpret_cast<UWB_SET_APP_CONFIG_PARAMS_STATUS*>(std::data(statusBuffer));
-        auto uwbStatus = UwbCxDdi::To(uwbSetAppConfigParamsStatus.status);
-        if (!IsUwbStatusOk(uwbStatus)) {
-            resultPromise.set_exception(std::make_exception_ptr(UwbException(std::move(uwbStatus))));
-        } else {
-            // TODO: Could move this logic into its own UwbCxDdi::To() function
-            std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>> appConfigParamsStatusList;
-            for (auto i = 0; i < uwbSetAppConfigParamsStatus.appConfigParamsCount; i++)
-            {
-                auto paramType = UwbCxDdi::To(uwbSetAppConfigParamsStatus.appConfigParamsStatus[i].paramType);
-                auto paramStatus = UwbCxDdi::To(uwbSetAppConfigParamsStatus.appConfigParamsStatus[i].status);
-
-                auto appConfigParamStatus = std::make_tuple(paramType, paramStatus);
-                appConfigParamsStatusList.push_back(appConfigParamStatus);
-            }
-            auto result = std::make_tuple(uwbStatus, std::move(appConfigParamsStatusList));
-            resultPromise.set_value(std::move(result));
-        }
-    }
+    //             auto appConfigParamStatus = std::make_tuple(paramType, paramStatus);
+    //             appConfigParamsStatusList.push_back(appConfigParamStatus);
+    //         }
+    //         auto result = std::make_tuple(uwbStatus, std::move(appConfigParamsStatusList));
+    //         resultPromise.set_value(std::move(result));
+    //     }
+    // }
 
     return resultFuture;
 }

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -325,7 +325,7 @@ UwbDeviceConnector::SessionUpdateControllerMulticastList(uint32_t sessionId, Uwb
 std::future<std::tuple<UwbStatus, std::vector<UwbApplicationConfigurationParameter>>>
 UwbDeviceConnector::GetApplicationConfigurationParameters(uint32_t sessionId, std::vector<UwbApplicationConfigurationParameterType> applicationConfigurationParameterTypes)
 {
-    std::promise<std::tuple<UwbStatus,  std::vector<UwbApplicationConfigurationParameter>>> promiseResult;
+    std::promise<std::tuple<UwbStatus, std::vector<UwbApplicationConfigurationParameter>>> promiseResult;
     auto resultFuture = promiseResult.get_future();
     // TODO: invoke IOCTL_UWB_GET_APP_CONFIG_PARAMS
 
@@ -339,8 +339,8 @@ UwbDeviceConnector::SetApplicationConfigurationParameters(uint32_t sessionId, st
     auto resultFuture = resultPromise.get_future();
     // TODO: invoke IOCTL_UWB_SET_APP_CONFIG_PARAMS
 
-    // 
-    // Old code that used the original one-off UwbSetAppConfigurationParameters wrapper. 
+    //
+    // Old code that used the original one-off UwbSetAppConfigurationParameters wrapper.
     // TODO: Once this is implemented, delete the commented out code.
     //
 

--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -87,8 +87,8 @@ UwbSession::ConfigureImpl(const ::uwb::protocol::fira::UwbSessionData& uwbSessio
     m_sessionId = sessionId;
 
     // Set the application configuration parameters for the session.
-    auto setParamsAdaptor = GenerateUwbSetAppConfigParameterDdi(uwbSessionData);
-    auto setAppConfigParamsFuture = m_uwbDeviceConnector->SetApplicationConfigurationParameters(sessionId, setParamsAdaptor);
+    std::vector<UwbApplicationConfigurationParameter> applicationConfigurationParameters{};
+    auto setAppConfigParamsFuture = m_uwbDeviceConnector->SetApplicationConfigurationParameters(sessionId, applicationConfigurationParameters);
     if (!setAppConfigParamsFuture.valid()) {
         // TODO: need to signal to upper layer that this failed instead of just returning
         PLOG_ERROR << "failed to set the application configuration parameters";

--- a/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
@@ -62,12 +62,12 @@ struct IUwbDeviceDdi
     SessionUpdateControllerMulticastList(uint32_t sessionId, ::uwb::protocol::fira::UwbMulticastAction multicastAction, std::vector<::uwb::UwbMacAddress> controlees) = 0;
 
     // IOCTL_UWB_GET_APP_CONFIG_PARAMS
-    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>>>>
+    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter>>>
     GetApplicationConfigurationParameters(uint32_t sessionId, std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameterType> applicationConfigurationParameterTypes) = 0;
 
     // IOCTL_UWB_SET_APP_CONFIG_PARAMS
     virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>>>
-    SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> applicationConfigurationParameters) = 0;
+    SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> applicationConfigurationParameters) = 0;
 
     // IOCTL_UWB_SET_APP_CONFIG_PARAMS
     virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>>>

--- a/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
@@ -11,7 +11,6 @@
 
 #include <uwb/protocols/fira/FiraDevice.hxx>
 #include <uwb/protocols/fira/UwbCapability.hxx>
-#include <windows/devices/uwb/UwbAppConfiguration.hxx>
 
 namespace windows::devices::uwb
 {

--- a/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
@@ -69,10 +69,6 @@ struct IUwbDeviceDdi
     virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>>>
     SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> applicationConfigurationParameters) = 0;
 
-    // IOCTL_UWB_SET_APP_CONFIG_PARAMS
-    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>>>
-    SetApplicationConfigurationParameters(uint32_t sessionId, UwbSetAppConfigurationParameters applicationConfigurationParameters) = 0;
-
     // TODO: unspecified IOCTLs below
     // IOCTL_UWB_SET_DEVICE_CONFIG_PARAMS
     // IOCTL_UWB_GET_DEVICE_CONFIG_PARAMS

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
@@ -138,9 +138,6 @@ public:
     virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>>>
     SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> applicationConfigurationParameters) override;
 
-    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>>>
-    SetApplicationConfigurationParameters(uint32_t sessionId, UwbSetAppConfigurationParameters applicationConfigurationParameters) override;
-
 private:
     /**
      * @brief Thread function for handling UWB notifications from the driver.

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
@@ -132,11 +132,11 @@ public:
     virtual std::future<::uwb::protocol::fira::UwbSessionUpdateMulicastListStatus>
     SessionUpdateControllerMulticastList(uint32_t sessionId, ::uwb::protocol::fira::UwbMulticastAction multicastAction, std::vector<::uwb::UwbMacAddress> controlees) override;
 
-    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>>>>
+    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter>>>
     GetApplicationConfigurationParameters(uint32_t sessionId, std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameterType> applicationConfigurationParameterTypes) override;
 
     virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>>>
-    SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> applicationConfigurationParameters) override;
+    SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> applicationConfigurationParameters) override;
 
     virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>>>
     SetApplicationConfigurationParameters(uint32_t sessionId, UwbSetAppConfigurationParameters applicationConfigurationParameters) override;

--- a/windows/drivers/uwb/simulator/IUwbSimulatorDdiCallbacksLrp.hxx
+++ b/windows/drivers/uwb/simulator/IUwbSimulatorDdiCallbacksLrp.hxx
@@ -77,11 +77,11 @@ struct IUwbSimulatorDdiCallbacksLrp
 
     /**
      * @brief Get the Application Configuration Parameters object
-     * 
-     * @param sessionId 
-     * @param applicationConfigurationParameterTypes 
-     * @param applicationConfigurationParameters 
-     * @return UwbStatus 
+     *
+     * @param sessionId
+     * @param applicationConfigurationParameterTypes
+     * @param applicationConfigurationParameters
+     * @return UwbStatus
      */
     virtual UwbStatus
     GetApplicationConfigurationParameters(uint32_t sessionId, const std::vector<UwbApplicationConfigurationParameterType> &applicationConfigurationParameterTypes, std::vector<UwbApplicationConfigurationParameter> &applicationConfigurationParameters) = 0;

--- a/windows/drivers/uwb/simulator/IUwbSimulatorDdiCallbacksLrp.hxx
+++ b/windows/drivers/uwb/simulator/IUwbSimulatorDdiCallbacksLrp.hxx
@@ -12,7 +12,6 @@
 #include <windows.h>
 
 #include <wdf.h>
-#include <windows/devices/uwb/UwbAppConfiguration.hxx>
 
 #include <uwb/protocols/fira/FiraDevice.hxx>
 #include <uwb/protocols/fira/UwbCapability.hxx>

--- a/windows/drivers/uwb/simulator/IUwbSimulatorDdiCallbacksLrp.hxx
+++ b/windows/drivers/uwb/simulator/IUwbSimulatorDdiCallbacksLrp.hxx
@@ -78,14 +78,14 @@ struct IUwbSimulatorDdiCallbacksLrp
 
     /**
      * @brief Get the Application Configuration Parameters object
-     *
-     * @param sessionId
-     * @param applicationConfigurationParameterTypes
-     * @param applicationConfigurationParameters
-     * @return UwbStatus
+     * 
+     * @param sessionId 
+     * @param applicationConfigurationParameterTypes 
+     * @param applicationConfigurationParameters 
+     * @return UwbStatus 
      */
     virtual UwbStatus
-    GetApplicationConfigurationParameters(uint32_t sessionId, const std::vector<UwbApplicationConfigurationParameterType> &applicationConfigurationParameterTypes, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> &applicationConfigurationParameters) = 0;
+    GetApplicationConfigurationParameters(uint32_t sessionId, const std::vector<UwbApplicationConfigurationParameterType> &applicationConfigurationParameterTypes, std::vector<UwbApplicationConfigurationParameter> &applicationConfigurationParameters) = 0;
 
     /**
      * @brief Set the Application Configuration Parameters object
@@ -95,7 +95,7 @@ struct IUwbSimulatorDdiCallbacksLrp
      * @return UwbStatus
      */
     virtual UwbStatus
-    SetApplicationConfigurationParameters(uint32_t sessionId, const std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> &applicationConfigurationParameters, std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>> &applicationConfigurationParameterResults) = 0;
+    SetApplicationConfigurationParameters(uint32_t sessionId, const std::vector<UwbApplicationConfigurationParameter> &applicationConfigurationParameters, std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>> &applicationConfigurationParameterResults) = 0;
 
     /**
      * @brief Get the Session Count object

--- a/windows/drivers/uwb/simulator/IUwbSimulatorSession.hxx
+++ b/windows/drivers/uwb/simulator/IUwbSimulatorSession.hxx
@@ -23,7 +23,7 @@ struct IUwbSimulatorSession
     uint32_t Sequence{ 0 };
     uint32_t RangingCount{ 0 };
     std::unordered_set<::uwb::UwbMacAddress> Controlees;
-    std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> ApplicationConfigurationParameters;
+    std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> ApplicationConfigurationParameters;
 };
 } // namespace windows::devices::uwb::simulator
 

--- a/windows/drivers/uwb/simulator/IUwbSimulatorSession.hxx
+++ b/windows/drivers/uwb/simulator/IUwbSimulatorSession.hxx
@@ -8,7 +8,6 @@
 
 #include <uwb/UwbMacAddress.hxx>
 #include <uwb/protocols/fira/FiraDevice.hxx>
-#include <windows/devices/uwb/UwbAppConfiguration.hxx>
 
 namespace windows::devices::uwb::simulator
 {

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
@@ -165,7 +165,7 @@ UwbSimulatorDdiCallbacks::SessionDeninitialize(uint32_t sessionId)
 }
 
 UwbStatus
-UwbSimulatorDdiCallbacks::SetApplicationConfigurationParameters(uint32_t sessionId, const std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> & /* applicationConfigurationParameters */, std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>> &applicationConfigurationParameterResults)
+UwbSimulatorDdiCallbacks::SetApplicationConfigurationParameters(uint32_t sessionId, const std::vector<UwbApplicationConfigurationParameter> & /* applicationConfigurationParameters */, std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>> &applicationConfigurationParameterResults)
 {
     TraceLoggingWrite(
         UwbSimulatorTraceloggingProvider,
@@ -179,7 +179,7 @@ UwbSimulatorDdiCallbacks::SetApplicationConfigurationParameters(uint32_t session
 }
 
 UwbStatus
-UwbSimulatorDdiCallbacks::GetApplicationConfigurationParameters(uint32_t sessionId, [[maybe_unused]] const std::vector<UwbApplicationConfigurationParameterType> &applicationConfigurationParameterTypes, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> &applicationConfigurationParameters)
+UwbSimulatorDdiCallbacks::GetApplicationConfigurationParameters(uint32_t sessionId, [[maybe_unused]] const std::vector<UwbApplicationConfigurationParameterType> &applicationConfigurationParameterTypes, std::vector<UwbApplicationConfigurationParameter> &applicationConfigurationParameters)
 {
     TraceLoggingWrite(
         UwbSimulatorTraceloggingProvider,

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
@@ -56,10 +56,10 @@ struct UwbSimulatorDdiCallbacks :
     SessionDeninitialize(uint32_t sessionId) override;
 
     virtual UwbStatus
-    SetApplicationConfigurationParameters(uint32_t sessionId, const std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> &applicationConfigurationParameters, std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>> &applicationConfigurationParameterResults) override;
+    SetApplicationConfigurationParameters(uint32_t sessionId, const std::vector<UwbApplicationConfigurationParameter> &applicationConfigurationParameters, std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>> &applicationConfigurationParameterResults) override;
 
     virtual UwbStatus
-    GetApplicationConfigurationParameters(uint32_t sessionId, const std::vector<UwbApplicationConfigurationParameterType> &applicationConfigurationParameterTypes, std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> &applicationConfigurationParameters) override;
+    GetApplicationConfigurationParameters(uint32_t sessionId, const std::vector<UwbApplicationConfigurationParameterType> &applicationConfigurationParameterTypes, std::vector<UwbApplicationConfigurationParameter> &applicationConfigurationParameters) override;
 
     virtual UwbStatus
     GetSessionCount(uint32_t &sessionCount) override;

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
@@ -22,7 +22,6 @@
 #include "UwbSimulatorSession.hxx"
 
 #include <uwb/protocols/fira/UwbCapability.hxx>
-#include <windows/devices/uwb/UwbAppConfiguration.hxx>
 
 namespace windows::devices::uwb::simulator
 {

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandlerLrp.cxx
@@ -201,7 +201,7 @@ UwbSimulatorDdiHandler::OnUwbGetApplicationConfigurationParameters(WDFREQUEST re
 
     // Convert DDI input type to neutral type.
     auto &applicationConfigurationParametersIn = *reinterpret_cast<UWB_SET_APP_CONFIG_PARAMS *>(std::data(inputBuffer));
-    std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> applicationConfigurationParameters{};
+    std::vector<UwbApplicationConfigurationParameter> applicationConfigurationParameters{};
     std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>> applicationConfigurationParameterResults;
 
     // Invoke callback.
@@ -228,7 +228,7 @@ UwbSimulatorDdiHandler::OnUwbSetApplicationConfigurationParameters(WDFREQUEST re
 
     // Convert DDI input type to neutral type.
     auto &applicationConfigurationParametersIn = *reinterpret_cast<UWB_SET_APP_CONFIG_PARAMS *>(std::data(inputBuffer));
-    std::vector<std::shared_ptr<IUwbAppConfigurationParameter>> applicationConfigurationParameters{};
+    std::vector<UwbApplicationConfigurationParameter> applicationConfigurationParameters{};
     std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>> applicationConfigurationParameterResults{};
 
     // Invoke callback.

--- a/windows/drivers/uwb/simulator/UwbSimulatorSession.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorSession.hxx
@@ -3,6 +3,7 @@
 #define UWB_SIMULATOR_SESSION_HXX
 
 #include <chrono>
+#include <functional>
 #include <thread>
 
 #include <uwb/protocols/fira/FiraDevice.hxx>


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Replace use of `IUwbAppConfigurationParameter` with `UwbApplicationConfigurationParameter `.

### Technical Details

* Replace `IUwbAppConfigurationParameter` and `UwbAppConfigurationParameter` with `UwbApplicationConfigurationParameter`
* Replace `std::vector<IUwbAppConfigurationParameter>` with `std::vector<UwbApplicationConfigurationParameter>`
* Replace `UwbSetAppConfigurationParameters` with `std::vector<UwbApplicationConfigurationParameter>`.
* Stop compiling source, including tests, containing `IUwbAppConfigurationParameter` and 

### Test Results

All unit tests pass on both Linux and Windows.

### Reviewer Focus

* Note that all the code implementing UwbSetAppConfigurationParameters, including neutral <-> DDI conversion functions has been saved and will be harvested to implement the conversion functions for the new types.
 
### Future Work

* Remove actual source files once code has been harvested for new neutral type implementation.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
