### PR TITLE
Add HandleDriverStartRanging function

### DIFF
--- a/tools/cli/NearObjectCliHandler.cxx
+++ b/tools/cli/NearObjectCliHandler.cxx
@@ -1,15 +1,13 @@
 
-#include <plog/Log.h>
-
 #include <nearobject/cli/NearObjectCli.hxx>
 #include <nearobject/cli/NearObjectCliHandler.hxx>
 #include <nearobject/cli/NearObjectCliUwbSessionEventCallbacks.hxx>
 #include <uwb/UwbDevice.hxx>
 #include <uwb/UwbSession.hxx>
+#include <uwb/protocols/fira/UwbException.hxx>
 #include <uwb/protocols/fira/UwbOobConversions.hxx>
 
 #include <plog/Log.h>
-#include <uwb/protocols/fira/UwbException.hxx>
 
 using namespace nearobject::cli;
 using namespace uwb::protocol::fira;

--- a/tools/cli/NearObjectCliHandler.cxx
+++ b/tools/cli/NearObjectCliHandler.cxx
@@ -22,6 +22,17 @@ NearObjectCliHandler::ResolveUwbDevice(const nearobject::cli::NearObjectCliData&
 }
 
 void
+NearObjectCliHandler::HandleDriverStartRanging(std::shared_ptr<uwb::UwbDevice> uwbDevice, const UwbRangingParameters& rangingParameters) noexcept
+try {
+    auto callbacks = std::make_shared<nearobject::cli::NearObjectCliUwbSessionEventCallbacks>();
+    auto session = uwbDevice->CreateSession(callbacks);
+    session->Configure(rangingParameters.sessionId, rangingParameters.appConfigParams);
+    session->StartRanging();
+} catch (...) {
+    PLOG_ERROR << "failed to start ranging";
+}
+
+void
 NearObjectCliHandler::HandleStartRanging(std::shared_ptr<uwb::UwbDevice> uwbDevice, uwb::protocol::fira::UwbSessionData& sessionData) noexcept
 try {
     auto callbacks = std::make_shared<nearobject::cli::NearObjectCliUwbSessionEventCallbacks>();

--- a/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
@@ -11,6 +11,15 @@
 namespace nearobject::cli
 {
 /**
+ * @brief Structure to hold parameters for a ranging session.
+ */
+struct UwbRangingParameters
+{
+    uint32_t sessionId;
+    std::vector<uwb::protocol::fira::UwbApplicationConfigurationParameter> appConfigParams;
+};
+
+/**
  * @brief Class which handles and executes resolved command-line requests. The
  * command line driver will invoke the function associated with the command line
  * request. Multiple distinct actions may be invoked simultaneously.
@@ -31,6 +40,17 @@ struct NearObjectCliHandler
      */
     virtual std::shared_ptr<uwb::UwbDevice>
     ResolveUwbDevice(const nearobject::cli::NearObjectCliData& cliData) noexcept;
+
+    /**
+     * @brief Invoked by command-line driver when the request is to start a
+     * ranging session.
+     * 
+     * @param uwbDevice The resolved uwb device to start the ranging session on.
+     * @param rangingParameters The parameters needed to configure and start a
+     * ranging session.
+     */
+    virtual void
+    HandleDriverStartRanging(std::shared_ptr<uwb::UwbDevice> uwbDevice, const UwbRangingParameters& rangingParameters) noexcept;
 
     /**
      * @brief Invoked by command-line driver when the request is to start a

--- a/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
@@ -2,6 +2,7 @@
 #ifndef NEAR_OBJECT_CLI_HANDLER_HXX
 #define NEAR_OBJECT_CLI_HANDLER_HXX
 
+#include <cstdint>
 #include <memory>
 
 #include <nearobject/cli/NearObjectCliData.hxx>

--- a/tools/cli/include/nearobject/cli/NearObjectCliUwbSessionEventCallbacks.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliUwbSessionEventCallbacks.hxx
@@ -19,7 +19,7 @@ struct NearObjectCliUwbSessionEventCallbacks :
      * 
      * @param onSessionEndedCallback The callback to invoke when the session ends.
      */
-    NearObjectCliUwbSessionEventCallbacks(std::function<void()> onSessionEndedCallback);
+    NearObjectCliUwbSessionEventCallbacks(std::function<void()> onSessionEndedCallback = {});
 
     /**
      * @brief Invoked when the session is ended.


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [x] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

This PR adds a new interface function for nocli to start a ranging session for driver testing.

### Technical Details

- Created UwbRangingParameters wrapper struct to contain a session ID and a list of UCI app config parameters.
- Added new HandleDriverStartRanging function. Unlike HandleStartRanging, this new function takes UwbRangingParameters instead of UwbSessionData.

### Test Results

Code builds. Will test further once nocli is reorganized to do driver-specific testing, which will call this new HandleDriverStartRanging function.

### Reviewer Focus

Location of UwbRangingParameters struct. Does it make sense where I put it, or should it be moved elsewhere?

### Future Work

None.

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
