### PR TITLE
Add conversion function for SetAppConfigParams

### DIFF
--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -678,6 +678,42 @@ windows::devices::uwb::ddi::lrp::From(const std::vector<UwbApplicationConfigurat
     return std::move(applicationConfigurationParametersWrapper);
 }
 
+UwbSetApplicationConfigurationParametersWrapper
+windows::devices::uwb::ddi::lrp::From(const std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> &uwbApplicationConfigurationParameters, const uint32_t sessionId)
+{
+    // Convert each individual parameter to its DDI wrapper.
+    std::vector<UwbApplicationConfigurationParameterWrapper> uwbApplicationConfigurationParameterWrappers{};
+    std::ranges::transform(uwbApplicationConfigurationParameters, std::back_inserter(uwbApplicationConfigurationParameterWrappers), [](const auto &uwbApplicationConfigurationParameter) {
+        return From(uwbApplicationConfigurationParameter);
+    });
+
+    // Calculate the total size required for the UWB_APP_CONFIG_PARAMS instance.
+    const std::size_t totalSize = std::accumulate(
+        std::cbegin(uwbApplicationConfigurationParameterWrappers),
+        std::cend(uwbApplicationConfigurationParameterWrappers),
+        static_cast<std::size_t>(offsetof(UWB_SET_APP_CONFIG_PARAMS, appConfigParams[0])),
+        [&](std::size_t totalSize, const auto &uwbApplicationConfigurationParameterWrapper) {
+            return totalSize + std::size(uwbApplicationConfigurationParameterWrapper);
+        });
+
+    // Instantiate a wrapper for UWB_SET_APP_CONFIG_PARAMS and fill it in.
+    UwbSetApplicationConfigurationParametersWrapper setApplicationConfigurationParametersWrapper{ totalSize };
+    UWB_SET_APP_CONFIG_PARAMS &setAppConfigParams = setApplicationConfigurationParametersWrapper.value();
+    setAppConfigParams.size = totalSize;
+    setAppConfigParams.sessionId = sessionId;
+    setAppConfigParams.appConfigParamsCount = std::size(uwbApplicationConfigurationParameterWrappers);
+
+    // Copy each of the converted UWB_APP_CONFIG_PARAM values into the UWB_SET_APP_CONFIG_PARAMS flex-array.
+    UWB_APP_CONFIG_PARAM *appConfigParam = reinterpret_cast<UWB_APP_CONFIG_PARAM *>(&setAppConfigParams.appConfigParams[0]);
+    for (auto &uwbApplicationConfigurationParameterWrapper : uwbApplicationConfigurationParameterWrappers) {
+        UWB_APP_CONFIG_PARAM &uwbAppConfigParam = uwbApplicationConfigurationParameterWrapper.value();
+        std::memcpy(appConfigParam, &uwbAppConfigParam, uwbAppConfigParam.size);
+        appConfigParam = reinterpret_cast<UWB_APP_CONFIG_PARAM *>(reinterpret_cast<uintptr_t>(appConfigParam) + uwbAppConfigParam.size);
+    }
+
+    return std::move(setApplicationConfigurationParametersWrapper);
+}
+
 namespace detail
 {
 /**

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -273,6 +273,18 @@ using UwbApplicationConfigurationParametersWrapper = notstd::flextype_wrapper<UW
 UwbApplicationConfigurationParametersWrapper
 From(const std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> &uwbApplicationConfigurationParameters);
 
+using UwbSetApplicationConfigurationParametersWrapper = notstd::flextype_wrapper<UWB_SET_APP_CONFIG_PARAMS>;
+
+/**
+ * @brief Converts a vector of UwbApplicationConfigurationParameter and sessionId to UWB_SET_APP_CONFIG_PARAMS.
+ * 
+ * @param uwbApplicationConfigurationParameters
+ * @param sessionId
+ * @return UwbSetApplicationConfigurationParametersWrapper
+ */
+UwbSetApplicationConfigurationParametersWrapper
+From(const std::vector <::uwb::protocol::fira::UwbApplicationConfigurationParameter> &uwbApplicationConfigurationParameters, const uint32_t sessionId);
+
 /**
  * @brief Converts UWB_DEVICE_CAPABILITIES to UwbCapability.
  *

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -283,7 +283,7 @@ using UwbSetApplicationConfigurationParametersWrapper = notstd::flextype_wrapper
  * @return UwbSetApplicationConfigurationParametersWrapper
  */
 UwbSetApplicationConfigurationParametersWrapper
-From(const std::vector <::uwb::protocol::fira::UwbApplicationConfigurationParameter> &uwbApplicationConfigurationParameters, const uint32_t sessionId);
+From(const std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> &uwbApplicationConfigurationParameters, const uint32_t sessionId);
 
 /**
  * @brief Converts UWB_DEVICE_CAPABILITIES to UwbCapability.


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [x] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

This PR adds a new conversion function for converting a std::vector<UwbApplicationConfigurationParameter> and uint32_t sessionId to UWB_SET_APP_CONFIG_PARAMS. This is necessary for properly and cleanly invoking IOCTL_UWB_SET_APP_CONFIG_PARAMS

### Technical Details

Add new conversion function.

### Test Results

Tested with local CLI changes and can successfully set app config params in the driver.

### Reviewer Focus

None.

### Future Work

May need to add a "To" function, since this PR only adds a "From" function.

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
