### PR TITLE
Enable control flow synchronization in nocli

### DIFF
--- a/tools/cli/CMakeLists.txt
+++ b/tools/cli/CMakeLists.txt
@@ -7,11 +7,13 @@ set(NO_CLI_DIR_PUBLIC_INCLUDE_PREFIX ${NO_CLI_DIR_PUBLIC_INCLUDE}/nearobject/cli
 target_sources(nocli-core
     PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/NearObjectCli.cxx
+        ${CMAKE_CURRENT_LIST_DIR}/NearObjectCliControlFlowContext.cxx
         ${CMAKE_CURRENT_LIST_DIR}/NearObjectCliData.cxx
         ${CMAKE_CURRENT_LIST_DIR}/NearObjectCliHandler.cxx
         ${CMAKE_CURRENT_LIST_DIR}/NearObjectCliUwbSessionEventCallbacks.cxx
     PUBLIC
         ${NO_CLI_DIR_PUBLIC_INCLUDE_PREFIX}/NearObjectCli.hxx
+        ${NO_CLI_DIR_PUBLIC_INCLUDE_PREFIX}/NearObjectCliControlFlowContext.hxx
         ${NO_CLI_DIR_PUBLIC_INCLUDE_PREFIX}/NearObjectCliHandler.hxx
         ${NO_CLI_DIR_PUBLIC_INCLUDE_PREFIX}/NearObjectCliData.hxx
         ${NO_CLI_DIR_PUBLIC_INCLUDE_PREFIX}/NearObjectCliUwbSessionEventCallbacks.hxx

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -114,7 +114,7 @@ NearObjectCli::CreateParser() noexcept
     // top-level command
     auto app = std::make_unique<CLI::App>("A command line tool to assist with all things nearobject", "nocli");
     app->require_subcommand();
-    app->final_callback([this] {
+    app->parse_complete_callback([this] {
         m_cliControlFlowContext = std::make_shared<NearObjectCliControlFlowContext>(m_numberOfOperations);
         m_cliHandler = std::make_shared<NearObjectCliHandler>(m_cliControlFlowContext);
     });

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -16,6 +16,7 @@ using namespace strings::ostream_operators;
 
 NearObjectCli::NearObjectCli(std::shared_ptr<NearObjectCliData> cliData, std::shared_ptr<NearObjectCliHandler> cliHandler) :
     m_cliData(cliData),
+    m_cliHandler(std::move(cliHandler)),
     m_cliApp(CreateParser())
 {
     if (!m_cliApp) {
@@ -116,7 +117,7 @@ NearObjectCli::CreateParser() noexcept
     app->require_subcommand();
     app->parse_complete_callback([this] {
         m_cliControlFlowContext = std::make_shared<NearObjectCliControlFlowContext>(m_numberOfOperations);
-        m_cliHandler = std::make_shared<NearObjectCliHandler>(m_cliControlFlowContext);
+        m_cliHandler->SetControlFlowContext(m_cliControlFlowContext);
     });
 
     // sub-commands

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -51,7 +51,10 @@ NearObjectCli::WaitForExecutionComplete()
 void
 NearObjectCli::CancelExecution()
 {
-    // TODO
+    bool stopRequested = m_cliControlFlowContext->RequestStopExecution();
+    if (!stopRequested) {
+        // TODO: log?
+    }
 }
 
 CLI::App&

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -383,7 +383,6 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App* parent)
         }
 
         m_cliHandler->HandleStartRanging(uwbDevice, m_cliData->SessionData);
-        m_cliControlFlowContext->SignalOperationComplete();
     });
 
     return rangeStartApp;

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -16,7 +16,6 @@ using namespace strings::ostream_operators;
 
 NearObjectCli::NearObjectCli(std::shared_ptr<NearObjectCliData> cliData, std::shared_ptr<NearObjectCliHandler> cliHandler) :
     m_cliData(cliData),
-    m_cliHandler(cliHandler),
     m_cliApp(CreateParser())
 {
     if (!m_cliApp) {
@@ -114,6 +113,7 @@ NearObjectCli::CreateParser() noexcept
     app->require_subcommand();
     app->final_callback([this] {
         m_cliControlFlowContext = std::make_shared<NearObjectCliControlFlowContext>(m_numberOfOperations);
+        m_cliHandler = std::make_shared<NearObjectCliHandler>(m_cliControlFlowContext);
     });
 
     // sub-commands

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -211,6 +211,7 @@ NearObjectCli::AddSubcommandUwbMonitor(CLI::App* parent)
 
     monitorApp->final_callback([this] {
         m_cliHandler->HandleMonitorMode();
+        m_cliControlFlowContext->SignalOperationComplete();
     });
 
     RegisterCliAppWithOperation(monitorApp);
@@ -382,6 +383,7 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App* parent)
         }
 
         m_cliHandler->HandleStartRanging(uwbDevice, m_cliData->SessionData);
+        m_cliControlFlowContext->SignalOperationComplete();
     });
 
     return rangeStartApp;
@@ -396,6 +398,7 @@ NearObjectCli::AddSubcommandUwbRangeStop(CLI::App* parent)
     rangeStopApp->parse_complete_callback([this] {
         std::cout << "stop ranging" << std::endl;
         m_cliHandler->HandleStopRanging();
+        m_cliControlFlowContext->SignalOperationComplete();
     });
 
     return rangeStopApp;
@@ -422,6 +425,7 @@ NearObjectCli::AddSubcommandUwbRawDeviceReset(CLI::App* parent)
         }
 
         m_cliHandler->HandleDeviceReset(uwbDevice);
+        m_cliControlFlowContext->SignalOperationComplete();
     });
 
     return rawDeviceResetApp;
@@ -448,6 +452,7 @@ NearObjectCli::AddSubcommandUwbRawGetDeviceInfo(CLI::App* parent)
         }
 
         m_cliHandler->HandleGetDeviceInfo(uwbDevice);
+        m_cliControlFlowContext->SignalOperationComplete();
     });
 
     return rawGetDeviceInfoApp;

--- a/tools/cli/NearObjectCliControlFlowContext.cxx
+++ b/tools/cli/NearObjectCliControlFlowContext.cxx
@@ -1,0 +1,14 @@
+
+#include <nearobject/cli/NearObjectCliControlFlowContext.hxx>
+
+using namespace nearobject::cli;
+
+ NearObjectCliControlFlowContext::NearObjectCliControlFlowContext(std::ptrdiff_t numOperations) :
+    m_operationCompleteLatch(numOperations)
+{}
+
+std::latch&
+NearObjectCliControlFlowContext::GetOperationCompleteLatch()
+{
+    return m_operationCompleteLatch;
+}

--- a/tools/cli/NearObjectCliControlFlowContext.cxx
+++ b/tools/cli/NearObjectCliControlFlowContext.cxx
@@ -7,6 +7,12 @@ using namespace nearobject::cli;
     m_operationCompleteLatch(numOperations)
 {}
 
+std::stop_token
+NearObjectCliControlFlowContext::GetExecutionStopToken()
+{
+    return m_stopSource.get_token();
+}
+
 std::latch&
 NearObjectCliControlFlowContext::GetOperationCompleteLatch()
 {

--- a/tools/cli/NearObjectCliControlFlowContext.cxx
+++ b/tools/cli/NearObjectCliControlFlowContext.cxx
@@ -13,6 +13,12 @@ NearObjectCliControlFlowContext::GetExecutionStopToken()
     return m_stopSource.get_token();
 }
 
+bool
+NearObjectCliControlFlowContext::RequestStopExecution()
+{
+    return m_stopSource.request_stop();
+}
+
 std::latch&
 NearObjectCliControlFlowContext::GetOperationCompleteLatch()
 {

--- a/tools/cli/NearObjectCliControlFlowContext.cxx
+++ b/tools/cli/NearObjectCliControlFlowContext.cxx
@@ -1,9 +1,13 @@
 
+#include <stdexcept>
+#include <string>
+
 #include <nearobject/cli/NearObjectCliControlFlowContext.hxx>
 
 using namespace nearobject::cli;
 
- NearObjectCliControlFlowContext::NearObjectCliControlFlowContext(std::ptrdiff_t numOperations) :
+NearObjectCliControlFlowContext::NearObjectCliControlFlowContext(std::ptrdiff_t numOperations) :
+    m_operationsCompleteLatchCount(numOperations),
     m_operationCompleteLatch(numOperations)
 {}
 
@@ -19,19 +23,24 @@ NearObjectCliControlFlowContext::RequestStopExecution()
     return m_stopSource.request_stop();
 }
 
-std::latch&
-NearObjectCliControlFlowContext::GetOperationCompleteLatch()
-{
-    return m_operationCompleteLatch;
-}
-
 bool
-NearObjectCliControlFlowContext::SignalOperationComplete()
+NearObjectCliControlFlowContext::OperationSignalComplete(uint16_t numOperationsCompleted)
 {
     const bool allOperationsComplete = m_operationCompleteLatch.try_wait();
     if (!allOperationsComplete) {
-        m_operationCompleteLatch.count_down(1);
+        if (m_operationsCompleteLatchCount < numOperationsCompleted) {
+            const std::string message = "BUG: too many operations were signaled complete (" + std::to_string(numOperationsCompleted) + " requested, " + std::to_string(m_operationsCompleteLatchCount) + "remaining)";
+            throw std::runtime_error(message);
+        }
+        m_operationCompleteLatch.count_down(numOperationsCompleted);
+        m_operationsCompleteLatchCount -= numOperationsCompleted;
     }
 
     return allOperationsComplete;
+}
+
+void
+NearObjectCliControlFlowContext::OperationsWaitForComplete()
+{
+    m_operationCompleteLatch.wait();
 }

--- a/tools/cli/NearObjectCliControlFlowContext.cxx
+++ b/tools/cli/NearObjectCliControlFlowContext.cxx
@@ -12,3 +12,14 @@ NearObjectCliControlFlowContext::GetOperationCompleteLatch()
 {
     return m_operationCompleteLatch;
 }
+
+bool
+NearObjectCliControlFlowContext::SignalOperationComplete()
+{
+    const bool allOperationsComplete = m_operationCompleteLatch.try_wait();
+    if (!allOperationsComplete) {
+        m_operationCompleteLatch.count_down(1);
+    }
+
+    return allOperationsComplete;
+}

--- a/tools/cli/NearObjectCliHandler.cxx
+++ b/tools/cli/NearObjectCliHandler.cxx
@@ -33,8 +33,10 @@ NearObjectCliHandler::ResolveUwbDevice(const nearobject::cli::NearObjectCliData&
 
 void
 NearObjectCliHandler::HandleStartRanging(std::shared_ptr<uwb::UwbDevice> uwbDevice, uwb::protocol::fira::UwbSessionData& sessionData) noexcept
-try {
-    auto callbacks = std::make_shared<nearobject::cli::NearObjectCliUwbSessionEventCallbacks>();
+{
+    auto callbacks = std::make_shared<nearobject::cli::NearObjectCliUwbSessionEventCallbacks>([this]() {
+        GetControlFlowContext().SignalOperationComplete();
+    });
     auto session = uwbDevice->CreateSession(callbacks);
     session->Configure(sessionData.sessionId, uwb::protocol::fira::GetUciConfigParams(sessionData.uwbConfiguration, session->GetDeviceType()));
     session->StartRanging();

--- a/tools/cli/NearObjectCliHandler.cxx
+++ b/tools/cli/NearObjectCliHandler.cxx
@@ -13,6 +13,16 @@
 using namespace nearobject::cli;
 using namespace uwb::protocol::fira;
 
+NearObjectCliHandler::NearObjectCliHandler(std::shared_ptr<NearObjectCliControlFlowContext> controlFlowContext) :
+    m_controlFlowContext(std::move(controlFlowContext))
+{}
+
+NearObjectCliControlFlowContext&
+NearObjectCliHandler::GetControlFlowContext()
+{
+    return *(m_controlFlowContext.get());
+}
+
 std::shared_ptr<uwb::UwbDevice>
 NearObjectCliHandler::ResolveUwbDevice(const nearobject::cli::NearObjectCliData& /*cliData */) noexcept
 {

--- a/tools/cli/NearObjectCliUwbSessionEventCallbacks.cxx
+++ b/tools/cli/NearObjectCliUwbSessionEventCallbacks.cxx
@@ -7,11 +7,18 @@
 using namespace nearobject::cli;
 using namespace strings::ostream_operators;
 
+NearObjectCliUwbSessionEventCallbacks::NearObjectCliUwbSessionEventCallbacks(std::function<void()> onSessionEndedCallback) :
+    m_onSessionEndedCallback(std::move(onSessionEndedCallback))
+{}
+
 void
 NearObjectCliUwbSessionEventCallbacks::OnSessionEnded(::uwb::UwbSession* session, ::uwb::UwbSessionEndReason /* reason */)
 {
     std::cout << "Session with id="
               << std::hex << std::setw(8) << std::setfill('0') << std::showbase << std::internal << session->GetId() << ": Session Ended" << std::endl;
+    if (m_onSessionEndedCallback) {
+        m_onSessionEndedCallback();
+    }
 }
 
 void

--- a/tools/cli/include/nearobject/cli/NearObjectCli.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCli.hxx
@@ -6,6 +6,7 @@
 #include <memory>
 
 #include <CLI/CLI.hpp>
+#include <nearobject/cli/NearObjectCliControlFlowContext.hxx>
 #include <nearobject/cli/NearObjectCliData.hxx>
 #include <nearobject/cli/NearObjectCliHandler.hxx>
 #include <uwb/UwbDevice.hxx>
@@ -58,6 +59,18 @@ public:
     Parse(int argc, char* argv[]) noexcept;
 
     /**
+     * @brief Wait for all queued operations to complete execution. 
+     */
+    void
+    WaitForExecutionComplete();
+
+    /**
+     * @brief Cancel all in-progress execution. 
+     */
+    void
+    CancelExecution();
+
+    /**
      * @brief Get the app object associated with the "uwb" sub-command.
      *
      * @return CLI::App&
@@ -98,6 +111,17 @@ public:
     GetRangeStopApp() noexcept;
 
 private:
+    /**
+     * @brief Register a CLI::App command that has an operation pending on it.
+     * 
+     * This function should be called once parsing is complete for the CLI::App
+     * instance.
+     * 
+     * @param app The CLI::App to register.
+     */
+    void
+    RegisterCliAppWithOperation(CLI::App *app);
+
     /**
      * @brief Obtain a reference to the resolved uwb device.
      *
@@ -197,6 +221,8 @@ private:
 private:
     std::shared_ptr<NearObjectCliData> m_cliData;
     std::shared_ptr<NearObjectCliHandler> m_cliHandler;
+    std::shared_ptr<NearObjectCliControlFlowContext> m_cliControlFlowContext;
+    std::size_t m_numberOfOperations{ 0 };
 
     std::unique_ptr<CLI::App> m_cliApp;
     // The following are helper references to the subcommands of m_cliApp, the memory is managed by CLI11.

--- a/tools/cli/include/nearobject/cli/NearObjectCli.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCli.hxx
@@ -4,6 +4,7 @@
 
 #include <functional>
 #include <memory>
+#include <unordered_set>
 
 #include <CLI/CLI.hpp>
 #include <nearobject/cli/NearObjectCliControlFlowContext.hxx>
@@ -49,6 +50,14 @@ public:
     GetData() const noexcept;
 
     /**
+     * @brief Get a shared reference to the the control flow object.
+     *
+     * @return std::shared_ptr<NearObjectCliControlFlowContext>
+     */
+    std::shared_ptr<NearObjectCliControlFlowContext>
+    GetControlFlowContext() const noexcept;
+
+    /**
      * @brief Parse the specified command line argumenbts.
      *
      * @param argc
@@ -59,13 +68,13 @@ public:
     Parse(int argc, char* argv[]) noexcept;
 
     /**
-     * @brief Wait for all queued operations to complete execution. 
+     * @brief Wait for all queued operations to complete execution.
      */
     void
     WaitForExecutionComplete();
 
     /**
-     * @brief Cancel all in-progress execution. 
+     * @brief Cancel all in-progress execution.
      */
     void
     CancelExecution();
@@ -113,14 +122,22 @@ public:
 private:
     /**
      * @brief Register a CLI::App command that has an operation pending on it.
-     * 
+     *
      * This function should be called once parsing is complete for the CLI::App
      * instance.
-     * 
+     *
      * @param app The CLI::App to register.
      */
     void
-    RegisterCliAppWithOperation(CLI::App *app);
+    RegisterCliAppWithOperation(CLI::App* app);
+
+    /**
+     * @brief Signal that an operation owned by a CLI::App has completed.
+     *
+     * @param app The app for which the operation completed.
+     */
+    void
+    SignalCliAppOperationCompleted(CLI::App* app);
 
     /**
      * @brief Obtain a reference to the resolved uwb device.
@@ -222,7 +239,7 @@ private:
     std::shared_ptr<NearObjectCliData> m_cliData;
     std::shared_ptr<NearObjectCliHandler> m_cliHandler;
     std::shared_ptr<NearObjectCliControlFlowContext> m_cliControlFlowContext;
-    std::size_t m_numberOfOperations{ 0 };
+    std::unordered_set<CLI::App*> m_cliAppOperations;
 
     std::unique_ptr<CLI::App> m_cliApp;
     // The following are helper references to the subcommands of m_cliApp, the memory is managed by CLI11.

--- a/tools/cli/include/nearobject/cli/NearObjectCliControlFlowContext.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliControlFlowContext.hxx
@@ -34,6 +34,15 @@ public:
     GetExecutionStopToken();
 
     /**
+     * @brief Request that execution is stopped. 
+     * 
+     * @return true If a request to stop execution was made.
+     * @return false If a request to stop execution could not be made.
+     */
+    bool
+    RequestStopExecution();
+
+    /**
      * @brief Get the latch tracking operation completion.
      * 
      * @return std::latch& 

--- a/tools/cli/include/nearobject/cli/NearObjectCliControlFlowContext.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliControlFlowContext.hxx
@@ -3,6 +3,7 @@
 #define NEAR_OBJECT_CLI_CONTROL_FLOW_CONTEXT_HXX
 
 #include <latch>
+#include <stop_token>
 
 namespace nearobject::cli
 {
@@ -18,6 +19,19 @@ public:
      * @param numOperations 
      */
     explicit NearObjectCliControlFlowContext(std::ptrdiff_t numOperations);
+
+    /**
+     * @brief Get the whole-program exection stop token. 
+     * 
+     * A request to stop will be signaled on this token when the program should
+     * halt execution. This is a cooperative, best-effort based request so may
+     * not actually result in halting execution depending on the operation(s)
+     * being carried out.
+     * 
+     * @return std::stop_token 
+     */
+    std::stop_token
+    GetExecutionStopToken();
 
     /**
      * @brief Get the latch tracking operation completion.
@@ -38,6 +52,8 @@ public:
 
 private:
     std::latch m_operationCompleteLatch;
+    std::stop_source m_stopSource;
+    std::stop_token m_stopToken;
 };
 } // namespace nearobject::cli
 

--- a/tools/cli/include/nearobject/cli/NearObjectCliControlFlowContext.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliControlFlowContext.hxx
@@ -6,13 +6,35 @@
 
 namespace nearobject::cli
 {
+/**
+ * @brief Class tracking control flow context for the CLI. 
+ */
 class NearObjectCliControlFlowContext
 {
 public:
+    /**
+     * @brief Construct a new Near Object Cli Control Flow Context object
+     * 
+     * @param numOperations 
+     */
     explicit NearObjectCliControlFlowContext(std::ptrdiff_t numOperations);
 
+    /**
+     * @brief Get the latch tracking operation completion.
+     * 
+     * @return std::latch& 
+     */
     std::latch&
     GetOperationCompleteLatch();
+
+    /**
+     * @brief Signal that execution of an operation is now complete.
+     * 
+     * @return true If all operations have completed.
+     * @return false If at least one operations is incomplete.
+     */
+    bool
+    SignalOperationComplete();
 
 private:
     std::latch m_operationCompleteLatch;

--- a/tools/cli/include/nearobject/cli/NearObjectCliControlFlowContext.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliControlFlowContext.hxx
@@ -1,0 +1,22 @@
+
+#ifndef NEAR_OBJECT_CLI_CONTROL_FLOW_CONTEXT_HXX
+#define NEAR_OBJECT_CLI_CONTROL_FLOW_CONTEXT_HXX
+
+#include <latch>
+
+namespace nearobject::cli
+{
+class NearObjectCliControlFlowContext
+{
+public:
+    explicit NearObjectCliControlFlowContext(std::ptrdiff_t numOperations);
+
+    std::latch&
+    GetOperationCompleteLatch();
+
+private:
+    std::latch m_operationCompleteLatch;
+};
+} // namespace nearobject::cli
+
+#endif // NEAR_OBJECT_CLI_CONTROL_FLOW_CONTEXT_HXX

--- a/tools/cli/include/nearobject/cli/NearObjectCliControlFlowContext.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliControlFlowContext.hxx
@@ -8,34 +8,34 @@
 namespace nearobject::cli
 {
 /**
- * @brief Class tracking control flow context for the CLI. 
+ * @brief Class tracking control flow context for the CLI.
  */
 class NearObjectCliControlFlowContext
 {
 public:
     /**
      * @brief Construct a new Near Object Cli Control Flow Context object
-     * 
-     * @param numOperations 
+     *
+     * @param numOperations
      */
     explicit NearObjectCliControlFlowContext(std::ptrdiff_t numOperations);
 
     /**
-     * @brief Get the whole-program exection stop token. 
-     * 
+     * @brief Get the whole-program exection stop token.
+     *
      * A request to stop will be signaled on this token when the program should
      * halt execution. This is a cooperative, best-effort based request so may
      * not actually result in halting execution depending on the operation(s)
      * being carried out.
-     * 
-     * @return std::stop_token 
+     *
+     * @return std::stop_token
      */
     std::stop_token
     GetExecutionStopToken();
 
     /**
-     * @brief Request that execution is stopped. 
-     * 
+     * @brief Request that execution is stopped.
+     *
      * @return true If a request to stop execution was made.
      * @return false If a request to stop execution could not be made.
      */
@@ -43,23 +43,23 @@ public:
     RequestStopExecution();
 
     /**
-     * @brief Get the latch tracking operation completion.
-     * 
-     * @return std::latch& 
-     */
-    std::latch&
-    GetOperationCompleteLatch();
-
-    /**
-     * @brief Signal that execution of an operation is now complete.
-     * 
+     * @brief Signal that execution of a number of operations completed.
+     *
+     * @param numOperationsCompleted The number of operations completed.
      * @return true If all operations have completed.
      * @return false If at least one operations is incomplete.
      */
     bool
-    SignalOperationComplete();
+    OperationSignalComplete(uint16_t numOperationsCompleted = 1);
+
+    /**
+     * @brief Wait for all outstanding operations to complete.
+     */
+    void
+    OperationsWaitForComplete();
 
 private:
+    std::ptrdiff_t m_operationsCompleteLatchCount;
     std::latch m_operationCompleteLatch;
     std::stop_source m_stopSource;
     std::stop_token m_stopToken;

--- a/tools/cli/include/nearobject/cli/NearObjectCliControlFlowContext.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliControlFlowContext.hxx
@@ -62,7 +62,6 @@ private:
     std::ptrdiff_t m_operationsCompleteLatchCount;
     std::latch m_operationCompleteLatch;
     std::stop_source m_stopSource;
-    std::stop_token m_stopToken;
 };
 } // namespace nearobject::cli
 

--- a/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
@@ -6,8 +6,8 @@
 
 #include <nearobject/cli/NearObjectCliControlFlowContext.hxx>
 #include <nearobject/cli/NearObjectCliData.hxx>
-#include <uwb/protocols/fira/UwbSessionData.hxx>
 #include <uwb/UwbDevice.hxx>
+#include <uwb/protocols/fira/UwbSessionData.hxx>
 
 namespace nearobject::cli
 {
@@ -20,22 +20,23 @@ struct NearObjectCliHandler
 {
     NearObjectCliHandler() = default;
 
-    /**
-     * @brief Construct a new NearObjectCliHandler object
-     * 
-     * @param controlFlowContext 
-     */
-    NearObjectCliHandler(std::shared_ptr<NearObjectCliControlFlowContext> controlFlowContext);
-
     virtual ~NearObjectCliHandler() = default;
+
+    /**
+     * @brief Assign the control flow context for this handler.
+     *
+     * @param controlFlowContext The control flow context to assign.
+     */
+    void
+    SetControlFlowContext(std::shared_ptr<NearObjectCliControlFlowContext> controlFlowContext);
 
     /**
      * @brief Invoked by the command line driver when a UWB device is required
      * for the selected nocli operation. This function must resolve and return
      * an instance of the appropriate UWB device to use for the operation.
-     * 
+     *
      * @param cliData The parsed command-line arguments.
-     * @return std::shared_ptr<uwb::UwbDevice> 
+     * @return std::shared_ptr<uwb::UwbDevice>
      */
     virtual std::shared_ptr<uwb::UwbDevice>
     ResolveUwbDevice(const nearobject::cli::NearObjectCliData& cliData) noexcept;
@@ -43,7 +44,7 @@ struct NearObjectCliHandler
     /**
      * @brief Invoked by command-line driver when the request is to start a
      * ranging session.
-     * 
+     *
      * @param uwbDevice The resolved uwb device to start the ranging session on.
      * @param sessionData The data to configure the ranging session.
      */
@@ -51,8 +52,8 @@ struct NearObjectCliHandler
     HandleStartRanging(std::shared_ptr<uwb::UwbDevice> uwbDevice, uwb::protocol::fira::UwbSessionData& sessionData) noexcept;
 
     /**
-     * @brief Invoked by the command-line driver when the request is to stop an ongoing ranging session. 
-     * 
+     * @brief Invoked by the command-line driver when the request is to stop an ongoing ranging session.
+     *
      * TODO: this will need to change to accept a session id. Or, prior state
      * saved may allow this to remain argumentless.
      */
@@ -74,21 +75,21 @@ struct NearObjectCliHandler
     HandleDeviceReset(std::shared_ptr<uwb::UwbDevice> uwbDevice) noexcept;
 
     /**
-    * @brief Invoked by the command-line driver when the request is to get device info.
-    * 
-    * @param uwbDevice The resolved uwb device to get device info from.
-    */
+     * @brief Invoked by the command-line driver when the request is to get device info.
+     *
+     * @param uwbDevice The resolved uwb device to get device info from.
+     */
     virtual void
     HandleGetDeviceInfo(std::shared_ptr<uwb::UwbDevice> uwbDevice) noexcept;
 
 protected:
     /**
-     * @brief Get a reference to the base class owned control flow context object.
-     * 
-     * @return NearObjectCliControlFlowContext& 
+     * @brief Get a shared reference to the control flow context object.
+     *
+     * @return std::shared_ptr<NearObjectCliControlFlowContext>
      */
-    NearObjectCliControlFlowContext&
-    GetControlFlowContext();
+    std::shared_ptr<NearObjectCliControlFlowContext>
+    GetControlFlowContext() const noexcept;
 
 private:
     std::shared_ptr<NearObjectCliControlFlowContext> m_controlFlowContext;

--- a/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
@@ -4,6 +4,7 @@
 
 #include <memory>
 
+#include <nearobject/cli/NearObjectCliControlFlowContext.hxx>
 #include <nearobject/cli/NearObjectCliData.hxx>
 #include <uwb/protocols/fira/UwbSessionData.hxx>
 #include <uwb/UwbDevice.hxx>
@@ -18,6 +19,13 @@ namespace nearobject::cli
 struct NearObjectCliHandler
 {
     NearObjectCliHandler() = default;
+
+    /**
+     * @brief Construct a new NearObjectCliHandler object
+     * 
+     * @param controlFlowContext 
+     */
+    NearObjectCliHandler(std::shared_ptr<NearObjectCliControlFlowContext> controlFlowContext);
 
     virtual ~NearObjectCliHandler() = default;
 
@@ -72,6 +80,18 @@ struct NearObjectCliHandler
     */
     virtual void
     HandleGetDeviceInfo(std::shared_ptr<uwb::UwbDevice> uwbDevice) noexcept;
+
+protected:
+    /**
+     * @brief Get a reference to the base class owned control flow context object.
+     * 
+     * @return NearObjectCliControlFlowContext& 
+     */
+    NearObjectCliControlFlowContext&
+    GetControlFlowContext();
+
+private:
+    std::shared_ptr<NearObjectCliControlFlowContext> m_controlFlowContext;
 };
 
 } // namespace nearobject::cli

--- a/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
@@ -11,6 +11,8 @@
 
 namespace nearobject::cli
 {
+class NearObjectCli;
+
 /**
  * @brief Class which handles and executes resolved command-line requests. The
  * command line driver will invoke the function associated with the command line
@@ -23,12 +25,12 @@ struct NearObjectCliHandler
     virtual ~NearObjectCliHandler() = default;
 
     /**
-     * @brief Assign the control flow context for this handler.
+     * @brief Assign the parent CLI object for this handler.
      *
-     * @param controlFlowContext The control flow context to assign.
+     * @param parent The (owning) parent object.
      */
     void
-    SetControlFlowContext(std::shared_ptr<NearObjectCliControlFlowContext> controlFlowContext);
+    SetParent(NearObjectCli* parent);
 
     /**
      * @brief Invoked by the command line driver when a UWB device is required
@@ -82,17 +84,8 @@ struct NearObjectCliHandler
     virtual void
     HandleGetDeviceInfo(std::shared_ptr<uwb::UwbDevice> uwbDevice) noexcept;
 
-protected:
-    /**
-     * @brief Get a shared reference to the control flow context object.
-     *
-     * @return std::shared_ptr<NearObjectCliControlFlowContext>
-     */
-    std::shared_ptr<NearObjectCliControlFlowContext>
-    GetControlFlowContext() const noexcept;
-
 private:
-    std::shared_ptr<NearObjectCliControlFlowContext> m_controlFlowContext;
+    NearObjectCli* m_parent;
 };
 
 } // namespace nearobject::cli

--- a/tools/cli/include/nearobject/cli/NearObjectCliUwbSessionEventCallbacks.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliUwbSessionEventCallbacks.hxx
@@ -2,6 +2,8 @@
 #ifndef NEAR_OBJECT_CLI_UWB_SESSION_EVENT_CALLBACKS_HXX
 #define NEAR_OBJECT_CLI_UWB_SESSION_EVENT_CALLBACKS_HXX
 
+#include <functional>
+
 #include <uwb/UwbSession.hxx>
 
 namespace nearobject::cli
@@ -12,6 +14,13 @@ namespace nearobject::cli
 struct NearObjectCliUwbSessionEventCallbacks :
     public ::uwb::UwbSessionEventCallbacks
 {
+    /**
+     * @brief Construct a new NearObjectCliUwbSessionEventCallbacks object.
+     * 
+     * @param onSessionEndedCallback The callback to invoke when the session ends.
+     */
+    NearObjectCliUwbSessionEventCallbacks(std::function<void()> onSessionEndedCallback);
+
     /**
      * @brief Invoked when the session is ended.
      *
@@ -58,6 +67,9 @@ struct NearObjectCliUwbSessionEventCallbacks :
      */
     void
     OnSessionMembershipChanged(::uwb::UwbSession *session, const std::vector<::uwb::UwbPeer> peersAdded, const std::vector<::uwb::UwbPeer> peersRemoved);
+
+private:
+    std::function<void()> m_onSessionEndedCallback;
 };
 
 } // namespace nearobject::cli

--- a/windows/tools/nocli/Main.cxx
+++ b/windows/tools/nocli/Main.cxx
@@ -51,6 +51,9 @@ try {
         return result;
     }
 
+    // Wait for all requested operations to complete running.
+    cli.WaitForExecutionComplete();
+
     return 0;
 } catch (...) {
     // TODO


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

1. Allow `nocli` program execution to be halted.
2. Ensure `nocli` program waits until all requested execution is completed.

### Technical Details

* Add `NearObjectCliControlFlowContext` to track control flow data for the program.
* Add `std::stop_source` and `std::stop_token` to control halting program execution. This works by providing a `std::stop_token` to the `NearObjectCliHandler` instance, whose implementation can periodically check the token to determine if a stop is requested. This is a cooperative method whereby the implementation can ignore the stop if it so chooses, or is unable to be interrupted. This supports many different scenarios and data structures, including `std::thread` and `std::condition_variable`.
* Add `std::latch` to track outstanding program execution. The latch is initialized with the total number of operations that have been queued by the command-line arguments; when each operation completes, it signals the latch "down". The main program driver internally calls `wait()` on the latch which will block until its count is 0, thus synchronizing completion of all work.

### Test Results

Ran the `nocli` tool through a few supported commands and ensured they completed, and the program exited. Also modified the cli to "down" the operation complete latch after 3s and observed that the cli waited for 3s then exited as expected.

### Reviewer Focus

* While the use of `std::latch` is semantically correct, there is (AFAIK) no way to interrupt the `wait()` call on the latch. Thus, if program execution is to be canceled, the cancelation code will have to forcibly stop all execution, or if that is not possible, then it must artificially down the latch until it reaches 0 to unblock it. The latter case is misleading since it implies execution completed when it really didn't. This could be acceptable given that this is only used in the scenario where the program should exit, so overall, the program state would be sane.
* The use of `std::latch` means we can't create the control flow context until the total number of operations are available. It also means the number of operations can't be changed once the latch is created. We should consider using a very slightly less fitting data structure like `std::counting_semaphore` instead, which doesn't suffer from this problem, however, more work would be required to ensure it is not misused (eg. prevent handlers from calling `acquire()` on it).

### Future Work

* Consider other alternatives for synchronizing `nocli` execution.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
