### PR TITLE
Invoke IOCTL_UWB_STOP_RANGING_SESSION

### DIFF
--- a/lib/uwb/UwbSession.cxx
+++ b/lib/uwb/UwbSession.cxx
@@ -60,7 +60,7 @@ UwbSession::StopRanging()
     bool rangingActiveExpected = true;
     const bool wasRangingActive = m_rangingActive.compare_exchange_weak(rangingActiveExpected, false);
     if (wasRangingActive) {
-        //StopRangingImpl();
+        StopRangingImpl();
     }
 }
 

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -326,7 +326,36 @@ UwbDeviceConnector::SessionRangingStop(uint32_t sessionId)
 {
     std::promise<UwbStatus> resultPromise;
     auto resultFuture = resultPromise.get_future();
-    // TODO: invoke IOCTL_UWB_STOP_RANGING_SESSION
+    
+    wil::shared_hfile handleDriver;
+    auto hr = OpenDriverHandle(handleDriver, m_deviceName.c_str());
+    if (FAILED(hr)) {
+        PLOG_ERROR << "failed to obtain driver handle for " << m_deviceName << ", hr=" << std::showbase << std::hex << hr;
+        resultPromise.set_exception(std::make_exception_ptr(UwbException(UwbStatusGeneric::Rejected)));
+        return resultFuture;
+    }
+
+    const UWB_STOP_RANGING_SESSION stopRanging{
+        .size = sizeof(UWB_STOP_RANGING_SESSION),
+        .sessionId = sessionId,
+    };
+    UWB_STATUS status;
+
+    BOOL ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_STOP_RANGING_SESSION, const_cast<UWB_STOP_RANGING_SESSION*>(&stopRanging), sizeof stopRanging, &status, sizeof status, nullptr, nullptr);
+    if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
+        HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
+        PLOG_ERROR << "error when sending IOCTL_UWB_STOP_RANGING_SESSION for session id " << sessionId << ", hr=" << std::showbase << std::hex << hr;
+        resultPromise.set_exception(std::make_exception_ptr(UwbException(UwbStatusGeneric::Rejected)));
+        return resultFuture;
+    } else {
+        PLOG_DEBUG << "IOCTL_UWB_STOP_RANGING_SESSION succeeded";
+        auto uwbStatus = UwbCxDdi::To(status);
+        if (!IsUwbStatusOk(uwbStatus)) {
+            resultPromise.set_exception(std::make_exception_ptr(UwbException(std::move(uwbStatus))));
+        } else {
+            resultPromise.set_value(std::move(uwbStatus));
+        }
+    }
 
     return resultFuture;
 }


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [x] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

This PR adds code to invoke IOCTL_UWB_STOP_RANGING_SESSION. This is the last necessary command IOCTL needed for running a full ranging session.

### Technical Details

- Invoke IOCTL_UWB_STOP_RANGING_SESSION in UwbDeviceConnector
- Uncomment StopRangingImpl in UwbSession

### Test Results

Code builds and unit tests pass. Need to do CLI testing once other components are finished and ready for testing.

### Reviewer Focus

None.

### Future Work

None.

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
