### PR TITLE
Fix bug where sessionId is not found after session has been initialized

### DIFF
--- a/lib/uwb/UwbDevice.cxx
+++ b/lib/uwb/UwbDevice.cxx
@@ -78,9 +78,9 @@ UwbDevice::OnSessionStatusChanged(UwbSessionStatus statusSession)
 }
 
 std::shared_ptr<UwbSession>
-UwbDevice::CreateSession(std::weak_ptr<UwbSessionEventCallbacks> callbacks)
+UwbDevice::CreateSession(uint32_t sessionId, std::weak_ptr<UwbSessionEventCallbacks> callbacks)
 {
-    auto session = CreateSessionImpl(callbacks);
+    auto session = CreateSessionImpl(sessionId, callbacks);
     {
         std::unique_lock sessionExclusiveLock{ m_sessionsGate };
         m_sessions[session->GetId()] = std::weak_ptr<UwbSession>(session);
@@ -98,8 +98,8 @@ UwbDevice::GetCapabilities()
 
 /**
  * @brief Get the FiRa device information of the device.
- * 
- * @return ::uwb::protocol::fira::UwbDeviceInformation 
+ *
+ * @return ::uwb::protocol::fira::UwbDeviceInformation
  */
 UwbDeviceInformation
 UwbDevice::GetDeviceInformation()

--- a/lib/uwb/UwbSession.cxx
+++ b/lib/uwb/UwbSession.cxx
@@ -11,11 +11,11 @@
 using namespace uwb;
 using namespace uwb::protocol::fira;
 
-UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<UwbSessionEventCallbacks> callbacks, uwb::protocol::fira::DeviceType deviceType) :
-    m_sessionId(sessionId),
+UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<UwbSessionEventCallbacks> callbacks, DeviceType deviceType) :
     m_uwbMacAddressSelf(UwbMacAddress::Random<UwbMacAddressType::Extended>()),
     m_callbacks(std::move(callbacks)),
-    m_deviceType{ deviceType }
+    m_deviceType{ deviceType },
+    m_sessionId(sessionId)
 {}
 
 uwb::protocol::fira::DeviceType

--- a/lib/uwb/UwbSession.cxx
+++ b/lib/uwb/UwbSession.cxx
@@ -11,7 +11,8 @@
 using namespace uwb;
 using namespace uwb::protocol::fira;
 
-UwbSession::UwbSession(std::weak_ptr<UwbSessionEventCallbacks> callbacks, uwb::protocol::fira::DeviceType deviceType) :
+UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<UwbSessionEventCallbacks> callbacks, uwb::protocol::fira::DeviceType deviceType) :
+    m_sessionId(sessionId),
     m_uwbMacAddressSelf(UwbMacAddress::Random<UwbMacAddressType::Extended>()),
     m_callbacks(std::move(callbacks)),
     m_deviceType{ deviceType }
@@ -45,11 +46,11 @@ UwbSession::AddPeer(UwbMacAddress peerMacAddress)
 }
 
 void
-UwbSession::Configure(const uint32_t sessionId, const std::vector<protocol::fira::UwbApplicationConfigurationParameter> configParams)
+UwbSession::Configure(const std::vector<protocol::fira::UwbApplicationConfigurationParameter> configParams)
 {
     PLOG_VERBOSE << "configure session with id " << m_sessionId;
     try {
-        ConfigureImpl(sessionId, configParams);
+        ConfigureImpl(configParams);
     } catch (UwbException& uwbException) {
         PLOG_ERROR << "error configuring session with id " << m_sessionId << ", status=" << ToString(uwbException.Status);
         throw uwbException;

--- a/lib/uwb/include/uwb/UwbDevice.hxx
+++ b/lib/uwb/include/uwb/UwbDevice.hxx
@@ -28,7 +28,7 @@ public:
      * @return std::shared_ptr<UwbSession>
      */
     std::shared_ptr<UwbSession>
-    CreateSession(std::weak_ptr<UwbSessionEventCallbacks> callbacks);
+    CreateSession(uint32_t sessionId, std::weak_ptr<UwbSessionEventCallbacks> callbacks);
 
     /**
      * @brief Get the FiRa capabilities of the device.
@@ -79,11 +79,12 @@ private:
     /**
      * @brief Creates a new UWB session with no configuration nor peers.
      *
+     * @param sessionId
      * @param callbacks
      * @return std::shared_ptr<UwbSession>
      */
     virtual std::shared_ptr<UwbSession>
-    CreateSessionImpl(std::weak_ptr<UwbSessionEventCallbacks> callbacks) = 0;
+    CreateSessionImpl(uint32_t sessionId, std::weak_ptr<UwbSessionEventCallbacks> callbacks) = 0;
 
     /**
      * @brief Get the FiRa capabilities of the device.

--- a/lib/uwb/include/uwb/UwbSession.hxx
+++ b/lib/uwb/include/uwb/UwbSession.hxx
@@ -25,8 +25,9 @@ public:
     /**
      * @brief Construct a new UwbSession object.
      *
-     * @param sessionId The requested sessionId
-     * @param callbacks The callbacks to invoke for session events.
+     * @param sessionId
+     * @param callbacks
+     * @param deviceType
      */
     UwbSession(uint32_t sessionId, std::weak_ptr<UwbSessionEventCallbacks> callbacks, uwb::protocol::fira::DeviceType deviceType = uwb::protocol::fira::DeviceType::Controller);
 
@@ -53,8 +54,9 @@ public:
 
     /**
      * @brief Configure the session for use.
-     * This function tells the UWBS to initialize the session for ranging with the particular sessionId and then
-     * configures it with configParams
+     *
+     * This function tells the UWBS to initialize the session for ranging with
+     * the particular sessionId and then configures it with configParams.
      *
      * @param configParams
      */

--- a/lib/uwb/include/uwb/UwbSession.hxx
+++ b/lib/uwb/include/uwb/UwbSession.hxx
@@ -25,9 +25,10 @@ public:
     /**
      * @brief Construct a new UwbSession object.
      *
+     * @param sessionId The requested sessionId
      * @param callbacks The callbacks to invoke for session events.
      */
-    UwbSession(std::weak_ptr<UwbSessionEventCallbacks> callbacks, uwb::protocol::fira::DeviceType deviceType = uwb::protocol::fira::DeviceType::Controller);
+    UwbSession(uint32_t sessionId, std::weak_ptr<UwbSessionEventCallbacks> callbacks, uwb::protocol::fira::DeviceType deviceType = uwb::protocol::fira::DeviceType::Controller);
 
     /**
      * @brief Destroy the UwbSession object.
@@ -36,8 +37,8 @@ public:
 
     /**
      * @brief Get the Device Type associated with the host of this UwbSession
-     * 
-     * @return uwb::protocol::fira::DeviceType 
+     *
+     * @return uwb::protocol::fira::DeviceType
      */
     uwb::protocol::fira::DeviceType
     GetDeviceType() const noexcept;
@@ -55,11 +56,10 @@ public:
      * This function tells the UWBS to initialize the session for ranging with the particular sessionId and then
      * configures it with configParams
      *
-     * @param sessionId
      * @param configParams
      */
     void
-    Configure(const uint32_t sessionId, const std::vector<protocol::fira::UwbApplicationConfigurationParameter> configParams);
+    Configure(const std::vector<protocol::fira::UwbApplicationConfigurationParameter> configParams);
 
     /**
      * @brief Set the type of mac address to be used for session participants.
@@ -118,11 +118,10 @@ private:
     /**
      * @brief Configures the session for use.
      *
-     * @param sessionId
      * @param uwbSessionData The session data to configure the session with.
      */
     virtual void
-    ConfigureImpl(const uint32_t sessionId, const std::vector<protocol::fira::UwbApplicationConfigurationParameter> configParams) = 0;
+    ConfigureImpl(const std::vector<protocol::fira::UwbApplicationConfigurationParameter> configParams) = 0;
 
     /**
      * @brief Start ranging.

--- a/linux/devices/uwb/UwbDevice.cxx
+++ b/linux/devices/uwb/UwbDevice.cxx
@@ -5,7 +5,7 @@ using namespace linux::devices;
 using namespace uwb::protocol::fira;
 
 std::shared_ptr<uwb::UwbSession>
-UwbDevice::CreateSessionImpl(std::weak_ptr<uwb::UwbSessionEventCallbacks> /* callbacks */)
+UwbDevice::CreateSessionImpl(uint32_t sessionId, std::weak_ptr<uwb::UwbSessionEventCallbacks> /* callbacks */)
 {
     // TODO
     return nullptr;

--- a/linux/devices/uwb/include/linux/uwb/UwbDevice.hxx
+++ b/linux/devices/uwb/include/linux/uwb/UwbDevice.hxx
@@ -23,10 +23,10 @@ public:
 
     /**
      * @brief Determine if this device is the same as another.
-     * 
-     * @param other 
-     * @return true 
-     * @return false 
+     *
+     * @param other
+     * @return true
+     * @return false
      */
     bool
     IsEqual(const uwb::UwbDevice& other) const noexcept override;
@@ -34,31 +34,32 @@ public:
 private:
     /**
      * @brief Create a Session object
-     * 
-     * @param callbacks 
-     * @return std::shared_ptr<uwb::UwbSession> 
+     *
+     * @param sessionId
+     * @param callbacks
+     * @return std::shared_ptr<uwb::UwbSession>
      */
     std::shared_ptr<uwb::UwbSession>
-    CreateSessionImpl(std::weak_ptr<uwb::UwbSessionEventCallbacks> callbacks) override;
+    CreateSessionImpl(uint32_t sessionId, std::weak_ptr<uwb::UwbSessionEventCallbacks> callbacks) override;
 
     /**
      * @brief Get the capabilities of the device.
-     * 
-     * @return uwb::protocol::fira::UwbCapability 
+     *
+     * @return uwb::protocol::fira::UwbCapability
      */
     uwb::protocol::fira::UwbCapability
     GetCapabilitiesImpl() override;
 
     /**
      * @brief Get the FiRa device information of the device.
-     * 
-     * @return uwb::protocol::fira::UwbDeviceInformation 
+     *
+     * @return uwb::protocol::fira::UwbDeviceInformation
      */
     uwb::protocol::fira::UwbDeviceInformation
     GetDeviceInformationImpl() override;
 
     /**
-     * @brief Reset the device to an initial clean state. 
+     * @brief Reset the device to an initial clean state.
      */
     void
     ResetImpl() override;

--- a/tests/unit/uwb/TestUwbDevice.cxx
+++ b/tests/unit/uwb/TestUwbDevice.cxx
@@ -21,7 +21,7 @@ struct UwbDeviceTestBase : public uwb::UwbDevice
     uint16_t Id;
 
     std::shared_ptr<UwbSession>
-    CreateSessionImpl(uint32_t /* sessionId */,std::weak_ptr<UwbSessionEventCallbacks> /* callbacks */) override
+    CreateSessionImpl(uint32_t /* sessionId */, std::weak_ptr<UwbSessionEventCallbacks> /* callbacks */) override
     {
         return nullptr;
     }

--- a/tests/unit/uwb/TestUwbDevice.cxx
+++ b/tests/unit/uwb/TestUwbDevice.cxx
@@ -21,7 +21,7 @@ struct UwbDeviceTestBase : public uwb::UwbDevice
     uint16_t Id;
 
     std::shared_ptr<UwbSession>
-    CreateSessionImpl(std::weak_ptr<UwbSessionEventCallbacks> /* callbacks */) override
+    CreateSessionImpl(uint32_t /* sessionId */,std::weak_ptr<UwbSessionEventCallbacks> /* callbacks */) override
     {
         return nullptr;
     }

--- a/tools/cli/NearObjectCliHandler.cxx
+++ b/tools/cli/NearObjectCliHandler.cxx
@@ -35,8 +35,8 @@ try {
             controlFlowContext->OperationSignalComplete();
         }
     });
-    auto session = uwbDevice->CreateSession(callbacks);
-    session->Configure(rangingParameters.sessionId, rangingParameters.appConfigParams);
+    auto session = uwbDevice->CreateSession(rangingParameters.sessionId, callbacks);
+    session->Configure(rangingParameters.appConfigParams);
     session->StartRanging();
 } catch (...) {
     PLOG_ERROR << "failed to start ranging";
@@ -51,8 +51,8 @@ try {
             controlFlowContext->OperationSignalComplete();
         }
     });
-    auto session = uwbDevice->CreateSession(callbacks);
-    session->Configure(sessionData.sessionId, uwb::protocol::fira::GetUciConfigParams(sessionData.uwbConfiguration, session->GetDeviceType()));
+    auto session = uwbDevice->CreateSession(sessionData.sessionId, callbacks);
+    session->Configure(uwb::protocol::fira::GetUciConfigParams(sessionData.uwbConfiguration, session->GetDeviceType()));
     session->StartRanging();
 } catch (...) {
     PLOG_ERROR << "failed to start ranging";

--- a/windows/devices/uwb/UwbDevice.cxx
+++ b/windows/devices/uwb/UwbDevice.cxx
@@ -44,9 +44,9 @@ UwbDevice::DeviceName() const noexcept
 }
 
 std::shared_ptr<uwb::UwbSession>
-UwbDevice::CreateSessionImpl(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks)
+UwbDevice::CreateSessionImpl(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks)
 {
-    return std::make_shared<UwbSession>(std::move(callbacks), m_uwbDeviceConnector);
+    return std::make_shared<UwbSession>(sessionId, std::move(callbacks), m_uwbDeviceConnector);
 }
 
 UwbCapability

--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -77,6 +77,8 @@ UwbSession::ConfigureImpl(const uint32_t sessionId, const std::vector<::uwb::pro
     UwbSessionType sessionType = UwbSessionType::RangingSession;
 
     // Request a new session from the driver.
+    m_sessionId = sessionId;
+
     auto sessionInitResultFuture = m_uwbDeviceConnector->SessionInitialize(sessionId, sessionType);
     if (!sessionInitResultFuture.valid()) {
         PLOG_ERROR << "failed to initialize session";
@@ -88,8 +90,6 @@ UwbSession::ConfigureImpl(const uint32_t sessionId, const std::vector<::uwb::pro
         LOG_ERROR << "failed to initialize session, " << ToString(statusSessionInit);
         throw UwbException(statusSessionInit);
     }
-
-    m_sessionId = sessionId;
 
     // Set the application configuration parameters for the session.
     auto setAppConfigParamsFuture = m_uwbDeviceConnector->SetApplicationConfigurationParameters(sessionId, configParams);

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
@@ -65,11 +65,12 @@ private:
     /**
      * @brief Create a new UWB session.
      *
+     * @param sessionId
      * @param callbacks The event callback instance.
      * @return std::shared_ptr<uwb::UwbSession>
      */
     virtual std::shared_ptr<::uwb::UwbSession>
-    CreateSessionImpl(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks) override;
+    CreateSessionImpl(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks) override;
 
     /**
      * @brief Get the capabilities of the device.

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
@@ -25,20 +25,20 @@ public:
      * @brief Construct a new UwbSession object.
      * This also registers the callbacks with the UwbDeviceConnector
      *
+     * @param sessionId
      * @param callbacks The event callback instance.
      * @param uwbDeviceConnector The connector to the UWB-CX driver instance.
      */
-    UwbSession(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, std::shared_ptr<UwbDeviceConnector> uwbDeviceConnector, ::uwb::protocol::fira::DeviceType deviceType = ::uwb::protocol::fira::DeviceType::Controller);
+    UwbSession(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, std::shared_ptr<UwbDeviceConnector> uwbDeviceConnector, ::uwb::protocol::fira::DeviceType deviceType = ::uwb::protocol::fira::DeviceType::Controller);
 
 private:
     /**
      * @brief Configure the session for use.
      *
-     * @param sessionId
      * @param uwbSessionData The session data to configure the session with.
      */
     virtual void
-    ConfigureImpl(const uint32_t sessionId, const std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> configParams) override;
+    ConfigureImpl(const std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> configParams) override;
 
     /**
      * @brief Start ranging.

--- a/windows/devices/uwbsimulator/UwbDeviceSimulator.cxx
+++ b/windows/devices/uwbsimulator/UwbDeviceSimulator.cxx
@@ -36,9 +36,9 @@ UwbDeviceSimulator::Initialize()
 }
 
 std::shared_ptr<::uwb::UwbSession>
-UwbDeviceSimulator::CreateSessionImpl(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks)
+UwbDeviceSimulator::CreateSessionImpl(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks)
 {
-    return std::make_shared<UwbSessionSimulator>(std::move(callbacks), m_uwbDeviceConnector, m_uwbDeviceSimulatorConnector);
+    return std::make_shared<UwbSessionSimulator>(sessionId, std::move(callbacks), m_uwbDeviceConnector, m_uwbDeviceSimulatorConnector);
 }
 
 UwbSimulatorCapabilities

--- a/windows/devices/uwbsimulator/UwbSessionSimulator.cxx
+++ b/windows/devices/uwbsimulator/UwbSessionSimulator.cxx
@@ -3,7 +3,7 @@
 
 using namespace windows::devices::uwb::simulator;
 
-UwbSessionSimulator::UwbSessionSimulator(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, std::shared_ptr<UwbDeviceConnector> uwbDeviceConnector, std::shared_ptr<UwbDeviceSimulatorConnector> uwbDeviceSimulatorConnector) :
-    UwbSession(std::move(callbacks), std::move(uwbDeviceConnector)),
+UwbSessionSimulator::UwbSessionSimulator(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, std::shared_ptr<UwbDeviceConnector> uwbDeviceConnector, std::shared_ptr<UwbDeviceSimulatorConnector> uwbDeviceSimulatorConnector) :
+    UwbSession(sessionId, std::move(callbacks), std::move(uwbDeviceConnector)),
     m_uwbDeviceSimulatorConnector(std::move(uwbDeviceSimulatorConnector))
 {}

--- a/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbDeviceSimulator.hxx
+++ b/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbDeviceSimulator.hxx
@@ -61,7 +61,7 @@ public:
 
 private:
     virtual std::shared_ptr<::uwb::UwbSession>
-    CreateSessionImpl(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks) override;
+    CreateSessionImpl(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks) override;
 
 private:
     const std::string m_deviceName;

--- a/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbSessionSimulator.hxx
+++ b/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbSessionSimulator.hxx
@@ -18,7 +18,7 @@ class UwbSessionSimulator :
     public windows::devices::uwb::UwbSession
 {
 public:
-    UwbSessionSimulator(std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, std::shared_ptr<UwbDeviceConnector> uwbDeviceConnector, std::shared_ptr<UwbDeviceSimulatorConnector> uwbDeviceSimulatorConnector);
+    UwbSessionSimulator(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, std::shared_ptr<UwbDeviceConnector> uwbDeviceConnector, std::shared_ptr<UwbDeviceSimulatorConnector> uwbDeviceSimulatorConnector);
 
     virtual ~UwbSessionSimulator() = default;
 


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [X] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [X] Infrastructure

### Goals
Bug description:
CreateSession initializes the session with a default sessionId and inserts the session object into UwbDevice::m_sessions map. Then the sessionId is set after Configure has been called on it, but we never update the UwbDevice::m_sessions map with the new mapping

This PR makes the following changes to fix:
* provide the requested sessionId in the CreateSession command, which would mean the session would be inserted properly into the m_sessions map. 
* the Configure command would just take in the appConfigParams

### Test Results

None yet


### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
