### PR TITLE
Separate driver and service testing functionality in nocli

### DIFF
--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -42,12 +42,6 @@ std::optional<uint32_t>
 StringToVersion(const std::string& input) noexcept;
 
 /**
- * @brief See FiRa Consortium - UCI Generic Specification v1.1.0, Section 8.3,
- * Table 29, 'APP Configuration Parameter IDs'.
- */
-constexpr auto MaxNumberOfControlees = 8;
-
-/**
  * @brief See FiRa Consortium MAC Technical Requirements v1.3.0,
  * Section D.1.8 STS, Figure 19, page 70.
  */

--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -42,6 +42,12 @@ std::optional<uint32_t>
 StringToVersion(const std::string& input) noexcept;
 
 /**
+ * @brief See FiRa Consortium - UCI Generic Specification v1.1.0, Section 8.3,
+ * Table 29, 'APP Configuration Parameter IDs'.
+ */
+constexpr auto MaxNumberOfControlees = 8;
+
+/**
  * @brief See FiRa Consortium MAC Technical Requirements v1.3.0,
  * Section D.1.8 STS, Figure 19, page 70.
  */

--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -554,6 +554,15 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
         .Value = std::move(uwbMacAddressExtended),
     };
 
+    // UWB_APP_CONFIG_PARAM_TYPE_DST_MAC_ADDRESS (single address)
+    const std::unordered_set<::uwb::UwbMacAddress> uwbMacAddressSetSingleAddress{
+        std::array<uint8_t, ::uwb::UwbMacAddressLength::Short>{ 0xAA, 0xBB },
+    };
+    const UwbApplicationConfigurationParameter parameterUwbMacAddressSetSingleAddress = {
+        .Type = UwbApplicationConfigurationParameterType::DestinationMacAddresses,
+        .Value = std::move(uwbMacAddressSetSingleAddress),
+    };
+
     constexpr auto uwbApplicationConfigurationParameterTypesAll = magic_enum::enum_values<UwbApplicationConfigurationParameterType>();
 
     SECTION("UwbApplicationConfigurationParameter bool variant is stable")
@@ -599,6 +608,11 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
     SECTION("UwbApplicationConfigurationParameter ::uwb::UwbMacAddress (extended type) is stable")
     {
         test::ValidateRoundtrip(parameterUwbMacAddressExtended);
+    }
+
+    SECTION("UwbApplicationConfigurationParameter std::unordered_set<::uwb::UwbMacAddress> (single address) is stable")
+    {
+        test::ValidateRoundtrip(parameterUwbMacAddressSetSingleAddress);
     }
 
     SECTION("std::vector<UwbApplicationConfigurationParameter> is stable")

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -404,11 +404,8 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App* parent)
             if (m_cliData->appConfigParamsData.numberOfControlees != 1) {
                 std::cerr << "Only 1 controlee expected in Unicast mode" << std::endl;
             }
-        } else {
-            if (m_cliData->appConfigParamsData.numberOfControlees < 1 || m_cliData->appConfigParamsData.numberOfControlees > MaxNumberOfControlees) {
-                std::cerr << "Invalid number of controlees. Must be 1 <= N <= 8" << std::endl;
-            }
         }
+
         // Set MAC addresses
         const auto macAddressType = m_cliData->appConfigParamsData.macAddressMode == uwb::UwbMacAddressType::Extended ? uwb::UwbMacAddressType::Extended : uwb::UwbMacAddressType::Short;
 

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -395,7 +395,7 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App* parent)
 
     detail::AddEnumOption(rangeStartApp, appConfigParamsData.deviceType, true);
 
-    rangeStartApp->parse_complete_callback([this] {
+    rangeStartApp->parse_complete_callback([this, rangeStartApp] {
         // TODO: Move validation logic into its own function
 
         // Validate NumberOfControlees
@@ -436,6 +436,8 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App* parent)
         m_cliData->RangingParameters.appConfigParams.push_back({ uwb::protocol::fira::UwbApplicationConfigurationParameterType::DeviceMacAddress, m_cliData->appConfigParamsData.deviceMacAddress.value() });
         m_cliData->RangingParameters.appConfigParams.push_back({ uwb::protocol::fira::UwbApplicationConfigurationParameterType::DestinationMacAddresses, m_cliData->appConfigParamsData.destinationMacAddresses.value() });
         m_cliData->RangingParameters.appConfigParams.push_back({ uwb::protocol::fira::UwbApplicationConfigurationParameterType::DeviceType, m_cliData->appConfigParamsData.deviceType.value() });
+
+        RegisterCliAppWithOperation(rangeStartApp);
     });
 
     rangeStartApp->final_callback([this] {

--- a/tools/cli/NearObjectCliHandler.cxx
+++ b/tools/cli/NearObjectCliHandler.cxx
@@ -36,8 +36,8 @@ try {
             controlFlowContext->OperationSignalComplete();
         }
     });
-    auto session = uwbDevice->CreateSession(rangingParameters.sessionId, callbacks);
-    session->Configure(rangingParameters.appConfigParams);
+    auto session = uwbDevice->CreateSession(rangingParameters.SessionId, callbacks);
+    session->Configure(rangingParameters.ApplicationConfigurationParameters);
     auto applicationConfigurationParameters = session->GetApplicationConfigurationParameters();
     PLOG_DEBUG << "Session Application Configuration Parameters: ";
     for (const auto& applicationConfigurationParameter : applicationConfigurationParameters) {

--- a/tools/cli/include/nearobject/cli/NearObjectCli.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCli.hxx
@@ -88,12 +88,20 @@ public:
     GetUwbApp() noexcept;
 
     /**
+     * @brief Get the app object associated with the "service" sub-command.
+     *
+     * @return CLI::App&
+     */
+    CLI::App&
+    GetServiceApp() noexcept;
+
+    /**
      * @brief Get the app object associated with the "uwb range" sub-command.
      *
      * @return CLI::App&
      */
     CLI::App&
-    GetRangeApp() noexcept;
+    GetUwbRangeApp() noexcept;
 
     /**
      * @brief Get the app object associated with the "uwb raw" sub-command.
@@ -101,7 +109,7 @@ public:
      * @return CLI::App&
      */
     CLI::App&
-    GetRawApp() noexcept;
+    GetUwbRawApp() noexcept;
 
     /**
      * @brief Get the app object associated with the "uwb range start" sub-command.
@@ -109,7 +117,7 @@ public:
      * @return CLI::App&
      */
     CLI::App&
-    GetRangeStartApp() noexcept;
+    GetUwbRangeStartApp() noexcept;
 
     /**
      * @brief Get the app object associated with the "uwb range stop" sub-command.
@@ -117,7 +125,31 @@ public:
      * @return CLI::App&
      */
     CLI::App&
-    GetRangeStopApp() noexcept;
+    GetUwbRangeStopApp() noexcept;
+
+    /**
+     * @brief Get the app object associated with the "service range" sub-command.
+     *
+     * @return CLI::App&
+     */
+    CLI::App&
+    GetServiceRangeApp() noexcept;
+
+    /**
+     * @brief Get the app object associated with the "service range start" sub-command.
+     *
+     * @return CLI::App&
+     */
+    CLI::App&
+    GetServiceRangeStartApp() noexcept;
+
+    /**
+     * @brief Get the app object associated with the "service range stop" sub-command.
+     *
+     * @return CLI::App&
+     */
+    CLI::App&
+    GetServiceRangeStopApp() noexcept;
 
 private:
     /**
@@ -173,6 +205,15 @@ private:
     AddSubcommandUwb(CLI::App* parent);
 
     /**
+     * @brief Add the 'service' sub-command.
+     *
+     * @param parent The parent app to add the command to.
+     * @return CLI::App*
+     */
+    CLI::App*
+    AddSubcommandService(CLI::App* parent);
+
+    /**
      * @brief Add the 'uwb monitor' sub-command.
      *
      * @param parent The parent app to add the command to.
@@ -180,6 +221,15 @@ private:
      */
     CLI::App*
     AddSubcommandUwbMonitor(CLI::App* parent);
+
+    /**
+     * @brief Add the 'uwb raw' sub-command.
+     *
+     * @param parent The parent app to add the command to.
+     * @return CLI::App*
+     */
+    CLI::App*
+    AddSubcommandUwbRaw(CLI::App* parent);
 
     /**
      * @brief Add the 'uwb range' sub-command.
@@ -191,13 +241,31 @@ private:
     AddSubcommandUwbRange(CLI::App* parent);
 
     /**
-     * @brief Add the 'uwb raw' sub-command.
+     * @brief Add the 'service range' sub-command.
      *
      * @param parent The parent app to add the command to.
      * @return CLI::App*
      */
     CLI::App*
-    AddSubcommandUwbRaw(CLI::App* parent);
+    AddSubcommandServiceRange(CLI::App* parent);
+
+    /**
+     * @brief Add the 'uwb raw devicereset' sub-command.
+     *
+     * @param parent The parent app to add the command to.
+     * @return CLI::App*
+     */
+    CLI::App*
+    AddSubcommandUwbRawDeviceReset(CLI::App* parent);
+
+    /**
+     * @brief Add the 'uwb raw getdeviceinfo' sub-command.
+     *
+     * @param parent The parent app to add the command to.
+     * @return CLI::App*
+     */
+    CLI::App*
+    AddSubcommandUwbRawGetDeviceInfo(CLI::App* parent);
 
     /**
      * @brief Add the 'uwb range start' sub-command.
@@ -218,22 +286,22 @@ private:
     AddSubcommandUwbRangeStop(CLI::App* parent);
 
     /**
-     * @brief Add the 'uwb raw devicereset' sub-command.
+     * @brief Add the 'service range start' sub-command.
      *
-     * @param parent The parent app to add the command to.
+     * @param parent
      * @return CLI::App*
      */
     CLI::App*
-    AddSubcommandUwbRawDeviceReset(CLI::App* parent);
+    AddSubcommandServiceRangeStart(CLI::App* parent);
 
     /**
-     * @brief Add the 'uwb raw getdeviceinfo' sub-command.
+     * @brief Add the 'service range stop' sub-command.
      *
      * @param parent The parent app to add the command to.
      * @return CLI::App*
      */
     CLI::App*
-    AddSubcommandUwbRawGetDeviceInfo(CLI::App* parent);
+    AddSubcommandServiceRangeStop(CLI::App* parent);
 
 private:
     std::shared_ptr<NearObjectCliData> m_cliData;
@@ -244,11 +312,15 @@ private:
     std::unique_ptr<CLI::App> m_cliApp;
     // The following are helper references to the subcommands of m_cliApp, the memory is managed by CLI11.
     CLI::App* m_uwbApp;
+    CLI::App* m_serviceApp;
     CLI::App* m_monitorApp;
-    CLI::App* m_rangeApp;
-    CLI::App* m_rawApp;
-    CLI::App* m_rangeStartApp;
-    CLI::App* m_rangeStopApp;
+    CLI::App* m_uwbRawApp;
+    CLI::App* m_uwbRangeApp;
+    CLI::App* m_serviceRangeApp;
+    CLI::App* m_uwbRangeStartApp;
+    CLI::App* m_uwbRangeStopApp;
+    CLI::App* m_serviceRangeStartApp;
+    CLI::App* m_serviceRangeStopApp;
 };
 } // namespace nearobject::cli
 

--- a/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
@@ -18,8 +18,8 @@ namespace nearobject::cli
  */
 struct UwbRangingParameters
 {
-    uint32_t sessionId;
-    std::vector<uwb::protocol::fira::UwbApplicationConfigurationParameter> appConfigParams;
+    uint32_t SessionId;
+    std::vector<uwb::protocol::fira::UwbApplicationConfigurationParameter> ApplicationConfigurationParameters;
 };
 
 /**

--- a/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
@@ -14,6 +14,15 @@
 namespace nearobject::cli
 {
 /**
+ * @brief Helper structure to hold parameters for a ranging session.
+ */
+struct UwbRangingParameters
+{
+    uint32_t sessionId;
+    std::vector<uwb::protocol::fira::UwbApplicationConfigurationParameter> appConfigParams;
+};
+
+/**
  * @brief Helper sturcture for staging UwbConfiguration data fields from CLI
  * input. This is an intermediary structure that allows native use with the
  * CLI11 parsing library.
@@ -68,6 +77,25 @@ struct UwbConfigurationData
 };
 
 /**
+ * @brief Helper structure for staging UwbApplicationConfigurationParameter data fields from CLI
+ * input. This is an intermediary structure that allows native use with the
+ * CLI11 parsing library.
+ */
+struct UwbApplicationConfigurationParameterData
+{
+    // Mirrored properties from UwbApplicationConfigurationParameter data. Any newly added fields
+    // that should be supported from the command-line must also be added here,
+    // along with parsing support in a NearObjectCli instance.
+    std::optional<uwb::protocol::fira::DeviceRole> deviceRole;
+    std::optional<uwb::protocol::fira::MultiNodeMode> multiNodeMode;
+    std::optional<uint8_t> numberOfControlees;
+    std::optional<uwb::UwbMacAddress> deviceMacAddress;
+    std::optional<std::unordered_set<uwb::UwbMacAddress>> destinationMacAddresses;
+    std::optional<uwb::protocol::fira::DeviceType> deviceType;
+    std::optional<uwb::UwbMacAddressType> macAddressMode;
+};
+
+/**
  * @brief Base class for data parsed by NearObjectCli.
  */
 struct NearObjectCliData
@@ -75,11 +103,13 @@ struct NearObjectCliData
     virtual ~NearObjectCliData() = default;
 
     bool HostIsController{ false };
-    std::string deviceMacAddress{};
-    std::string destinationMacAddress{}; // TODO: List of strings to support multiple controlees
+    std::string deviceMacAddressString;
+    std::string destinationMacAddressString; // TODO: List of strings (or large string of mac address substrings) to support multiple controlees
     UwbConfigurationData uwbConfiguration{};
+    UwbApplicationConfigurationParameterData appConfigParamsData{};
     uwb::protocol::fira::StaticRangingInfo StaticRanging{};
     uwb::protocol::fira::UwbSessionData SessionData{};
+    UwbRangingParameters RangingParameters{};
 };
 
 } // namespace nearobject::cli

--- a/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
@@ -13,16 +13,6 @@
 namespace nearobject::cli
 {
 class NearObjectCli;
-
-/**
- * @brief Structure to hold parameters for a ranging session.
- */
-struct UwbRangingParameters
-{
-    uint32_t sessionId;
-    std::vector<uwb::protocol::fira::UwbApplicationConfigurationParameter> appConfigParams;
-};
-
 /**
  * @brief Class which handles and executes resolved command-line requests. The
  * command line driver will invoke the function associated with the command line

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -644,6 +644,15 @@ windows::devices::uwb::ddi::lrp::From(const UwbApplicationConfigurationParameter
             applicationConfigurationParameterWrapper = std::make_unique<UwbApplicationConfigurationParameterWrapper>(totalSize);
             UWB_APP_CONFIG_PARAM &applicationConfigurationParameter = applicationConfigurationParameterWrapper->value();
             applicationConfigurationParameter.paramValue[0] = value;
+        } else if constexpr (std::is_same_v<T, std::unordered_set<::uwb::UwbMacAddress>>) {
+            // TODO: Get all values from set, not just first one
+            const auto val = *std::begin(arg);
+            const auto value = val.GetValue();
+            parameterLength = std::size(value);
+            totalSize += parameterLength;
+            applicationConfigurationParameterWrapper = std::make_unique<UwbApplicationConfigurationParameterWrapper>(totalSize);
+            UWB_APP_CONFIG_PARAM &applicationConfigurationParameter = applicationConfigurationParameterWrapper->value();
+            std::memcpy(&applicationConfigurationParameter.paramValue[0], std::data(value), parameterLength);
         } else {
             throw std::runtime_error("unknown UwbApplicationConfigurationParameter variant value encountered");
         }

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -1561,6 +1561,13 @@ windows::devices::uwb::ddi::lrp::To(const UWB_APP_CONFIG_PARAM &applicationConfi
         // in some way, but it's unclear how that information would be injected
         // here. Re-visit.
         std::unordered_set<::uwb::UwbMacAddress> value{};
+
+        // TODO: Currently assuming that DST_MAC_ADDRESS is a single, short address.
+        // However, the addresses could be extended and there could be multiple.
+        // Re-visit.
+        ::uwb::UwbMacAddress::ShortType data{};
+        std::memcpy(std::data(data), &applicationConfigurationParameter.paramValue[0], std::size(data));
+        value.insert(::uwb::UwbMacAddress(std::move(data)));
         uwbApplicationConfigurationParameter.Value = std::move(value);
         break;
     }

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -450,8 +450,10 @@ UwbDeviceConnector::SetApplicationConfigurationParameters(uint32_t sessionId, st
         return resultFuture;
     }
 
-    auto paramsDdi = UwbCxDdi::From(applicationConfigurationParameters);
+    UwbCxDdi::UwbSetApplicationConfigurationParameters setAppConfigParams{ sessionId, applicationConfigurationParameters };
+    auto paramsDdi = UwbCxDdi::From(setAppConfigParams);
     auto paramsBuffer = std::data(paramsDdi);
+
     auto statusSize = offsetof(UWB_SET_APP_CONFIG_PARAMS_STATUS, appConfigParamsStatus[std::size(applicationConfigurationParameters)]);
     std::vector<uint8_t> statusBuffer(statusSize);
     BOOL ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_SET_APP_CONFIG_PARAMS, std::data(paramsBuffer), std::size(paramsBuffer), std::data(statusBuffer), statusSize, nullptr, nullptr);


### PR DESCRIPTION
### Type

- [x] Bug fix
- [ ] Feature addition
- [x] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

This PR separates the driver testing functionality (under sub-command 'uwb') from service testing functionality (under new sub-command 'service'). This is necessary for configuring ranging sessions, because users testing drivers will need to set UCI app config params whereas users testing service code will need to set OOB params.

### Technical Details

- Created new top-level sub-command calls 'service'
- Restored original 'range start' code and moved under 'service' (nocli.exe service range start)
- Modified 'range start' code for driver testing and moved under 'uwb' (nocli.exe uwb range start)
- Added structures under NearObjectCliData.hxx for setting mandatory app config params for driver testing
- Added support for unordered_set<UwbMacAddress> in a conversion function in UwbCxAdapterDdiLrp.cxx
- Fixed implementation of UwbDeviceConnector::SetApplicationConfigurationParameters to use new wrapper for UWB_SET_APP_CONFIG_PARAMS

### Test Results

Ran nocli tool for driver testing ('uwb' sub-command) with newest TestClient driver and can successfully invoke necessary IOCTLs for starting a ranging session.

### Reviewer Focus

Note: The current code in HandleDriverStartRanging tries to get the app config params after configuring a session. Because the TestClient driver does not support this (yet!), I had to comment these few lines out in order for nocli to work.

### Future Work

- Need to ensure that stopping the ranging session will trigger StopRanging and SessionDeinit.
- Add rest of UCI app config params support in NearObjectCli.cxx. Currently, only the mandatory app config params are supported
- The code for 'uwb range start' could be improved. For example, the current code manually pushes each of the mandatory app config params into a std::vector<UwbApplicationConfigurationParameter>
- Multicast support (more than one destination MAC address / controlee).

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
