### PR TITLE
Invoke IOCTL_UWB_SET_APP_CONFIG_PARAMS

### DIFF
--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -395,46 +395,45 @@ UwbDeviceConnector::SetApplicationConfigurationParameters(uint32_t sessionId, st
 {
     std::promise<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>>> resultPromise;
     auto resultFuture = resultPromise.get_future();
-    // TODO: invoke IOCTL_UWB_SET_APP_CONFIG_PARAMS
 
-    //
-    // Old code that used the original one-off UwbSetAppConfigurationParameters wrapper.
-    // TODO: Once this is implemented, delete the commented out code.
-    //
+    wil::shared_hfile handleDriver;
+    auto hr = OpenDriverHandle(handleDriver, m_deviceName.c_str());
+    if (FAILED(hr)) {
+        PLOG_ERROR << "failed to obtain driver handle for " << m_deviceName << ", hr=" << std::showbase << std::hex << hr;
+        resultPromise.set_exception(std::make_exception_ptr(UwbException(UwbStatusGeneric::Rejected)));
+        return resultFuture;
+    }
 
-    // auto& setParamsBuffer = applicationConfigurationParameters.DdiBuffer();
-    // auto& setParams = applicationConfigurationParameters.DdiParameters();
+    auto paramsBuffer = UwbCxDdi::From(applicationConfigurationParameters).data();
+    auto statusSize = offsetof(UWB_SET_APP_CONFIG_PARAMS_STATUS, appConfigParamsStatus[applicationConfigurationParameters.size()]);
+    std::vector<uint8_t> statusBuffer(statusSize);
+    BOOL ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_SET_APP_CONFIG_PARAMS, std::data(paramsBuffer), std::size(paramsBuffer), std::data(statusBuffer), statusSize, nullptr, nullptr);
+    if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
+        HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
+        PLOG_ERROR << "error when sending IOCTL_UWB_SET_APP_CONFIG_PARAMS with sessionId " << sessionId << ", hr = " << std::showbase << std::hex << hr;
+        resultPromise.set_exception(std::make_exception_ptr(UwbException(UwbStatusGeneric::Rejected)));
+        return resultFuture;
+    } else {
+        PLOG_DEBUG << "IOCTL_UWB_SET_APP_CONFIG_PARAMS succeeded";
+        auto& uwbSetAppConfigParamsStatus = *reinterpret_cast<UWB_SET_APP_CONFIG_PARAMS_STATUS*>(std::data(statusBuffer));
+        auto uwbStatus = UwbCxDdi::To(uwbSetAppConfigParamsStatus.status);
+        if (!IsUwbStatusOk(uwbStatus)) {
+            resultPromise.set_exception(std::make_exception_ptr(UwbException(std::move(uwbStatus))));
+        } else {
+            // TODO: Could move this logic into its own UwbCxDdi::To() function
+            std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>> appConfigParamsStatusList;
+            for (auto i = 0; i < uwbSetAppConfigParamsStatus.appConfigParamsCount; i++)
+            {
+                auto paramType = UwbCxDdi::To(uwbSetAppConfigParamsStatus.appConfigParamsStatus[i].paramType);
+                auto paramStatus = UwbCxDdi::To(uwbSetAppConfigParamsStatus.appConfigParamsStatus[i].status);
 
-    // // Allocate memory for the UWB_SET_APP_CONFIG_PARAMS_STATUS structure, and pass this to the driver request
-    // auto statusSize = offsetof(UWB_SET_APP_CONFIG_PARAMS_STATUS, appConfigParamsStatus[setParams.appConfigParamsCount]);
-    // std::vector<uint8_t> statusBuffer(statusSize);
-    // BOOL ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_SET_APP_CONFIG_PARAMS, std::data(setParamsBuffer), std::size(setParamsBuffer), std::data(statusBuffer), statusSize, nullptr, nullptr);
-    // if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
-    //     HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
-    //     PLOG_ERROR << "error when sending IOCTL_UWB_SET_APP_CONFIG_PARAMS with sessionId " << sessionId << ", hr = " << std::showbase << std::hex << hr;
-    //     resultPromise.set_exception(std::make_exception_ptr(UwbException(UwbStatusGeneric::Rejected)));
-    //     return resultFuture;
-    // } else {
-    //     PLOG_DEBUG << "IOCTL_UWB_SET_APP_CONFIG_PARAMS succeeded";
-    //     auto& uwbSetAppConfigParamsStatus = *reinterpret_cast<UWB_SET_APP_CONFIG_PARAMS_STATUS*>(std::data(statusBuffer));
-    //     auto uwbStatus = UwbCxDdi::To(uwbSetAppConfigParamsStatus.status);
-    //     if (!IsUwbStatusOk(uwbStatus)) {
-    //         resultPromise.set_exception(std::make_exception_ptr(UwbException(std::move(uwbStatus))));
-    //     } else {
-    //         // TODO: Could move this logic into its own UwbCxDdi::To() function
-    //         std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>> appConfigParamsStatusList;
-    //         for (auto i = 0; i < uwbSetAppConfigParamsStatus.appConfigParamsCount; i++)
-    //         {
-    //             auto paramType = UwbCxDdi::To(uwbSetAppConfigParamsStatus.appConfigParamsStatus[i].paramType);
-    //             auto paramStatus = UwbCxDdi::To(uwbSetAppConfigParamsStatus.appConfigParamsStatus[i].status);
-
-    //             auto appConfigParamStatus = std::make_tuple(paramType, paramStatus);
-    //             appConfigParamsStatusList.push_back(appConfigParamStatus);
-    //         }
-    //         auto result = std::make_tuple(uwbStatus, std::move(appConfigParamsStatusList));
-    //         resultPromise.set_value(std::move(result));
-    //     }
-    // }
+                auto appConfigParamStatus = std::make_tuple(paramType, paramStatus);
+                appConfigParamsStatusList.push_back(appConfigParamStatus);
+            }
+            auto result = std::make_tuple(uwbStatus, std::move(appConfigParamsStatusList));
+            resultPromise.set_value(std::move(result));
+        }
+    }
 
     return resultFuture;
 }


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [x] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

This PR adds code to invoke IOCTL_UWB_SET_APP_CONFIG_PARAMS using the new interface containing a std::vector<UwbApplicationConfigurationParameter>.

### Technical Details

Invoke IOCTL_UWB_SET_APP_CONFIG_PARAMS in UwbDeviceConnector.

### Test Results

None yet. Will test once the caller code has all the pieces needed to set app config params from the nocli tool. This could be tested in an ad-hoc manner too.

### Reviewer Focus

None.

### Future Work

None.

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
