### PR TITLE
Wait for outstanding futures in UwbSession::ConfigureImpl

### DIFF
--- a/lib/uwb/UwbSession.cxx
+++ b/lib/uwb/UwbSession.cxx
@@ -40,7 +40,7 @@ UwbSession::AddPeer(UwbMacAddress peerMacAddress)
 void
 UwbSession::Configure(const uwb::protocol::fira::UwbSessionData& uwbSessionData)
 {
-    PLOG_VERBOSE << "configure with with id " << m_sessionId;
+    PLOG_VERBOSE << "configure session with id " << m_sessionId;
     try {
         ConfigureImpl(uwbSessionData);
     } catch (UwbException &uwbException) {

--- a/lib/uwb/UwbSession.cxx
+++ b/lib/uwb/UwbSession.cxx
@@ -4,9 +4,9 @@
 
 #include <plog/Log.h>
 
-#include <uwb/protocols/fira/UwbException.hxx>
 #include <uwb/UwbSession.hxx>
 #include <uwb/UwbSessionEventCallbacks.hxx>
+#include <uwb/protocols/fira/UwbException.hxx>
 
 using namespace uwb;
 using namespace uwb::protocol::fira;
@@ -43,10 +43,10 @@ UwbSession::Configure(const uwb::protocol::fira::UwbSessionData& uwbSessionData)
     PLOG_VERBOSE << "configure session with id " << m_sessionId;
     try {
         ConfigureImpl(uwbSessionData);
-    } catch (UwbException &uwbException) {
+    } catch (UwbException& uwbException) {
         PLOG_ERROR << "error configuring session with id " << m_sessionId << ", status=" << ToString(uwbException.Status);
         throw uwbException;
-    } catch (std::exception &e) {
+    } catch (std::exception& e) {
         PLOG_ERROR << "error configuring session with id " << m_sessionId << ", unexpected exception status=" << e.what();
         throw e;
     }

--- a/lib/uwb/UwbSession.cxx
+++ b/lib/uwb/UwbSession.cxx
@@ -4,10 +4,12 @@
 
 #include <plog/Log.h>
 
+#include <uwb/protocols/fira/UwbException.hxx>
 #include <uwb/UwbSession.hxx>
 #include <uwb/UwbSessionEventCallbacks.hxx>
 
 using namespace uwb;
+using namespace uwb::protocol::fira;
 
 UwbSession::UwbSession(std::weak_ptr<UwbSessionEventCallbacks> callbacks) :
     m_uwbMacAddressSelf(UwbMacAddress::Random<UwbMacAddressType::Extended>()),
@@ -38,8 +40,16 @@ UwbSession::AddPeer(UwbMacAddress peerMacAddress)
 void
 UwbSession::Configure(const uwb::protocol::fira::UwbSessionData& uwbSessionData)
 {
-    PLOG_VERBOSE << "configure";
-    ConfigureImpl(uwbSessionData);
+    PLOG_VERBOSE << "configure with with id " << m_sessionId;
+    try {
+        ConfigureImpl(uwbSessionData);
+    } catch (UwbException &uwbException) {
+        PLOG_ERROR << "error configuring session with id " << m_sessionId << ", status=" << ToString(uwbException.Status);
+        throw uwbException;
+    } catch (std::exception &e) {
+        PLOG_ERROR << "error configuring session with id " << m_sessionId << ", unexpected exception status=" << e.what();
+        throw e;
+    }
 }
 
 void

--- a/lib/uwb/include/uwb/protocols/fira/UwbException.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/UwbException.hxx
@@ -2,13 +2,15 @@
 #ifndef UWB_EXCEPTION_HXX
 #define UWB_EXCEPTION_HXX
 
+#include <exception>
 #include <utility>
 
 #include <uwb/protocols/fira/FiraDevice.hxx>
 
 namespace uwb::protocol::fira
 {
-struct UwbException
+struct UwbException :
+    public std::exception
 {
     explicit UwbException(UwbStatus status) :
         Status(std::move(status))

--- a/tools/cli/CMakeLists.txt
+++ b/tools/cli/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(nocli-core
     PRIVATE
         CLI11::CLI11
         magic_enum::magic_enum
+        plog::plog
     PUBLIC
         uwb-proto-fira
         uwb

--- a/tools/cli/NearObjectCliHandler.cxx
+++ b/tools/cli/NearObjectCliHandler.cxx
@@ -1,10 +1,14 @@
 
+#include <plog/Log.h>
+
 #include <nearobject/cli/NearObjectCliHandler.hxx>
 #include <nearobject/cli/NearObjectCliUwbSessionEventCallbacks.hxx>
 #include <uwb/UwbDevice.hxx>
 #include <uwb/UwbSession.hxx>
+#include <uwb/protocols/fira/UwbException.hxx>
 
 using namespace nearobject::cli;
+using namespace uwb::protocol::fira;
 
 std::shared_ptr<uwb::UwbDevice>
 NearObjectCliHandler::ResolveUwbDevice(const nearobject::cli::NearObjectCliData& /*cliData */) noexcept
@@ -16,34 +20,44 @@ NearObjectCliHandler::ResolveUwbDevice(const nearobject::cli::NearObjectCliData&
 
 void
 NearObjectCliHandler::HandleStartRanging(std::shared_ptr<uwb::UwbDevice> uwbDevice, uwb::protocol::fira::UwbSessionData& sessionData) noexcept
-{
+try {
     auto callbacks = std::make_shared<nearobject::cli::NearObjectCliUwbSessionEventCallbacks>();
     auto session = uwbDevice->CreateSession(callbacks);
     session->Configure(sessionData);
     session->StartRanging();
+} catch (...) {
+    PLOG_ERROR << "failed to start ranging";
 }
 
 void
 NearObjectCliHandler::HandleStopRanging() noexcept
-{
+try {
     // TODO
+} catch (...) {
+    PLOG_ERROR << "failed to stop ranging";
 }
 
 void
 NearObjectCliHandler::HandleMonitorMode() noexcept
-{
+try {
     // TODO
+} catch (...) {
+    PLOG_ERROR << "failed to initiate monitor mode";
 }
 
 void
 NearObjectCliHandler::HandleDeviceReset(std::shared_ptr<uwb::UwbDevice> uwbDevice) noexcept
-{
+try {
     uwbDevice->Reset();
+} catch (...) {
+    PLOG_ERROR << "failed to reset uwb device";
 }
 
 void
 NearObjectCliHandler::HandleGetDeviceInfo(std::shared_ptr<uwb::UwbDevice> uwbDevice) noexcept
-{
+try {
     auto deviceInfo = uwbDevice->GetDeviceInformation();
     std::cout << deviceInfo.ToString() << std::endl;
+} catch (...) {
+    PLOG_ERROR << "failed to obtain device information";
 }

--- a/windows/devices/uwb/CMakeLists.txt
+++ b/windows/devices/uwb/CMakeLists.txt
@@ -67,6 +67,7 @@ target_include_directories(windev-uwb
 
 target_link_libraries(windev-uwb
     PRIVATE
+        magic_enum::magic_enum
         windev-util
         windev-uwb-cx-adapter
     PUBLIC

--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -110,7 +110,7 @@ UwbSession::ConfigureImpl(const ::uwb::protocol::fira::UwbSessionData& uwbSessio
     // TODO: the caller probably wants to know about this, figure out the best way to signal the error.
     //       One option is to define a UwbSetApplicationConfigurationParameterException which has an
     //       accessor that just returns the vector entries with statusSetParameter != Ok
-    for (const auto &[applicationConfigurationParameterType, statusSetParameter] : resultSetParameters) {
+    for (const auto& [applicationConfigurationParameterType, statusSetParameter] : resultSetParameters) {
         if (!IsUwbStatusOk(statusSetParameter)) {
             LOG_ERROR << "failed to set application configuration parameter " << magic_enum::enum_name(applicationConfigurationParameterType) << ", status=" << ToString(statusSetParameter);
         }


### PR DESCRIPTION
### Type

- [X] Bug fix
- [X] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Ensure calling `UwbSession::Configure` works.

### Technical Details

* Add calls to `get()` for the futures returned from `UwbConnector::SessionInitialize` and `UwbConnector::SetApplicationConfigurationParameters` in `UwbSession::ConfigureImpl` such that the code waits for the promise to be satisfied.
* Propagate `UwbExceptions` up the stack from `UwbSession::Configure` implementation chains.
* Subclass `UwbException` from `std::exception` per hicpp guidelines, allowing top-level code to catch `std::exception` in case they don't care about the specific exception details.
* Add proper exception handling in `UwbSession::Configure` and log errors if encountered.
* Add proper exception hanlding in all `nocli` command handlers.

### Test Results

Ran `nocli.exe uwb range --SessionId 1234 start --DeviceRole 1 --MultiNodeMode 0 --NumberOfControlees 1 --DeviceMacAddress 12:34 --DestinationMacAddress 67:89 --DeviceType 1` and ensured that the future results are provided. The `UwbConnector::SetApplicationConfigurationParameters` call is still unimplemented (in develop) so the `get()` call on this future still errors out, but this is expected at this time.

### Reviewer Focus

None

### Future Work

* Allow the `std::exception::what()` function to provide additional details about the UWB-specific error.
* Propagate errors when setting application configuration parameters via `Configure()` to the caller.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
