### PR TITLE
Enable neutral <-> DDI conversion for UwbApplicationConfigurationParameter

### DIFF
--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -529,6 +529,17 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
         .Value = staticStsInitializationVector,
     };
 
+    // UWB_APP_CONFIG_PARAM_TYPE_RESULT_REPORT_CONFIG
+    const std::unordered_set<ResultReportConfiguration> resultReportConfig{
+        ResultReportConfiguration::TofReport,
+        ResultReportConfiguration::AoAElevationReport,
+        ResultReportConfiguration::AoAFoMReport,
+    };
+    const UwbApplicationConfigurationParameter parameterResultReportConfig = {
+        .Type = UwbApplicationConfigurationParameterType::ResultReportConfig,
+        .Value = resultReportConfig,
+    };
+
     // UWB_APP_CONFIG_PARAM_TYPE_DEVICE_MAC_ADDRESS (short)
     constexpr ::uwb::UwbMacAddress uwbMacAddressShort(std::array<uint8_t, ::uwb::UwbMacAddressLength::Short>{ 0xAA, 0xBB });
     constexpr UwbApplicationConfigurationParameter parameterUwbMacAddressShort = {
@@ -573,6 +584,11 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
         test::ValidateRoundtrip(parameterStaticStsInitializationVector);
     }
 
+    SECTION("UwbApplicationConfigurationParameter std::unordered_set<ResultReportConfiguration> variant is stable")
+    {
+        test::ValidateRoundtrip(parameterResultReportConfig);
+    }
+
     SECTION("UwbApplicationConfigurationParameter ::uwb::UwbMacAddress (short type)")
     {
         test::ValidateRoundtrip(parameterUwbMacAddressShort);
@@ -592,6 +608,7 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
             parameterRangingInterval,
             parameterAoaResult,
             parameterStaticStsInitializationVector,
+            parameterResultReportConfig,
             parameterUwbMacAddressShort,
             parameterUwbMacAddressExtended,
         };

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -555,7 +555,7 @@ windows::devices::uwb::ddi::lrp::From(const UwbNotificationData &uwbNotification
 UwbApplicationConfigurationParameterWrapper
 windows::devices::uwb::ddi::lrp::From(const UwbApplicationConfigurationParameter &uwbApplicationConfigurationParameter)
 {
-    std::size_t totalSize = sizeof(UWB_APP_CONFIG_PARAM);
+    std::size_t totalSize = offsetof(UWB_APP_CONFIG_PARAM, paramValue[0]);
     std::unique_ptr<UwbApplicationConfigurationParameterWrapper> applicationConfigurationParameterWrapper;
 
     std::visit([&](auto &&arg) {
@@ -563,14 +563,14 @@ windows::devices::uwb::ddi::lrp::From(const UwbApplicationConfigurationParameter
         if constexpr (std::is_enum_v<T>) {
             const auto uvalue = notstd::to_underlying(arg);
             constexpr auto argSize = sizeof(uvalue);
-            totalSize += argSize - 1;
+            totalSize += argSize;
             applicationConfigurationParameterWrapper = std::make_unique<UwbApplicationConfigurationParameterWrapper>(totalSize);
             UWB_APP_CONFIG_PARAM &applicationConfigurationParameter = applicationConfigurationParameterWrapper->value();
             applicationConfigurationParameter.paramLength = argSize;
             std::memcpy(&applicationConfigurationParameter.paramValue[0], &uvalue, sizeof uvalue);
         } else if constexpr (std::is_integral_v<T> || std::is_same_v<T, std::array<uint8_t, StaticStsInitializationVectorLength>>) {
             constexpr auto argSize = sizeof(T);
-            totalSize += argSize - 1;
+            totalSize += argSize;
             applicationConfigurationParameterWrapper = std::make_unique<UwbApplicationConfigurationParameterWrapper>(totalSize);
             UWB_APP_CONFIG_PARAM &applicationConfigurationParameter = applicationConfigurationParameterWrapper->value();
             applicationConfigurationParameter.paramLength = argSize;
@@ -578,7 +578,7 @@ windows::devices::uwb::ddi::lrp::From(const UwbApplicationConfigurationParameter
         } else if constexpr (std::is_same_v<T, ::uwb::UwbMacAddress>) {
             const auto value = arg.GetValue();
             const auto argSize = std::size(value);
-            totalSize += argSize - 1;
+            totalSize += argSize;
             applicationConfigurationParameterWrapper = std::make_unique<UwbApplicationConfigurationParameterWrapper>(totalSize);
             UWB_APP_CONFIG_PARAM &applicationConfigurationParameter = applicationConfigurationParameterWrapper->value();
             applicationConfigurationParameter.paramLength = argSize;

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -583,6 +583,17 @@ windows::devices::uwb::ddi::lrp::From(const UwbApplicationConfigurationParameter
             UWB_APP_CONFIG_PARAM &applicationConfigurationParameter = applicationConfigurationParameterWrapper->value();
             applicationConfigurationParameter.paramLength = argSize;
             std::memcpy(&applicationConfigurationParameter.paramValue[0], std::data(value), std::size(value));
+        } else if constexpr (std::is_same_v<T, std::unordered_set<ResultReportConfiguration>>) {
+            uint8_t value = 0;
+            const auto argSize = sizeof value;
+            totalSize += argSize;
+            for (const auto &resultReportConfiguration : arg) {
+                value |= notstd::to_underlying(resultReportConfiguration);
+            }
+            applicationConfigurationParameterWrapper = std::make_unique<UwbApplicationConfigurationParameterWrapper>(totalSize);
+            UWB_APP_CONFIG_PARAM &applicationConfigurationParameter = applicationConfigurationParameterWrapper->value();
+            applicationConfigurationParameter.paramLength = argSize;
+            applicationConfigurationParameter.paramValue[0] = value;
         } else {
             throw std::runtime_error("unknown UwbApplicationConfigurationParameter variant value encountered");
         }

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -1398,10 +1398,10 @@ windows::devices::uwb::ddi::lrp::To(const UWB_APP_CONFIG_PARAM &applicationConfi
         break;
     case UWB_APP_CONFIG_PARAM_TYPE_RESULT_REPORT_CONFIG: {
         std::unordered_set<ResultReportConfiguration> configs;
-        uint8_t value = applicationConfigurationParameter.paramValue[0];
+        const uint8_t value = applicationConfigurationParameter.paramValue[0];
         for (const auto bitmap : magic_enum::enum_values<ResultReportConfiguration>()) {
-            auto underlyingMap = notstd::to_underlying(bitmap);
-            if (value & underlyingMap) {
+            auto underlyingMap = std::bitset<sizeof value>(notstd::to_underlying(bitmap));
+            if (underlyingMap.test(value)) {
                 configs.insert(bitmap);
             }
         }


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

* Ensure neutral <-> DDI conversion for UWB application parameter type `UWB_APP_CONFIG_PARAM_TYPE_RESULT_REPORT_CONFIG` works.

### Technical Details

* Add conversion code for `UWB_APP_CONFIG_PARAM_TYPE_RESULT_REPORT_CONFIG` to `UwbApplicationConfigurationParameter` `From()` conversion function.
* Add unit test for ``UWB_APP_CONFIG_PARAM_TYPE_RESULT_REPORT_CONFIG``.
* Consolidate some repeated code in `UwbApplicationConfigurationParameter` `From()` conversion function.
* Update conversion function name to clarify where it's intended to be used.
 
### Test Results

* All unit tests pass on both Linux and Windows.

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
