### PR TITLE
Implement conversion functions for UWB_SET_APP_CONFIG_PARAMS

### DIFF
--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -574,6 +574,14 @@ struct UwbApplicationConfigurationParameter
 
     bool
     operator==(const UwbApplicationConfigurationParameter&) const noexcept = default;
+
+    /**
+     * @brief Returns a string representation of the object.
+     * 
+     * @return std::string 
+     */
+    std::string
+    ToString() const;
 };
 
 struct UwbMulticastListStatus
@@ -733,6 +741,15 @@ ToString(const UwbStatus& uwbStatus);
  */
 std::string
 ToString(const UwbNotificationData& uwbNotificationData);
+
+/**
+ * @brief Returns a string representation of the object.
+ * 
+ * @param uwbApplicationConfigurationParameterValue 
+ * @return std::string 
+ */
+std::string
+ToString(const UwbApplicationConfigurationParameterValue &uwbApplicationConfigurationParameterValue);
 
 } // namespace uwb::protocol::fira
 

--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -266,7 +266,7 @@ enum class ResultReportConfiguration : uint8_t {
  * @return std::string
  */
 std::string
-ResultReportConfigurationToString(const std::unordered_set<ResultReportConfiguration>& resultReportConfiguration);
+ToString(const std::unordered_set<ResultReportConfiguration>& resultReportConfiguration);
 
 /**
  * @brief Converts a string to vector of ResultReportConfiguration.

--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -577,8 +577,8 @@ struct UwbApplicationConfigurationParameter
 
     /**
      * @brief Returns a string representation of the object.
-     * 
-     * @return std::string 
+     *
+     * @return std::string
      */
     std::string
     ToString() const;
@@ -744,12 +744,12 @@ ToString(const UwbNotificationData& uwbNotificationData);
 
 /**
  * @brief Returns a string representation of the object.
- * 
- * @param uwbApplicationConfigurationParameterValue 
- * @return std::string 
+ *
+ * @param uwbApplicationConfigurationParameterValue
+ * @return std::string
  */
 std::string
-ToString(const UwbApplicationConfigurationParameterValue &uwbApplicationConfigurationParameterValue);
+ToString(const UwbApplicationConfigurationParameterValue& uwbApplicationConfigurationParameterValue);
 
 } // namespace uwb::protocol::fira
 

--- a/lib/uwb/protocols/fira/FiraDevice.cxx
+++ b/lib/uwb/protocols/fira/FiraDevice.cxx
@@ -70,7 +70,7 @@ uwb::protocol::fira::StringToVersion(const std::string& input) noexcept
 }
 
 std::string
-uwb::protocol::fira::ResultReportConfigurationToString(const std::unordered_set<ResultReportConfiguration>& input)
+uwb::protocol::fira::ToString(const std::unordered_set<ResultReportConfiguration>& input)
 {
     return std::transform_reduce(
         std::cbegin(input),

--- a/lib/uwb/protocols/fira/FiraDevice.cxx
+++ b/lib/uwb/protocols/fira/FiraDevice.cxx
@@ -258,3 +258,34 @@ uwb::protocol::fira::IsUwbStatusOk(const UwbStatus& uwbStatus) noexcept
     const auto* status = std::get_if<UwbStatusGeneric>(&uwbStatus);
     return (status != nullptr) && (*status == UwbStatusGeneric::Ok);
 }
+
+std::string
+UwbApplicationConfigurationParameter::ToString() const
+{
+    std::ostringstream ss{};
+    ss << magic_enum::enum_name(Type) << ": " << ::ToString(Value);
+    return ss.str();
+}
+
+/**
+ * @brief Returns a string representation of the object.
+ *
+ * @param uwbApplicationConfigurationParameterValue
+ * @return std::string
+ */
+std::string
+uwb::protocol::fira::ToString(const UwbApplicationConfigurationParameterValue& uwbApplicationConfigurationParameterValue)
+{
+    std::ostringstream ss{};
+    std::visit([&](auto&& arg) {
+        using T = std::decay_t<decltype(arg)>;
+        if constexpr (std::is_enum_v<T>) {
+            ss << magic_enum::enum_name(arg);
+        } else if constexpr (std::is_integral_v<T> || std::is_same_v<T, ::uwb::UwbMacAddress>) {
+            ss << arg;
+        }
+    },
+        uwbApplicationConfigurationParameterValue);
+
+    return ss.str();
+}

--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -628,4 +628,23 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
         };
         test::ValidateRoundtrip(uwbGetApplicationConfigurationParameters);
     }
+
+    SECTION("UwbSetApplicationConfigurationParameters is stable")
+    {
+        const UwbSetApplicationConfigurationParameters uwbSetApplicationConfigurationParameters{
+            .SessionId = test::GetRandom<uint32_t>(),
+            .Parameters{
+                parameterHoppingMode,
+                parameterNumberOfControlees,
+                parameterSlotDuration,
+                parameterRangingInterval,
+                parameterAoaResult,
+                parameterStaticStsInitializationVector,
+                parameterResultReportConfig,
+                parameterUwbMacAddressShort,
+                parameterUwbMacAddressExtended,
+            }
+        };
+        test::ValidateRoundtrip(uwbSetApplicationConfigurationParameters);
+    }
 }

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -381,7 +381,7 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App* parent)
                 if constexpr (std::is_enum_v<ParameterValueT>) {
                     std::cout << magic_enum::enum_type_name<ParameterValueT>() << "::" << magic_enum::enum_name(arg) << std::endl;
                 } else if constexpr (std::is_same_v<ParameterValueT, std::unordered_set<uwb::protocol::fira::ResultReportConfiguration>>) {
-                    std::cout << "ResultReportConfigurations: " << uwb::protocol::fira::ResultReportConfigurationToString(arg) << std::endl;
+                    std::cout << "ResultReportConfigurations: " << uwb::protocol::fira::ToString(arg) << std::endl;
                 }
             },
                 parameterValue);

--- a/tools/cli/NearObjectCliHandler.cxx
+++ b/tools/cli/NearObjectCliHandler.cxx
@@ -57,8 +57,13 @@ try {
             controlFlowContext->OperationSignalComplete();
         }
     });
-    auto session = uwbDevice->CreateSession(sessionData.sessionId, callbacks);
-    session->Configure(uwb::protocol::fira::GetUciConfigParams(sessionData.uwbConfiguration, session->GetDeviceType()));
+    auto session = uwbDevice->CreateSession(callbacks);
+    session->Configure(sessionData.sessionId, uwb::protocol::fira::GetUciConfigParams(sessionData.uwbConfiguration, session->GetDeviceType()));
+    auto applicationConfigurationParameters = session->GetApplicationConfigurationParameters();
+    PLOG_DEBUG << "Session Application Configuration Parameters: ";
+    for (const auto &applicationConfigurationParameter : applicationConfigurationParameters) {
+        PLOG_DEBUG << " > " << applicationConfigurationParameter.ToString();
+    }
     session->StartRanging();
 } catch (...) {
     PLOG_ERROR << "failed to start ranging";

--- a/tools/cli/NearObjectCliHandler.cxx
+++ b/tools/cli/NearObjectCliHandler.cxx
@@ -40,7 +40,7 @@ try {
     session->Configure(rangingParameters.appConfigParams);
     auto applicationConfigurationParameters = session->GetApplicationConfigurationParameters();
     PLOG_DEBUG << "Session Application Configuration Parameters: ";
-    for (const auto &applicationConfigurationParameter : applicationConfigurationParameters) {
+    for (const auto& applicationConfigurationParameter : applicationConfigurationParameters) {
         PLOG_DEBUG << " > " << applicationConfigurationParameter.ToString();
     }
     session->StartRanging();
@@ -61,7 +61,7 @@ try {
     session->Configure(sessionData.sessionId, uwb::protocol::fira::GetUciConfigParams(sessionData.uwbConfiguration, session->GetDeviceType()));
     auto applicationConfigurationParameters = session->GetApplicationConfigurationParameters();
     PLOG_DEBUG << "Session Application Configuration Parameters: ";
-    for (const auto &applicationConfigurationParameter : applicationConfigurationParameters) {
+    for (const auto& applicationConfigurationParameter : applicationConfigurationParameters) {
         PLOG_DEBUG << " > " << applicationConfigurationParameter.ToString();
     }
     session->StartRanging();

--- a/tools/cli/NearObjectCliHandler.cxx
+++ b/tools/cli/NearObjectCliHandler.cxx
@@ -7,6 +7,7 @@
 #include <uwb/protocols/fira/UwbException.hxx>
 #include <uwb/protocols/fira/UwbOobConversions.hxx>
 
+#include <magic_enum.hpp>
 #include <plog/Log.h>
 
 using namespace nearobject::cli;
@@ -37,6 +38,11 @@ try {
     });
     auto session = uwbDevice->CreateSession(rangingParameters.sessionId, callbacks);
     session->Configure(rangingParameters.appConfigParams);
+    auto applicationConfigurationParameters = session->GetApplicationConfigurationParameters();
+    PLOG_DEBUG << "Session Application Configuration Parameters: ";
+    for (const auto &applicationConfigurationParameter : applicationConfigurationParameters) {
+        PLOG_DEBUG << " > " << applicationConfigurationParameter.ToString();
+    }
     session->StartRanging();
 } catch (...) {
     PLOG_ERROR << "failed to start ranging";

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -1359,10 +1359,12 @@ windows::devices::uwb::ddi::lrp::To(const UWB_SET_APP_CONFIG_PARAMS &setApplicat
     };
     uwbSetApplicationConfigurationParameters.Parameters.reserve(setApplicationConfigurationParameters.appConfigParamsCount);
 
-    std::span applicationConfigurationParameters(setApplicationConfigurationParameters.appConfigParams, setApplicationConfigurationParameters.appConfigParamsCount);
-    std::ranges::transform(applicationConfigurationParameters, std::back_inserter(uwbSetApplicationConfigurationParameters.Parameters), [](const auto &applicationConfigurationParameter) {
-        return To(applicationConfigurationParameter);
-    });
+    auto *appConfigParam = reinterpret_cast<const UWB_APP_CONFIG_PARAM *>(&setApplicationConfigurationParameters.appConfigParams[0]);
+    for (auto i = 0; i < setApplicationConfigurationParameters.appConfigParamsCount; i++) {
+        auto uwbAppConfigParam = To(*appConfigParam);
+        uwbSetApplicationConfigurationParameters.Parameters.push_back(std::move(uwbAppConfigParam));
+        appConfigParam = reinterpret_cast<const UWB_APP_CONFIG_PARAM *>(reinterpret_cast<uintptr_t>(appConfigParam) + appConfigParam->size);
+    }
 
     return std::move(uwbSetApplicationConfigurationParameters);
 }

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -569,6 +569,42 @@ windows::devices::uwb::ddi::lrp::From(const UwbGetApplicationConfigurationParame
     return std::move(getApplicationConfigurationParameterTypesWrapper);
 }
 
+UwbSetApplicationConfigurationParametersWrapper
+windows::devices::uwb::ddi::lrp::From(const UwbSetApplicationConfigurationParameters &uwbSetApplicationConfigurationParameters)
+{
+    // Convert each individual parameter to its DDI wrapper.
+    std::vector<UwbApplicationConfigurationParameterWrapper> uwbApplicationConfigurationParameterWrappers{};
+    std::ranges::transform(uwbSetApplicationConfigurationParameters.Parameters, std::back_inserter(uwbApplicationConfigurationParameterWrappers), [](const auto &uwbApplicationConfigurationParameter) {
+        return From(uwbApplicationConfigurationParameter);
+    });
+
+    // Calculate the total size required for the UWB_APP_CONFIG_PARAMS instance.
+    const std::size_t totalSize = std::accumulate(
+        std::cbegin(uwbApplicationConfigurationParameterWrappers),
+        std::cend(uwbApplicationConfigurationParameterWrappers),
+        static_cast<std::size_t>(offsetof(UWB_SET_APP_CONFIG_PARAMS, appConfigParams[0])),
+        [&](std::size_t totalSize, const auto &uwbApplicationConfigurationParameterWrapper) {
+            return totalSize + std::size(uwbApplicationConfigurationParameterWrapper);
+        });
+
+    // Instantiate a wrapper for UWB_SET_APP_CONFIG_PARAMS and fill it in.
+    UwbSetApplicationConfigurationParametersWrapper setApplicationConfigurationParametersWrapper{ totalSize };
+    UWB_SET_APP_CONFIG_PARAMS &setAppConfigParams = setApplicationConfigurationParametersWrapper.value();
+    setAppConfigParams.size = totalSize;
+    setAppConfigParams.sessionId = uwbSetApplicationConfigurationParameters.SessionId;
+    setAppConfigParams.appConfigParamsCount = std::size(uwbApplicationConfigurationParameterWrappers);
+
+    // Copy each of the converted UWB_APP_CONFIG_PARAM values into the UWB_SET_APP_CONFIG_PARAMS flex-array.
+    UWB_APP_CONFIG_PARAM *appConfigParam = reinterpret_cast<UWB_APP_CONFIG_PARAM *>(&setAppConfigParams.appConfigParams[0]);
+    for (auto &uwbApplicationConfigurationParameterWrapper : uwbApplicationConfigurationParameterWrappers) {
+        UWB_APP_CONFIG_PARAM &uwbAppConfigParam = uwbApplicationConfigurationParameterWrapper.value();
+        std::memcpy(appConfigParam, &uwbAppConfigParam, uwbAppConfigParam.size);
+        appConfigParam = reinterpret_cast<UWB_APP_CONFIG_PARAM *>(reinterpret_cast<uintptr_t>(appConfigParam) + appConfigParam->size);
+    }
+
+    return std::move(setApplicationConfigurationParametersWrapper);
+}
+
 UwbApplicationConfigurationParameterWrapper
 windows::devices::uwb::ddi::lrp::From(const UwbApplicationConfigurationParameter &uwbApplicationConfigurationParameter)
 {

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -1315,6 +1315,22 @@ windows::devices::uwb::ddi::lrp::To(const UWB_GET_APP_CONFIG_PARAMS &getApplicat
     return std::move(uwbGetApplicationConfigurationParameters);
 }
 
+UwbSetApplicationConfigurationParameters
+windows::devices::uwb::ddi::lrp::To(const UWB_SET_APP_CONFIG_PARAMS &setApplicationConfigurationParameters)
+{
+    UwbSetApplicationConfigurationParameters uwbSetApplicationConfigurationParameters{
+        .SessionId = setApplicationConfigurationParameters.sessionId
+    };
+    uwbSetApplicationConfigurationParameters.Parameters.reserve(setApplicationConfigurationParameters.appConfigParamsCount);
+
+    std::span applicationConfigurationParameters(setApplicationConfigurationParameters.appConfigParams, setApplicationConfigurationParameters.appConfigParamsCount);
+    std::ranges::transform(applicationConfigurationParameters, std::back_inserter(uwbSetApplicationConfigurationParameters.Parameters), [](const auto &applicationConfigurationParameter) {
+        return To(applicationConfigurationParameter);
+    });
+
+    return std::move(uwbSetApplicationConfigurationParameters);
+}
+
 namespace detail
 {
 /**

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -266,13 +266,33 @@ struct UwbGetApplicationConfigurationParameters
 using UwbGetApplicationConfigurationParametersWrapper = notstd::flextype_wrapper<UWB_GET_APP_CONFIG_PARAMS>;
 
 /**
- * @brief Converts a list of UwbApplicationConfigurationParameterType to UWB_GET_APP_CONFIG_PARAMS.
+ * @brief Converts UwbGetApplicationConfigurationParameters to UWB_GET_APP_CONFIG_PARAMS.
  *
- * @param uwbApplicationConfigurationParameterTypes
+ * @param uwbGetApplicationConfigurationParameters
  * @return UwbGetApplicationConfigurationParametersWrapper
  */
 UwbGetApplicationConfigurationParametersWrapper
 From(const UwbGetApplicationConfigurationParameters &uwbGetApplicationConfigurationParameters);
+
+/**
+ * @brief Neutral type for the UWB_SET_APP_CONFIG_PARAMS DDI structure.
+ */
+struct UwbSetApplicationConfigurationParameters
+{
+    uint32_t SessionId;
+    std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> Parameters;
+};
+
+using UwbSetApplicationConfigurationParametersWrapper = notstd::flextype_wrapper<UWB_SET_APP_CONFIG_PARAMS>;
+
+/**
+ * @brief
+ *
+ * @param uwbSetApplicationConfigurationParameters
+ * @return UwbSetApplicationConfigurationParametersWrapper
+ */
+UwbSetApplicationConfigurationParametersWrapper
+From(const UwbSetApplicationConfigurationParameters &uwbSetApplicationConfigurationParameters);
 
 using UwbApplicationConfigurationParameterWrapper = notstd::flextype_wrapper<UWB_APP_CONFIG_PARAM>;
 
@@ -519,6 +539,15 @@ To(const UWB_NOTIFICATION_DATA &notificationData);
  */
 UwbGetApplicationConfigurationParameters
 To(const UWB_GET_APP_CONFIG_PARAMS &getApplicationConfigurationParameters);
+
+/**
+ * @brief Converts UWB_SET_APP_CONFIG_PARAMS to UwbSetApplicationConfigurationParameters.
+ *
+ * @param setApplicationConfigurationParameters
+ * @return UwbSetApplicationConfigurationParameters
+ */
+UwbSetApplicationConfigurationParameters
+To(const UWB_SET_APP_CONFIG_PARAMS &setApplicationConfigurationParameters);
 
 /**
  * @brief Converts UWB_APP_CONFIG_PARAM to UwbApplicationConfigurationParameter.

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -281,6 +281,9 @@ struct UwbSetApplicationConfigurationParameters
 {
     uint32_t SessionId;
     std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> Parameters;
+
+    auto
+    operator<=>(const UwbSetApplicationConfigurationParameters &) const noexcept = default;
 };
 
 using UwbSetApplicationConfigurationParametersWrapper = notstd::flextype_wrapper<UWB_SET_APP_CONFIG_PARAMS>;


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

* Ensure application parameters can be set for a session.

### Technical Details

* Add `UwbSetApplicationConfigurationParameters` wrapper representing `UWB_SET_APP_CONFIG_PARAMS`.
* Add neutral <-> DDI conversion functions for `UwbSetApplicationConfigurationParameters` (most code taken from #166 by @corbin-phipps)
* Add `ToString()` functions for `UwbApplicationConfigurationParameter`.
* Debug-print app configuration values prior to starting ranging via `nocli`.
* Rename `ToString()` function for `ResultReportConfiguration` to be consistent with existing naming.

### Test Results

* New unit test for `UwbSetApplicationConfigurationParameters` is currently failing, all other tests are passing. The test is failing because the `UWB_SET_APP_CONFIG_PARAMS::appConfigParam[]` values after index 0 are becoming corrupted. This occurs around `UwbCxAdapterDdiLrp.cxx:598-603`.

### Reviewer Focus

Consider why the conversion function corrupts all but the first `appConfigParam` in the `UWB_SET_APP_CONFIG_PARAMS` instance. The array element size calculation is certainly going wrong somewhere.

### Future Work

???

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
