### PR TITLE
Implement more simulator functionality for IOCTL_UWB_{GET|SET}_APP_CONFIG_PARAMS

### DIFF
--- a/lib/uwb/UwbDevice.cxx
+++ b/lib/uwb/UwbDevice.cxx
@@ -80,7 +80,7 @@ UwbDevice::OnSessionStatusChanged(UwbSessionStatus statusSession)
 std::shared_ptr<UwbSession>
 UwbDevice::CreateSession(uint32_t sessionId, std::weak_ptr<UwbSessionEventCallbacks> callbacks)
 {
-    auto session = CreateSessionImpl(sessionId, callbacks);
+    auto session = CreateSessionImpl(sessionId, std::move(callbacks));
     {
         std::unique_lock sessionExclusiveLock{ m_sessionsGate };
         m_sessions[session->GetId()] = std::weak_ptr<UwbSession>(session);

--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -633,7 +633,7 @@ struct UwbSetApplicationConfigurationParameterStatus
     UwbApplicationConfigurationParameterType ParameterType;
 
     auto
-    operator<=>(const UwbSetApplicationConfigurationParameterStatus &) const noexcept = default;
+    operator<=>(const UwbSetApplicationConfigurationParameterStatus&) const noexcept = default;
 };
 
 struct UwbMulticastListStatus

--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <span>
 #include <string>
 #include <unordered_set>
@@ -562,6 +563,14 @@ using UwbApplicationConfigurationParameterValue = std::variant<
     std::unordered_set<::uwb::UwbMacAddress>>; // DST_MAC_ADDRESS, tag 0x07, size 2/8*N
 // clang-format on
 
+constexpr std::array<UwbApplicationConfigurationParameterType, 5> UwbApplicationConfigurationParameterTypesUpdateableWhileActive{
+    UwbApplicationConfigurationParameterType::BlockStrideLength,
+    UwbApplicationConfigurationParameterType::RangingInterval,
+    UwbApplicationConfigurationParameterType::RangeDataNotificationConfig,
+    UwbApplicationConfigurationParameterType::RangeDataNotificationProximityNear,
+    UwbApplicationConfigurationParameterType::RangeDataNotificationProximityFar,
+};
+
 /**
  * @brief Determines whether the specified application configuration parameter
  * (type) is allowed to be updated while a session is in the 'Active' state. 
@@ -573,17 +582,19 @@ using UwbApplicationConfigurationParameterValue = std::variant<
 constexpr bool
 IsApplicationConfigurationParameterChangeableWhileActive(const UwbApplicationConfigurationParameterType& uwbApplicationConfigurationParameterType)
 {
-    // TODO: the UCI spec (section 7.3.1) indicates STATUS_ERROR_SESSION_ACTIVE
-    // will be returned for application configuration parameters 'which are not
-    // allowed to set during the SESSION_STATE_ACTIVE Session State'. However,
-    // it does not list which parameters fall into this case. So for now, the
-    // list here is empty.
-    switch (uwbApplicationConfigurationParameterType) {
-    default:
-        break;
-    }
-
-    return false;
+    return std::ranges::any_of(UwbApplicationConfigurationParameterTypesUpdateableWhileActive, [&](const auto &type){
+        return (type == uwbApplicationConfigurationParameterType);
+    });
+    // switch (uwbApplicationConfigurationParameterType) {
+    // case UwbApplicationConfigurationParameterType::BlockStrideLength:
+    // case UwbApplicationConfigurationParameterType::RangingInterval:
+    // case UwbApplicationConfigurationParameterType::RangeDataNotificationConfig:
+    // case UwbApplicationConfigurationParameterType::RangeDataNotificationProximityNear:
+    // case UwbApplicationConfigurationParameterType::RangeDataNotificationProximityFar:
+    //     return true;
+    // default:
+    //     return false;
+    // }
 }
 
 /**

--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -563,6 +563,30 @@ using UwbApplicationConfigurationParameterValue = std::variant<
 // clang-format on
 
 /**
+ * @brief Determines whether the specified application configuration parameter
+ * (type) is allowed to be updated while a session is in the 'Active' state. 
+ * 
+ * @param uwbApplicationConfigurationParameterType 
+ * @return true The parameter may be updated while a session is active.
+ * @return false The parameter may not be updated while a session is active.
+ */
+constexpr bool
+IsApplicationConfigurationParameterChangeableWhileActive(const UwbApplicationConfigurationParameterType& uwbApplicationConfigurationParameterType)
+{
+    // TODO: the UCI spec (section 7.3.1) indicates STATUS_ERROR_SESSION_ACTIVE
+    // will be returned for application configuration parameters 'which are not
+    // allowed to set during the SESSION_STATE_ACTIVE Session State'. However,
+    // it does not list which parameters fall into this case. So for now, the
+    // list here is empty.
+    switch (uwbApplicationConfigurationParameterType) {
+    default:
+        break;
+    }
+
+    return false;
+}
+
+/**
  * @brief Represents a FiRa UWB Application Configuration Parameter as
  * described in the FiRa Consortium UWB Command Interface Generic Technical
  * Specification.

--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -573,16 +573,16 @@ constexpr std::array<UwbApplicationConfigurationParameterType, 5> UwbApplication
 
 /**
  * @brief Determines whether the specified application configuration parameter
- * (type) is allowed to be updated while a session is in the 'Active' state. 
- * 
- * @param uwbApplicationConfigurationParameterType 
+ * (type) is allowed to be updated while a session is in the 'Active' state.
+ *
+ * @param uwbApplicationConfigurationParameterType
  * @return true The parameter may be updated while a session is active.
  * @return false The parameter may not be updated while a session is active.
  */
 constexpr bool
 IsApplicationConfigurationParameterChangeableWhileActive(const UwbApplicationConfigurationParameterType& uwbApplicationConfigurationParameterType)
 {
-    return std::ranges::any_of(UwbApplicationConfigurationParameterTypesUpdateableWhileActive, [&](const auto &type){
+    return std::ranges::any_of(UwbApplicationConfigurationParameterTypesUpdateableWhileActive, [&](const auto& type) {
         return (type == uwbApplicationConfigurationParameterType);
     });
 }
@@ -611,14 +611,14 @@ struct UwbApplicationConfigurationParameter
 
 /**
  * @brief Determines whether the specified application configuration parameter
- * is allowed to be updated while a session is in the 'Active' state. 
- * 
- * @param uwbApplicationConfigurationParameter 
+ * is allowed to be updated while a session is in the 'Active' state.
+ *
+ * @param uwbApplicationConfigurationParameter
  * @return true The parameter may be updated while a session is active.
  * @return false The parameter may not be updated while a session is active.
  */
 constexpr bool
-IsApplicationConfigurationChangeableWhileActive(const UwbApplicationConfigurationParameter &uwbApplicationConfigurationParameter)
+IsApplicationConfigurationChangeableWhileActive(const UwbApplicationConfigurationParameter& uwbApplicationConfigurationParameter)
 {
     return IsApplicationConfigurationParameterChangeableWhileActive(uwbApplicationConfigurationParameter.Type);
 }
@@ -791,5 +791,21 @@ std::string
 ToString(const UwbApplicationConfigurationParameterValue& uwbApplicationConfigurationParameterValue);
 
 } // namespace uwb::protocol::fira
+
+namespace std
+{
+using ::uwb::protocol::fira::UwbApplicationConfigurationParameter;
+using ::uwb::protocol::fira::UwbApplicationConfigurationParameterType;
+
+template <>
+struct less<UwbApplicationConfigurationParameter>
+{
+    bool
+    operator()(const UwbApplicationConfigurationParameter& lhs, const UwbApplicationConfigurationParameter& rhs) const
+    {
+        return std::less<UwbApplicationConfigurationParameterType>{}(lhs.Type, rhs.Type);
+    }
+};
+} // namespace std
 
 #endif // FIRA_DEVICE_HXX

--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -585,16 +585,6 @@ IsApplicationConfigurationParameterChangeableWhileActive(const UwbApplicationCon
     return std::ranges::any_of(UwbApplicationConfigurationParameterTypesUpdateableWhileActive, [&](const auto &type){
         return (type == uwbApplicationConfigurationParameterType);
     });
-    // switch (uwbApplicationConfigurationParameterType) {
-    // case UwbApplicationConfigurationParameterType::BlockStrideLength:
-    // case UwbApplicationConfigurationParameterType::RangingInterval:
-    // case UwbApplicationConfigurationParameterType::RangeDataNotificationConfig:
-    // case UwbApplicationConfigurationParameterType::RangeDataNotificationProximityNear:
-    // case UwbApplicationConfigurationParameterType::RangeDataNotificationProximityFar:
-    //     return true;
-    // default:
-    //     return false;
-    // }
 }
 
 /**
@@ -618,6 +608,20 @@ struct UwbApplicationConfigurationParameter
     std::string
     ToString() const;
 };
+
+/**
+ * @brief Determines whether the specified application configuration parameter
+ * is allowed to be updated while a session is in the 'Active' state. 
+ * 
+ * @param uwbApplicationConfigurationParameter 
+ * @return true The parameter may be updated while a session is active.
+ * @return false The parameter may not be updated while a session is active.
+ */
+constexpr bool
+IsApplicationConfigurationChangeableWhileActive(const UwbApplicationConfigurationParameter &uwbApplicationConfigurationParameter)
+{
+    return IsApplicationConfigurationParameterChangeableWhileActive(uwbApplicationConfigurationParameter.Type);
+}
 
 struct UwbMulticastListStatus
 {

--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -623,6 +623,19 @@ IsApplicationConfigurationChangeableWhileActive(const UwbApplicationConfiguratio
     return IsApplicationConfigurationParameterChangeableWhileActive(uwbApplicationConfigurationParameter.Type);
 }
 
+/**
+ * @brief Represents the status of setting an application configuration
+ * parameter using FiRa UCI SESSION_SET_APP_CONFIG_CMD.
+ */
+struct UwbSetApplicationConfigurationParameterStatus
+{
+    UwbStatus Status;
+    UwbApplicationConfigurationParameterType ParameterType;
+
+    auto
+    operator<=>(const UwbSetApplicationConfigurationParameterStatus &) const noexcept = default;
+};
+
 struct UwbMulticastListStatus
 {
     uwb::UwbMacAddress ControleeMacAddress;

--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -646,9 +646,17 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
         test::ValidateRoundtrip(uwbSetApplicationConfigurationParameters);
     }
 
-    SECTION("UwbSetApplicationConfigurationParametersResult is stable")
+    SECTION("UwbSetApplicationConfigurationParameterStatus is stable")
     {
-        std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>> uwbSetApplicationConfigurationParametersStatuses{};
-        test::ValidateRoundtrip(uwbSetApplicationConfigurationParametersStatuses);
+        const UwbSetApplicationConfigurationParameterStatus uwbSetApplicationConfigurationParameterStatus{};
+        // TODO: above should be filled in with non-trivial data
+        test::ValidateRoundtrip(uwbSetApplicationConfigurationParameterStatus);
+    }
+
+    SECTION("UwbSetApplicationConfigurationParametersStatus is stable")
+    {
+        const UwbSetApplicationConfigurationParametersStatus uwbSetApplicationConfigurationParametersStatus{};
+        // TODO: above should be filled in with non-trivial data
+        test::ValidateRoundtrip(uwbSetApplicationConfigurationParametersStatus);
     }
 }

--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -647,4 +647,10 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
         };
         test::ValidateRoundtrip(uwbSetApplicationConfigurationParameters);
     }
+
+    SECTION("UwbSetApplicationConfigurationParametersResult is stable")
+    {
+        std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>> uwbSetApplicationConfigurationParametersStatuses{};
+        test::ValidateRoundtrip(uwbSetApplicationConfigurationParametersStatuses);
+    }
 }

--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -561,6 +561,21 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
         .Value = std::move(uwbMacAddressSetSingleAddress),
     };
 
+    constexpr UwbSetApplicationConfigurationParameterStatus uwbSetApplicationConfigurationParameterStatusAoaResulReq{
+        .Status = UwbStatusOk,
+        .ParameterType = UwbApplicationConfigurationParameterType::AoAResultRequest,
+    };
+
+    constexpr UwbSetApplicationConfigurationParameterStatus uwbSetApplicationConfigurationParameterStatusBlockStrideLength{
+        .Status = UwbStatusSession::Active,
+        .ParameterType = UwbApplicationConfigurationParameterType::BlockStrideLength,
+    };
+
+    constexpr UwbSetApplicationConfigurationParameterStatus uwbSetApplicationConfigurationParameterStatusBprfPhrDataRate{
+        .Status = UwbStatusRanging::RxTimeout,
+        .ParameterType = UwbApplicationConfigurationParameterType::BprfPhrDataRate,
+    };
+
     constexpr auto uwbApplicationConfigurationParameterTypesAll = magic_enum::enum_values<UwbApplicationConfigurationParameterType>();
 
     SECTION("UwbApplicationConfigurationParameter bool variant is stable")
@@ -662,15 +677,21 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
 
     SECTION("UwbSetApplicationConfigurationParameterStatus is stable")
     {
-        const UwbSetApplicationConfigurationParameterStatus uwbSetApplicationConfigurationParameterStatus{};
-        // TODO: above should be filled in with non-trivial data
-        test::ValidateRoundtrip(uwbSetApplicationConfigurationParameterStatus);
+        test::ValidateRoundtrip(uwbSetApplicationConfigurationParameterStatusAoaResulReq);
+        test::ValidateRoundtrip(uwbSetApplicationConfigurationParameterStatusBlockStrideLength);
+        test::ValidateRoundtrip(uwbSetApplicationConfigurationParameterStatusBprfPhrDataRate);
     }
 
     SECTION("UwbSetApplicationConfigurationParametersStatus is stable")
     {
-        const UwbSetApplicationConfigurationParametersStatus uwbSetApplicationConfigurationParametersStatus{};
-        // TODO: above should be filled in with non-trivial data
+        const UwbSetApplicationConfigurationParametersStatus uwbSetApplicationConfigurationParametersStatus{
+            .Status = UwbStatusOk,
+            .ParameterStatuses{
+                uwbSetApplicationConfigurationParameterStatusAoaResulReq,
+                uwbSetApplicationConfigurationParameterStatusBlockStrideLength,
+                uwbSetApplicationConfigurationParameterStatusBprfPhrDataRate,
+            },
+        };
         test::ValidateRoundtrip(uwbSetApplicationConfigurationParametersStatus);
     }
 }

--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -13,8 +13,6 @@
 #include <uwb/protocols/fira/FiraDevice.hxx>
 #include <windows/devices/uwb/UwbCxAdapterDdiLrp.hxx>
 
-namespace UwbCxDdi = windows::devices::uwb::ddi::lrp;
-
 namespace windows::devices::uwb::ddi::lrp::test
 {
 /**

--- a/tools/cli/NearObjectCliHandler.cxx
+++ b/tools/cli/NearObjectCliHandler.cxx
@@ -20,7 +20,7 @@ NearObjectCliHandler::SetParent(NearObjectCli* parent)
 }
 
 std::shared_ptr<uwb::UwbDevice>
-NearObjectCliHandler::ResolveUwbDevice(const nearobject::cli::NearObjectCliData& /*cliData */) noexcept
+NearObjectCliHandler::ResolveUwbDevice(const NearObjectCliData& /*cliData */) noexcept
 {
     // Default implementation does not know how to resolve a device. OS-specific
     // implementations are expected to sub-class and override this function.
@@ -31,7 +31,7 @@ void
 NearObjectCliHandler::HandleDriverStartRanging(std::shared_ptr<uwb::UwbDevice> uwbDevice, const UwbRangingParameters& rangingParameters) noexcept
 try {
     auto controlFlowContext = (m_parent != nullptr) ? m_parent->GetControlFlowContext() : nullptr;
-    auto callbacks = std::make_shared<nearobject::cli::NearObjectCliUwbSessionEventCallbacks>([this, controlFlowContext = std::move(controlFlowContext)]() {
+    auto callbacks = std::make_shared<NearObjectCliUwbSessionEventCallbacks>([this, controlFlowContext = std::move(controlFlowContext)]() {
         if (controlFlowContext != nullptr) {
             controlFlowContext->OperationSignalComplete();
         }
@@ -57,7 +57,7 @@ NearObjectCliHandler::HandleStartRanging(std::shared_ptr<uwb::UwbDevice> uwbDevi
 try {
     // Instantiate callbacks for session events.
     auto controlFlowContext = (m_parent != nullptr) ? m_parent->GetControlFlowContext() : nullptr;
-    auto callbacks = std::make_shared<nearobject::cli::NearObjectCliUwbSessionEventCallbacks>([this, controlFlowContext = std::move(controlFlowContext)]() {
+    auto callbacks = std::make_shared<NearObjectCliUwbSessionEventCallbacks>([this, controlFlowContext = std::move(controlFlowContext)]() {
         if (controlFlowContext != nullptr) {
             controlFlowContext->OperationSignalComplete();
         }

--- a/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
@@ -58,7 +58,7 @@ struct NearObjectCliHandler
     /**
      * @brief Invoked by command-line driver when the request is to start a
      * ranging session.
-     * 
+     *
      * @param uwbDevice The resolved uwb device to start the ranging session on.
      * @param sessionData The data to configure the ranging session.
      */

--- a/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
@@ -98,7 +98,7 @@ struct NearObjectCliHandler
 
 private:
     NearObjectCli* m_parent;
-    std::shared_ptr<::uwb::UwbSession> m_activeSession{ nullptr };
+    std::shared_ptr<::uwb::UwbSession> m_activeSession;
 };
 
 } // namespace nearobject::cli

--- a/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
@@ -8,6 +8,7 @@
 #include <nearobject/cli/NearObjectCliControlFlowContext.hxx>
 #include <nearobject/cli/NearObjectCliData.hxx>
 #include <uwb/UwbDevice.hxx>
+#include <uwb/UwbSession.hxx>
 #include <uwb/protocols/fira/UwbSessionData.hxx>
 
 namespace nearobject::cli
@@ -107,6 +108,7 @@ struct NearObjectCliHandler
 
 private:
     NearObjectCli* m_parent;
+    std::shared_ptr<::uwb::UwbSession> m_activeSession{ nullptr };
 };
 
 } // namespace nearobject::cli

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -620,7 +620,7 @@ windows::devices::uwb::ddi::lrp::From(const UwbSetApplicationConfigurationParame
 UwbSetApplicationConfigurationParametersStatusWrapper
 windows::devices::uwb::ddi::lrp::From([[maybe_unused]] const UwbSetApplicationConfigurationParametersStatus &uwbSetApplicationConfigurationParameterResult)
 {
-    UwbSetApplicationConfigurationParametersStatusWrapper uwbSetApplicationConfigurationParametersStatusWrapper{1 /* FIXME */};
+    UwbSetApplicationConfigurationParametersStatusWrapper uwbSetApplicationConfigurationParametersStatusWrapper{1024  /* FIXME */};
     // TODO
     return std::move(uwbSetApplicationConfigurationParametersStatusWrapper);
 }

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -605,6 +605,14 @@ windows::devices::uwb::ddi::lrp::From(const UwbSetApplicationConfigurationParame
     return std::move(setApplicationConfigurationParametersWrapper);
 }
 
+UwbSetApplicationConfigurationParametersStatusWrapper
+windows::devices::uwb::ddi::lrp::From([[maybe_unused]] const std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>>& uwbSetApplicationConfigurationParametersStatuses)
+{
+    UwbSetApplicationConfigurationParametersStatusWrapper uwbSetApplicationConfigurationParametersStatusWrapper{1 /* FIXME */};
+    // TODO
+    return std::move(uwbSetApplicationConfigurationParametersStatusWrapper);
+}
+
 UwbApplicationConfigurationParameterWrapper
 windows::devices::uwb::ddi::lrp::From(const UwbApplicationConfigurationParameter &uwbApplicationConfigurationParameter)
 {
@@ -1367,6 +1375,14 @@ windows::devices::uwb::ddi::lrp::To(const UWB_SET_APP_CONFIG_PARAMS &setApplicat
     }
 
     return std::move(uwbSetApplicationConfigurationParameters);
+}
+
+std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>>
+windows::devices::uwb::ddi::lrp::To([[maybe_unused]] const UWB_SET_APP_CONFIG_PARAMS_STATUS& setApplicationConfigurationParametersStatus)
+{
+    std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>> uwbSetApplicationConfigurationParametersStatuses{};
+    // TODO
+    return uwbSetApplicationConfigurationParametersStatuses; 
 }
 
 namespace detail

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -570,13 +570,12 @@ windows::devices::uwb::ddi::lrp::From(const UwbGetApplicationConfigurationParame
 }
 
 UWB_APP_CONFIG_PARAM_STATUS
-windows::devices::uwb::ddi::lrp::From(const std::tuple<::uwb::protocol::fira::UwbStatus, ::uwb::protocol::fira::UwbApplicationConfigurationParameterType> &uwbApplicationConfigurationParameterStatus)
+windows::devices::uwb::ddi::lrp::From(const UwbSetApplicationConfigurationParameterStatus &uwbSetApplicationConfigurationParameterStatus) 
 {
-    const auto &[status, uwbApplicationConfigurationParameterType] = uwbApplicationConfigurationParameterStatus;
     UWB_APP_CONFIG_PARAM_STATUS applicationConfigurationParameterStatus = {
         .size = sizeof applicationConfigurationParameterStatus,
-        .paramType = From(uwbApplicationConfigurationParameterType),
-        .status = From(status),
+        .paramType = From(uwbSetApplicationConfigurationParameterStatus.ParameterType),
+        .status = From(uwbSetApplicationConfigurationParameterStatus.Status),
     };
 
     return applicationConfigurationParameterStatus;
@@ -619,7 +618,7 @@ windows::devices::uwb::ddi::lrp::From(const UwbSetApplicationConfigurationParame
 }
 
 UwbSetApplicationConfigurationParametersStatusWrapper
-windows::devices::uwb::ddi::lrp::From([[maybe_unused]] const std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>>& uwbSetApplicationConfigurationParametersStatuses)
+windows::devices::uwb::ddi::lrp::From([[maybe_unused]] const UwbSetApplicationConfigurationParametersStatus &uwbSetApplicationConfigurationParameterResult)
 {
     UwbSetApplicationConfigurationParametersStatusWrapper uwbSetApplicationConfigurationParametersStatusWrapper{1 /* FIXME */};
     // TODO
@@ -1372,13 +1371,15 @@ windows::devices::uwb::ddi::lrp::To(const UWB_GET_APP_CONFIG_PARAMS &getApplicat
     return std::move(uwbGetApplicationConfigurationParameters);
 }
 
-std::tuple<UwbStatus, UwbApplicationConfigurationParameterType>
-windows::devices::uwb::ddi::lrp::To([[maybe_unused]] const UWB_APP_CONFIG_PARAM_STATUS &applicationConfigurationParameterStatus)
+UwbSetApplicationConfigurationParameterStatus
+windows::devices::uwb::ddi::lrp::To(const UWB_APP_CONFIG_PARAM_STATUS &applicationConfigurationParameterStatus)
 {
-    return {
-        To(applicationConfigurationParameterStatus.status),
-        To(applicationConfigurationParameterStatus.paramType)
+    UwbSetApplicationConfigurationParameterStatus uwbSetApplicationConfigurationParameterStatus {
+        .Status = To(applicationConfigurationParameterStatus.status),
+        .ParameterType = To(applicationConfigurationParameterStatus.paramType),
     };
+
+    return uwbSetApplicationConfigurationParameterStatus;
 }
 
 UwbSetApplicationConfigurationParameters
@@ -1399,12 +1400,12 @@ windows::devices::uwb::ddi::lrp::To(const UWB_SET_APP_CONFIG_PARAMS &setApplicat
     return std::move(uwbSetApplicationConfigurationParameters);
 }
 
-std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>>
+UwbSetApplicationConfigurationParametersStatus
 windows::devices::uwb::ddi::lrp::To([[maybe_unused]] const UWB_SET_APP_CONFIG_PARAMS_STATUS& setApplicationConfigurationParametersStatus)
 {
-    std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>> uwbSetApplicationConfigurationParametersStatuses{};
+    UwbSetApplicationConfigurationParametersStatus uwbSetApplicationConfigurationParameterResult{};
     // TODO
-    return uwbSetApplicationConfigurationParametersStatuses; 
+    return uwbSetApplicationConfigurationParameterResult; 
 }
 
 namespace detail

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -569,6 +569,19 @@ windows::devices::uwb::ddi::lrp::From(const UwbGetApplicationConfigurationParame
     return std::move(getApplicationConfigurationParameterTypesWrapper);
 }
 
+UWB_APP_CONFIG_PARAM_STATUS
+windows::devices::uwb::ddi::lrp::From(const std::tuple<::uwb::protocol::fira::UwbStatus, ::uwb::protocol::fira::UwbApplicationConfigurationParameterType> &uwbApplicationConfigurationParameterStatus)
+{
+    const auto &[status, uwbApplicationConfigurationParameterType] = uwbApplicationConfigurationParameterStatus;
+    UWB_APP_CONFIG_PARAM_STATUS applicationConfigurationParameterStatus = {
+        .size = sizeof applicationConfigurationParameterStatus,
+        .paramType = From(uwbApplicationConfigurationParameterType),
+        .status = From(status),
+    };
+
+    return applicationConfigurationParameterStatus;
+}
+
 UwbSetApplicationConfigurationParametersWrapper
 windows::devices::uwb::ddi::lrp::From(const UwbSetApplicationConfigurationParameters &uwbSetApplicationConfigurationParameters)
 {
@@ -1357,6 +1370,15 @@ windows::devices::uwb::ddi::lrp::To(const UWB_GET_APP_CONFIG_PARAMS &getApplicat
     });
 
     return std::move(uwbGetApplicationConfigurationParameters);
+}
+
+std::tuple<UwbStatus, UwbApplicationConfigurationParameterType>
+windows::devices::uwb::ddi::lrp::To([[maybe_unused]] const UWB_APP_CONFIG_PARAM_STATUS &applicationConfigurationParameterStatus)
+{
+    return {
+        To(applicationConfigurationParameterStatus.status),
+        To(applicationConfigurationParameterStatus.paramType)
+    };
 }
 
 UwbSetApplicationConfigurationParameters

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -570,7 +570,7 @@ windows::devices::uwb::ddi::lrp::From(const UwbGetApplicationConfigurationParame
 }
 
 UWB_APP_CONFIG_PARAM_STATUS
-windows::devices::uwb::ddi::lrp::From(const UwbSetApplicationConfigurationParameterStatus &uwbSetApplicationConfigurationParameterStatus) 
+windows::devices::uwb::ddi::lrp::From(const UwbSetApplicationConfigurationParameterStatus &uwbSetApplicationConfigurationParameterStatus)
 {
     UWB_APP_CONFIG_PARAM_STATUS applicationConfigurationParameterStatus = {
         .size = sizeof applicationConfigurationParameterStatus,
@@ -627,8 +627,7 @@ windows::devices::uwb::ddi::lrp::From(const UwbSetApplicationConfigurationParame
     setApplicationConfigurationParametersStatus.appConfigParamsCount = std::size(uwbSetApplicationConfigurationParametersStatus.ParameterStatuses);
 
     auto parameterStatuses = std::span(setApplicationConfigurationParametersStatus.appConfigParamsStatus, setApplicationConfigurationParametersStatus.appConfigParamsCount);
-    std::ranges::transform(uwbSetApplicationConfigurationParametersStatus.ParameterStatuses, std::ranges::begin(parameterStatuses), [&](const auto &parameterStatus)
-    {
+    std::ranges::transform(uwbSetApplicationConfigurationParametersStatus.ParameterStatuses, std::ranges::begin(parameterStatuses), [&](const auto &parameterStatus) {
         return From(parameterStatus);
     });
 
@@ -1393,7 +1392,7 @@ windows::devices::uwb::ddi::lrp::To(const UWB_GET_APP_CONFIG_PARAMS &getApplicat
 UwbSetApplicationConfigurationParameterStatus
 windows::devices::uwb::ddi::lrp::To(const UWB_APP_CONFIG_PARAM_STATUS &applicationConfigurationParameterStatus)
 {
-    UwbSetApplicationConfigurationParameterStatus uwbSetApplicationConfigurationParameterStatus {
+    UwbSetApplicationConfigurationParameterStatus uwbSetApplicationConfigurationParameterStatus{
         .Status = To(applicationConfigurationParameterStatus.status),
         .ParameterType = To(applicationConfigurationParameterStatus.paramType),
     };
@@ -1420,7 +1419,7 @@ windows::devices::uwb::ddi::lrp::To(const UWB_SET_APP_CONFIG_PARAMS &setApplicat
 }
 
 UwbSetApplicationConfigurationParametersStatus
-windows::devices::uwb::ddi::lrp::To(const UWB_SET_APP_CONFIG_PARAMS_STATUS& setApplicationConfigurationParametersStatus)
+windows::devices::uwb::ddi::lrp::To(const UWB_SET_APP_CONFIG_PARAMS_STATUS &setApplicationConfigurationParametersStatus)
 {
     UwbSetApplicationConfigurationParametersStatus uwbSetApplicationConfigurationParameterResult{
         .Status = To(setApplicationConfigurationParametersStatus.status),
@@ -1428,11 +1427,11 @@ windows::devices::uwb::ddi::lrp::To(const UWB_SET_APP_CONFIG_PARAMS_STATUS& setA
 
     uwbSetApplicationConfigurationParameterResult.ParameterStatuses.reserve(setApplicationConfigurationParametersStatus.appConfigParamsCount);
     auto parameterStatusesRange = std::span(setApplicationConfigurationParametersStatus.appConfigParamsStatus, setApplicationConfigurationParametersStatus.appConfigParamsCount);
-    std::ranges::transform(parameterStatusesRange, std::back_inserter(uwbSetApplicationConfigurationParameterResult.ParameterStatuses), [&](const auto &parameterStatus){
+    std::ranges::transform(parameterStatusesRange, std::back_inserter(uwbSetApplicationConfigurationParameterResult.ParameterStatuses), [&](const auto &parameterStatus) {
         return To(parameterStatus);
     });
 
-    return std::move(uwbSetApplicationConfigurationParameterResult); 
+    return std::move(uwbSetApplicationConfigurationParameterResult);
 }
 
 namespace detail

--- a/windows/devices/uwb/UwbDevice.cxx
+++ b/windows/devices/uwb/UwbDevice.cxx
@@ -16,12 +16,6 @@
 using namespace windows::devices::uwb;
 using namespace ::uwb::protocol::fira;
 
-/**
- * @brief Namespace alias to reduce typing but preserve clarity regarding DDI
- * conversion.
- */
-namespace UwbCxDdi = windows::devices::uwb::ddi::lrp;
-
 UwbDevice::UwbDevice(std::string deviceName) :
     m_deviceName(std::move(deviceName))
 {

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -450,7 +450,12 @@ UwbDeviceConnector::SetApplicationConfigurationParameters(uint32_t sessionId, st
         return resultFuture;
     }
 
-    auto paramsDdi = UwbCxDdi::From(applicationConfigurationParameters);
+    UwbCxDdi::UwbSetApplicationConfigurationParameters uwbSetApplicationConfigurationParameters{
+        .SessionId = sessionId,
+        .Parameters = std::move(applicationConfigurationParameters),
+    };
+
+    auto paramsDdi = UwbCxDdi::From(uwbSetApplicationConfigurationParameters);
     auto paramsBuffer = std::data(paramsDdi);
     auto statusSize = offsetof(UWB_SET_APP_CONFIG_PARAMS_STATUS, appConfigParamsStatus[std::size(applicationConfigurationParameters)]);
     std::vector<uint8_t> statusBuffer(statusSize);

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -26,12 +26,6 @@ class RegisteredCallbackToken
 };
 } // namespace windows::devices::uwb
 
-/**
- * @brief Namespace alias to reduce typing but preserve clarity regarding DDI
- * conversion.
- */
-namespace UwbCxDdi = windows::devices::uwb::ddi::lrp;
-
 UwbDeviceConnector::UwbDeviceConnector(std::string deviceName) :
     m_deviceName(std::move(deviceName))
 {}

--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -106,7 +106,7 @@ UwbSession::ConfigureImpl(const std::vector<::uwb::protocol::fira::UwbApplicatio
     // TODO: the caller probably wants to know about this, figure out the best way to signal the error.
     //       One option is to define a UwbSetApplicationConfigurationParameterException which has an
     //       accessor that just returns the vector entries with statusSetParameter != Ok
-    for (const auto &[applicationConfigurationParameterType, statusSetParameter] : resultSetParameters) {
+    for (const auto &[statusSetParameter, applicationConfigurationParameterType] : resultSetParameters) {
         if (!IsUwbStatusOk(statusSetParameter)) {
             LOG_ERROR << "failed to set application configuration parameter " << magic_enum::enum_name(applicationConfigurationParameterType) << ", status=" << ToString(statusSetParameter);
         }

--- a/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
@@ -65,7 +65,7 @@ struct IUwbDeviceDdi
     GetApplicationConfigurationParameters(uint32_t sessionId, std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameterType> applicationConfigurationParameterTypes) = 0;
 
     // IOCTL_UWB_SET_APP_CONFIG_PARAMS
-    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>>>
+    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<::uwb::protocol::fira::UwbSetApplicationConfigurationParameterStatus>>>
     SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> applicationConfigurationParameters) = 0;
 
     // TODO: unspecified IOCTLs below

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -286,6 +286,15 @@ struct UwbSetApplicationConfigurationParameters
     operator<=>(const UwbSetApplicationConfigurationParameters &) const noexcept = default;
 };
 
+/**
+ * @brief Converts a UwbStatus, UwbApplicationConfigurationParameterType pair to UWB_APP_CONFIG_PARAM_STATUS.
+ * 
+ * @param uwbApplicationConfigurationParameterStatus 
+ * @return UWB_APP_CONFIG_PARAM_STATUS 
+ */
+UWB_APP_CONFIG_PARAM_STATUS
+From(const std::tuple<::uwb::protocol::fira::UwbStatus, ::uwb::protocol::fira::UwbApplicationConfigurationParameterType> &uwbApplicationConfigurationParameterStatus);
+
 using UwbSetApplicationConfigurationParametersWrapper = notstd::flextype_wrapper<UWB_SET_APP_CONFIG_PARAMS>;
 
 /**
@@ -553,6 +562,15 @@ To(const UWB_NOTIFICATION_DATA &notificationData);
  */
 UwbGetApplicationConfigurationParameters
 To(const UWB_GET_APP_CONFIG_PARAMS &getApplicationConfigurationParameters);
+
+/**
+ * @brief Converts UWB_APP_CONFIG_PARAM_STATUS to a pair of UwbStatus and UwbApplicationConfigurationParameterType.
+ * 
+ * @param applicationConfigurationParameterStatus 
+ * @return std::tuple<::uwb::protocol::fira::UwbStatus, ::uwb::protocol::fira::UwbApplicationConfigurationParameterType> 
+ */
+std::tuple<::uwb::protocol::fira::UwbStatus, ::uwb::protocol::fira::UwbApplicationConfigurationParameterType>
+To(const UWB_APP_CONFIG_PARAM_STATUS &applicationConfigurationParameterStatus);
 
 /**
  * @brief Converts UWB_SET_APP_CONFIG_PARAMS to UwbSetApplicationConfigurationParameters.

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -289,7 +289,7 @@ struct UwbSetApplicationConfigurationParameters
 /**
  * @brief Converts a UwbSetApplicationConfigurationParameterStatus to UWB_APP_CONFIG_PARAM_STATUS.
  *
- * @param uwbApplicationConfigurationParameterStatus
+ * @param uwbSetApplicationConfigurationParameterStatus
  * @return UWB_APP_CONFIG_PARAM_STATUS
  */
 UWB_APP_CONFIG_PARAM_STATUS

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -287,25 +287,13 @@ struct UwbSetApplicationConfigurationParameters
 };
 
 /**
- * @brief Neutral type for the UWB_APP_CONFIG_PARAM_STATUS DDI structure.
- */
-struct UwbSetApplicationConfigurationParameterStatus
-{
-    ::uwb::protocol::fira::UwbStatus Status;
-    ::uwb::protocol::fira::UwbApplicationConfigurationParameterType ParameterType;
-
-    auto
-    operator<=>(const UwbSetApplicationConfigurationParameterStatus &) const noexcept = default;
-};
-
-/**
  * @brief Converts a UwbSetApplicationConfigurationParameterStatus to UWB_APP_CONFIG_PARAM_STATUS.
  * 
  * @param uwbApplicationConfigurationParameterStatus 
  * @return UWB_APP_CONFIG_PARAM_STATUS 
  */
 UWB_APP_CONFIG_PARAM_STATUS
-From(const UwbSetApplicationConfigurationParameterStatus &uwbSetApplicationConfigurationParameterStatus);
+From(const ::uwb::protocol::fira::UwbSetApplicationConfigurationParameterStatus &uwbSetApplicationConfigurationParameterStatus);
 
 using UwbSetApplicationConfigurationParametersWrapper = notstd::flextype_wrapper<UWB_SET_APP_CONFIG_PARAMS>;
 
@@ -324,7 +312,7 @@ From(const UwbSetApplicationConfigurationParameters &uwbSetApplicationConfigurat
 struct UwbSetApplicationConfigurationParametersStatus
 {
     ::uwb::protocol::fira::UwbStatus Status;
-    std::vector<UwbSetApplicationConfigurationParameterStatus> ParameterStatuses;
+    std::vector<::uwb::protocol::fira::UwbSetApplicationConfigurationParameterStatus> ParameterStatuses;
 
     auto
     operator<=>(const UwbSetApplicationConfigurationParametersStatus &) const noexcept = default;
@@ -591,9 +579,9 @@ To(const UWB_GET_APP_CONFIG_PARAMS &getApplicationConfigurationParameters);
  * @brief Converts UWB_APP_CONFIG_PARAM_STATUS to UwbSetApplicationConfigurationParameterStatus.
  * 
  * @param applicationConfigurationParameterStatus 
- * @return UwbSetApplicationConfigurationParameterStatus 
+ * @return ::uwb::protocol::fira::UwbSetApplicationConfigurationParameterStatus 
  */
-UwbSetApplicationConfigurationParameterStatus
+::uwb::protocol::fira::UwbSetApplicationConfigurationParameterStatus
 To(const UWB_APP_CONFIG_PARAM_STATUS &applicationConfigurationParameterStatus);
 
 /**

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -288,9 +288,9 @@ struct UwbSetApplicationConfigurationParameters
 
 /**
  * @brief Converts a UwbSetApplicationConfigurationParameterStatus to UWB_APP_CONFIG_PARAM_STATUS.
- * 
- * @param uwbApplicationConfigurationParameterStatus 
- * @return UWB_APP_CONFIG_PARAM_STATUS 
+ *
+ * @param uwbApplicationConfigurationParameterStatus
+ * @return UWB_APP_CONFIG_PARAM_STATUS
  */
 UWB_APP_CONFIG_PARAM_STATUS
 From(const ::uwb::protocol::fira::UwbSetApplicationConfigurationParameterStatus &uwbSetApplicationConfigurationParameterStatus);
@@ -322,9 +322,9 @@ using UwbSetApplicationConfigurationParametersStatusWrapper = notstd::flextype_w
 
 /**
  * @brief Converts UwbSetApplicationConfigurationParametersStatus to UWB_SET_APP_CONFIG_PARAMS_STATUS.
- * 
- * @param uwbSetApplicationConfigurationParameterResult 
- * @return UwbSetApplicationConfigurationParametersStatusWrapper 
+ *
+ * @param uwbSetApplicationConfigurationParameterResult
+ * @return UwbSetApplicationConfigurationParametersStatusWrapper
  */
 UwbSetApplicationConfigurationParametersStatusWrapper
 From(const UwbSetApplicationConfigurationParametersStatus &uwbSetApplicationConfigurationParameterResult);
@@ -577,9 +577,9 @@ To(const UWB_GET_APP_CONFIG_PARAMS &getApplicationConfigurationParameters);
 
 /**
  * @brief Converts UWB_APP_CONFIG_PARAM_STATUS to UwbSetApplicationConfigurationParameterStatus.
- * 
- * @param applicationConfigurationParameterStatus 
- * @return ::uwb::protocol::fira::UwbSetApplicationConfigurationParameterStatus 
+ *
+ * @param applicationConfigurationParameterStatus
+ * @return ::uwb::protocol::fira::UwbSetApplicationConfigurationParameterStatus
  */
 ::uwb::protocol::fira::UwbSetApplicationConfigurationParameterStatus
 To(const UWB_APP_CONFIG_PARAM_STATUS &applicationConfigurationParameterStatus);
@@ -595,9 +595,9 @@ To(const UWB_SET_APP_CONFIG_PARAMS &setApplicationConfigurationParameters);
 
 /**
  * @brief Converts UWB_SET_APP_CONFIG_PARAMS_STATUS to UwbSetApplicationConfigurationParametersStatus.
- * 
- * @param applicationConfigurationParameterStatus 
- * @return UwbSetApplicationConfigurationParametersStatus 
+ *
+ * @param applicationConfigurationParameterStatus
+ * @return UwbSetApplicationConfigurationParametersStatus
  */
 UwbSetApplicationConfigurationParametersStatus
 To(const UWB_SET_APP_CONFIG_PARAMS_STATUS &applicationConfigurationParameterStatus);

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -325,6 +325,9 @@ struct UwbSetApplicationConfigurationParametersStatus
 {
     ::uwb::protocol::fira::UwbStatus Status;
     std::vector<UwbSetApplicationConfigurationParameterStatus> ParameterStatuses;
+
+    auto
+    operator<=>(const UwbSetApplicationConfigurationParametersStatus &) const noexcept = default;
 };
 
 using UwbSetApplicationConfigurationParametersStatusWrapper = notstd::flextype_wrapper<UWB_SET_APP_CONFIG_PARAMS_STATUS>;

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -297,6 +297,17 @@ using UwbSetApplicationConfigurationParametersWrapper = notstd::flextype_wrapper
 UwbSetApplicationConfigurationParametersWrapper
 From(const UwbSetApplicationConfigurationParameters &uwbSetApplicationConfigurationParameters);
 
+using UwbSetApplicationConfigurationParametersStatusWrapper = notstd::flextype_wrapper<UWB_SET_APP_CONFIG_PARAMS_STATUS>;
+
+/**
+ * @brief 
+ * 
+ * @param uwbSetApplicationConfigurationParametersStatuses 
+ * @return UwbSetApplicationConfigurationParametersStatusWrapper 
+ */
+UwbSetApplicationConfigurationParametersStatusWrapper
+From(const std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>& uwbSetApplicationConfigurationParametersStatuses);
+
 using UwbApplicationConfigurationParameterWrapper = notstd::flextype_wrapper<UWB_APP_CONFIG_PARAM>;
 
 /**
@@ -551,6 +562,15 @@ To(const UWB_GET_APP_CONFIG_PARAMS &getApplicationConfigurationParameters);
  */
 UwbSetApplicationConfigurationParameters
 To(const UWB_SET_APP_CONFIG_PARAMS &setApplicationConfigurationParameters);
+
+/**
+ * @brief Converts UWB_SET_APP_CONFIG_PARAMS_STATUS to a list of corresponding neutral types.
+ * 
+ * @param setApplicationConfigurationParametersStatus 
+ * @return std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>> 
+ */
+std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>
+To(const UWB_SET_APP_CONFIG_PARAMS_STATUS& setApplicationConfigurationParametersStatus);
 
 /**
  * @brief Converts UWB_APP_CONFIG_PARAM to UwbApplicationConfigurationParameter.

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -287,13 +287,25 @@ struct UwbSetApplicationConfigurationParameters
 };
 
 /**
- * @brief Converts a UwbStatus, UwbApplicationConfigurationParameterType pair to UWB_APP_CONFIG_PARAM_STATUS.
+ * @brief Neutral type for the UWB_APP_CONFIG_PARAM_STATUS DDI structure.
+ */
+struct UwbSetApplicationConfigurationParameterStatus
+{
+    ::uwb::protocol::fira::UwbStatus Status;
+    ::uwb::protocol::fira::UwbApplicationConfigurationParameterType ParameterType;
+
+    auto
+    operator<=>(const UwbSetApplicationConfigurationParameterStatus &) const noexcept = default;
+};
+
+/**
+ * @brief Converts a UwbSetApplicationConfigurationParameterStatus to UWB_APP_CONFIG_PARAM_STATUS.
  * 
  * @param uwbApplicationConfigurationParameterStatus 
  * @return UWB_APP_CONFIG_PARAM_STATUS 
  */
 UWB_APP_CONFIG_PARAM_STATUS
-From(const std::tuple<::uwb::protocol::fira::UwbStatus, ::uwb::protocol::fira::UwbApplicationConfigurationParameterType> &uwbApplicationConfigurationParameterStatus);
+From(const UwbSetApplicationConfigurationParameterStatus &uwbSetApplicationConfigurationParameterStatus);
 
 using UwbSetApplicationConfigurationParametersWrapper = notstd::flextype_wrapper<UWB_SET_APP_CONFIG_PARAMS>;
 
@@ -306,16 +318,25 @@ using UwbSetApplicationConfigurationParametersWrapper = notstd::flextype_wrapper
 UwbSetApplicationConfigurationParametersWrapper
 From(const UwbSetApplicationConfigurationParameters &uwbSetApplicationConfigurationParameters);
 
+/**
+ * @brief Neutral type for the UWB_SET_APP_CONFIG_PARAMS_STATUS DDI structure.
+ */
+struct UwbSetApplicationConfigurationParametersStatus
+{
+    ::uwb::protocol::fira::UwbStatus Status;
+    std::vector<UwbSetApplicationConfigurationParameterStatus> ParameterStatuses;
+};
+
 using UwbSetApplicationConfigurationParametersStatusWrapper = notstd::flextype_wrapper<UWB_SET_APP_CONFIG_PARAMS_STATUS>;
 
 /**
- * @brief 
+ * @brief Converts UwbSetApplicationConfigurationParameterResult to UWB_SET_APP_CONFIG_PARAMS_STATUS.
  * 
- * @param uwbSetApplicationConfigurationParametersStatuses 
+ * @param uwbSetApplicationConfigurationParameterResult 
  * @return UwbSetApplicationConfigurationParametersStatusWrapper 
  */
 UwbSetApplicationConfigurationParametersStatusWrapper
-From(const std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>& uwbSetApplicationConfigurationParametersStatuses);
+From(const UwbSetApplicationConfigurationParametersStatus &uwbSetApplicationConfigurationParameterResult);
 
 using UwbApplicationConfigurationParameterWrapper = notstd::flextype_wrapper<UWB_APP_CONFIG_PARAM>;
 
@@ -564,12 +585,12 @@ UwbGetApplicationConfigurationParameters
 To(const UWB_GET_APP_CONFIG_PARAMS &getApplicationConfigurationParameters);
 
 /**
- * @brief Converts UWB_APP_CONFIG_PARAM_STATUS to a pair of UwbStatus and UwbApplicationConfigurationParameterType.
+ * @brief Converts UWB_APP_CONFIG_PARAM_STATUS to UwbSetApplicationConfigurationParameterStatus.
  * 
  * @param applicationConfigurationParameterStatus 
- * @return std::tuple<::uwb::protocol::fira::UwbStatus, ::uwb::protocol::fira::UwbApplicationConfigurationParameterType> 
+ * @return UwbSetApplicationConfigurationParameterStatus 
  */
-std::tuple<::uwb::protocol::fira::UwbStatus, ::uwb::protocol::fira::UwbApplicationConfigurationParameterType>
+UwbSetApplicationConfigurationParameterStatus
 To(const UWB_APP_CONFIG_PARAM_STATUS &applicationConfigurationParameterStatus);
 
 /**
@@ -582,13 +603,13 @@ UwbSetApplicationConfigurationParameters
 To(const UWB_SET_APP_CONFIG_PARAMS &setApplicationConfigurationParameters);
 
 /**
- * @brief Converts UWB_SET_APP_CONFIG_PARAMS_STATUS to a list of corresponding neutral types.
+ * @brief Converts UWB_SET_APP_CONFIG_PARAMS_STATUS to UwbSetApplicationConfigurationParametersStatus.
  * 
- * @param setApplicationConfigurationParametersStatus 
- * @return std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>> 
+ * @param applicationConfigurationParameterStatus 
+ * @return UwbSetApplicationConfigurationParametersStatus 
  */
-std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>
-To(const UWB_SET_APP_CONFIG_PARAMS_STATUS& setApplicationConfigurationParametersStatus);
+UwbSetApplicationConfigurationParametersStatus
+To(const UWB_SET_APP_CONFIG_PARAMS_STATUS &applicationConfigurationParameterStatus);
 
 /**
  * @brief Converts UWB_APP_CONFIG_PARAM to UwbApplicationConfigurationParameter.

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -330,7 +330,7 @@ struct UwbSetApplicationConfigurationParametersStatus
 using UwbSetApplicationConfigurationParametersStatusWrapper = notstd::flextype_wrapper<UWB_SET_APP_CONFIG_PARAMS_STATUS>;
 
 /**
- * @brief Converts UwbSetApplicationConfigurationParameterResult to UWB_SET_APP_CONFIG_PARAMS_STATUS.
+ * @brief Converts UwbSetApplicationConfigurationParametersStatus to UWB_SET_APP_CONFIG_PARAMS_STATUS.
  * 
  * @param uwbSetApplicationConfigurationParameterResult 
  * @return UwbSetApplicationConfigurationParametersStatusWrapper 
@@ -630,5 +630,11 @@ std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter>
 To(const UWB_APP_CONFIG_PARAMS &applicationConfigurationParameters);
 
 } // namespace windows::devices::uwb::ddi::lrp
+
+/**
+ * @brief Namespace alias to reduce typing but preserve clarity regarding DDI
+ * conversion.
+ */
+namespace UwbCxDdi = windows::devices::uwb::ddi::lrp;
 
 #endif // UWB_CX_ADAPTER_DDI_LRP_HXX

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
@@ -135,7 +135,7 @@ public:
     virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter>>>
     GetApplicationConfigurationParameters(uint32_t sessionId, std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameterType> applicationConfigurationParameterTypes) override;
 
-    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<std::tuple<::uwb::protocol::fira::UwbApplicationConfigurationParameterType, ::uwb::protocol::fira::UwbStatus>>>>
+    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::vector<::uwb::protocol::fira::UwbSetApplicationConfigurationParameterStatus>>>
     SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> applicationConfigurationParameters) override;
 
 private:

--- a/windows/drivers/uwb/simulator/IUwbSimulatorDdiCallbacksLrp.hxx
+++ b/windows/drivers/uwb/simulator/IUwbSimulatorDdiCallbacksLrp.hxx
@@ -15,6 +15,7 @@
 
 #include <uwb/protocols/fira/FiraDevice.hxx>
 #include <uwb/protocols/fira/UwbCapability.hxx>
+#include <windows/devices/uwb/UwbCxAdapterDdiLrp.hxx>
 
 using namespace uwb::protocol::fira;
 
@@ -80,7 +81,7 @@ struct IUwbSimulatorDdiCallbacksLrp
      *
      * @param sessionId
      * @param applicationConfigurationParameterTypes
-     * @param applicationConfigurationParameters
+     * @param uwbSetApplicationConfigurationParameters
      * @return UwbStatus
      */
     virtual UwbStatus
@@ -89,12 +90,12 @@ struct IUwbSimulatorDdiCallbacksLrp
     /**
      * @brief Set the Application Configuration Parameters object
      *
-     * @param applicationConfigurationParameters
+     * @param uwbSetApplicationConfigurationParameters
      * @param applicationConfigurationParameterResults
      * @return UwbStatus
      */
     virtual UwbStatus
-    SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<UwbApplicationConfigurationParameter> applicationConfigurationParameters, std::vector<UwbSetApplicationConfigurationParameterStatus> &applicationConfigurationParameterResults) = 0;
+    SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> &uwbApplicationConfigurationParameters, std::vector<UwbCxDdi::UwbSetApplicationConfigurationParameterStatus> &uwbSetApplicationConfigurationParameterStatuses) = 0;
 
     /**
      * @brief Get the Session Count object

--- a/windows/drivers/uwb/simulator/IUwbSimulatorDdiCallbacksLrp.hxx
+++ b/windows/drivers/uwb/simulator/IUwbSimulatorDdiCallbacksLrp.hxx
@@ -70,8 +70,6 @@ struct IUwbSimulatorDdiCallbacksLrp
      * @param deviceConfigurationParameters
      * @param deviceConfigurationParameterResults
      * @return UwbStatus
-     *
-     * TODO: possibly separate the results into a vector with ones that had UwbStatus::Ok, and a separate vector with the ones that weren't retrieved.
      */
     virtual UwbStatus
     DeviceSetConfigurationParameters(const std::vector<UwbDeviceConfigurationParameter> &deviceConfigurationParameters, std::vector<std::tuple<UwbDeviceConfigurationParameterType, UwbStatus>> &deviceConfigurationParameterResults) = 0;

--- a/windows/drivers/uwb/simulator/IUwbSimulatorDdiCallbacksLrp.hxx
+++ b/windows/drivers/uwb/simulator/IUwbSimulatorDdiCallbacksLrp.hxx
@@ -94,7 +94,7 @@ struct IUwbSimulatorDdiCallbacksLrp
      * @return UwbStatus
      */
     virtual UwbStatus
-    SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<UwbApplicationConfigurationParameter> applicationConfigurationParameters, std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>> &applicationConfigurationParameterResults) = 0;
+    SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<UwbApplicationConfigurationParameter> applicationConfigurationParameters, std::vector<UwbSetApplicationConfigurationParameterStatus> &applicationConfigurationParameterResults) = 0;
 
     /**
      * @brief Get the Session Count object

--- a/windows/drivers/uwb/simulator/IUwbSimulatorDdiCallbacksLrp.hxx
+++ b/windows/drivers/uwb/simulator/IUwbSimulatorDdiCallbacksLrp.hxx
@@ -93,7 +93,7 @@ struct IUwbSimulatorDdiCallbacksLrp
      * @return UwbStatus
      */
     virtual UwbStatus
-    SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> &uwbApplicationConfigurationParameters, std::vector<UwbCxDdi::UwbSetApplicationConfigurationParameterStatus> &uwbSetApplicationConfigurationParameterStatuses) = 0;
+    SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> &uwbApplicationConfigurationParameters, std::vector<::uwb::protocol::fira::UwbSetApplicationConfigurationParameterStatus> &uwbSetApplicationConfigurationParameterStatuses) = 0;
 
     /**
      * @brief Get the Session Count object

--- a/windows/drivers/uwb/simulator/IUwbSimulatorDdiCallbacksLrp.hxx
+++ b/windows/drivers/uwb/simulator/IUwbSimulatorDdiCallbacksLrp.hxx
@@ -29,7 +29,7 @@ struct IUwbSimulatorDdiCallbacksLrp
     virtual ~IUwbSimulatorDdiCallbacksLrp() = default;
 
     /**
-     * @brief
+     * @brief Reset the UWB device.
      *
      * @return UwbStatus
      */
@@ -37,7 +37,7 @@ struct IUwbSimulatorDdiCallbacksLrp
     DeviceReset() = 0;
 
     /**
-     * @brief
+     * @brief Get uwb device information.
      *
      * @param deviceInfo
      * @return UwbStatus
@@ -46,7 +46,7 @@ struct IUwbSimulatorDdiCallbacksLrp
     DeviceGetInformation(UwbDeviceInformation &deviceInfo) = 0;
 
     /**
-     * @brief
+     * @brief Get uwb device capabilities.
      *
      * @param deviceCapabilities
      * @return UwbStatus
@@ -55,7 +55,7 @@ struct IUwbSimulatorDdiCallbacksLrp
     DeviceGetCapabilities(UwbCapability &deviceCapabilities) = 0;
 
     /**
-     * @brief
+     * @brief Get uwb device configuration parameters.
      *
      * @param deviceConfigurationParameterTypes
      * @param deviceConfigurationParameterResults
@@ -65,7 +65,7 @@ struct IUwbSimulatorDdiCallbacksLrp
     DeviceGetConfigurationParameters(std::vector<UwbDeviceConfigurationParameterType> &deviceConfigurationParameterTypes, std::vector<std::tuple<UwbDeviceConfigurationParameterType, UwbStatus, std::optional<UwbDeviceConfigurationParameter>>> &deviceConfigurationParameterResults) = 0;
 
     /**
-     * @brief
+     * @brief Set uwb device configuration parameters.
      *
      * @param deviceConfigurationParameters
      * @param deviceConfigurationParameterResults
@@ -75,28 +75,29 @@ struct IUwbSimulatorDdiCallbacksLrp
     DeviceSetConfigurationParameters(const std::vector<UwbDeviceConfigurationParameter> &deviceConfigurationParameters, std::vector<std::tuple<UwbDeviceConfigurationParameterType, UwbStatus>> &deviceConfigurationParameterResults) = 0;
 
     /**
-     * @brief Get the Application Configuration Parameters object
+     * @brief Get the session application configuration parameters.
      *
      * @param sessionId
      * @param applicationConfigurationParameterTypes
-     * @param uwbSetApplicationConfigurationParameters
+     * @param applicationConfigurationParameters
      * @return UwbStatus
      */
     virtual UwbStatus
     GetApplicationConfigurationParameters(uint32_t sessionId, std::vector<UwbApplicationConfigurationParameterType> applicationConfigurationParameterTypes, std::vector<UwbApplicationConfigurationParameter> &applicationConfigurationParameters) = 0;
 
     /**
-     * @brief Set the Application Configuration Parameters object
+     * @brief Set the session application configuration parameters.
      *
-     * @param uwbSetApplicationConfigurationParameters
-     * @param applicationConfigurationParameterResults
+     * @param sessionId
+     * @param uwbApplicationConfigurationParameters
+     * @param uwbSetApplicationConfigurationParameterStatuses
      * @return UwbStatus
      */
     virtual UwbStatus
     SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> &uwbApplicationConfigurationParameters, std::vector<::uwb::protocol::fira::UwbSetApplicationConfigurationParameterStatus> &uwbSetApplicationConfigurationParameterStatuses) = 0;
 
     /**
-     * @brief Get the Session Count object
+     * @brief Get the count of active sessions.
      *
      * @param sessionCount
      * @return UwbStatus
@@ -105,7 +106,7 @@ struct IUwbSimulatorDdiCallbacksLrp
     GetSessionCount(uint32_t &sessionCount) = 0;
 
     /**
-     * @brief
+     * @brief Initialize a new session.
      *
      * @param sessionId
      * @param sessionType
@@ -115,7 +116,7 @@ struct IUwbSimulatorDdiCallbacksLrp
     SessionInitialize(uint32_t sessionId, UwbSessionType sessionType) = 0;
 
     /**
-     * @brief
+     * @brief Deinitialize an existing session.
      *
      * @param sessionId
      * @return UwbStatus
@@ -124,7 +125,7 @@ struct IUwbSimulatorDdiCallbacksLrp
     SessionDeninitialize(uint32_t sessionId) = 0;
 
     /**
-     * @brief
+     * @brief Obtain the state of a session.
      *
      * @param sessionId
      * @param sessionState
@@ -134,7 +135,7 @@ struct IUwbSimulatorDdiCallbacksLrp
     SessionGetState(uint32_t sessionId, UwbSessionState &sessionState) = 0;
 
     /**
-     * @brief
+     * @brief Update the multicast list for a session.
      *
      * @param sessionId
      * @param action
@@ -145,7 +146,7 @@ struct IUwbSimulatorDdiCallbacksLrp
     SessionUpdateControllerMulticastList(uint32_t sessionId, UwbMulticastAction action, std::vector<UwbSessionUpdateMulticastListEntry> updateMulticastListEntries) = 0;
 
     /**
-     * @brief
+     * @brief Start ranging in a session.
      *
      * @param sessionId
      * @return UwbStatus
@@ -154,7 +155,7 @@ struct IUwbSimulatorDdiCallbacksLrp
     SessionStartRanging(uint32_t sessionId) = 0;
 
     /**
-     * @brief
+     * @brief Stop ranging in a session.
      *
      * @param sessionId
      * @return UwbStatus
@@ -163,7 +164,7 @@ struct IUwbSimulatorDdiCallbacksLrp
     SessionStopRanging(uint32_t sessionId) = 0;
 
     /**
-     * @brief
+     * @brief Get the number of times ranging was performed in a session.
      *
      * @param sessionId
      * @param rangingCount
@@ -173,7 +174,7 @@ struct IUwbSimulatorDdiCallbacksLrp
     SessionGetRangingCount(uint32_t sessionId, uint32_t &rangingCount) = 0;
 
     /**
-     * @brief
+     * @brief Obtain uwb notification event data.
      *
      * @param notificationData
      * @return NTSTATUS

--- a/windows/drivers/uwb/simulator/IUwbSimulatorDdiCallbacksLrp.hxx
+++ b/windows/drivers/uwb/simulator/IUwbSimulatorDdiCallbacksLrp.hxx
@@ -84,7 +84,7 @@ struct IUwbSimulatorDdiCallbacksLrp
      * @return UwbStatus
      */
     virtual UwbStatus
-    GetApplicationConfigurationParameters(uint32_t sessionId, const std::vector<UwbApplicationConfigurationParameterType> &applicationConfigurationParameterTypes, std::vector<UwbApplicationConfigurationParameter> &applicationConfigurationParameters) = 0;
+    GetApplicationConfigurationParameters(uint32_t sessionId, std::vector<UwbApplicationConfigurationParameterType> applicationConfigurationParameterTypes, std::vector<UwbApplicationConfigurationParameter> &applicationConfigurationParameters) = 0;
 
     /**
      * @brief Set the Application Configuration Parameters object
@@ -94,7 +94,7 @@ struct IUwbSimulatorDdiCallbacksLrp
      * @return UwbStatus
      */
     virtual UwbStatus
-    SetApplicationConfigurationParameters(uint32_t sessionId, const std::vector<UwbApplicationConfigurationParameter> &applicationConfigurationParameters, std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>> &applicationConfigurationParameterResults) = 0;
+    SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<UwbApplicationConfigurationParameter> applicationConfigurationParameters, std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>> &applicationConfigurationParameterResults) = 0;
 
     /**
      * @brief Get the Session Count object

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
@@ -340,8 +340,8 @@ UwbSimulatorDdiCallbacks::SessionStopRanging(uint32_t sessionId)
     }
 
     // TODO: session exclusive mutex
-    // TODO: how do we mark this as stopped ranging? update the state?
-
+    SessionUpdateState(*session, UwbSessionState::Idle, UwbSessionReasonCode::StateChangeWithSessionManagementCommands);
+    
     return UwbStatusOk;
 }
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
@@ -183,7 +183,7 @@ UwbSimulatorDdiCallbacks::SessionDeninitialize(uint32_t sessionId)
 }
 
 UwbStatus
-UwbSimulatorDdiCallbacks::SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<UwbApplicationConfigurationParameter> applicationConfigurationParameters, std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>> &applicationConfigurationParameterResults)
+UwbSimulatorDdiCallbacks::SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<UwbApplicationConfigurationParameter> applicationConfigurationParameters, std::vector<UwbSetApplicationConfigurationParameterStatus> &applicationConfigurationParameterResults)
 {
     TraceLoggingWrite(
         UwbSimulatorTraceloggingProvider,
@@ -198,7 +198,7 @@ UwbSimulatorDdiCallbacks::SetApplicationConfigurationParameters(uint32_t session
         return UwbStatusSession::NotExist;
     }
 
-    std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>> results{};
+    std::vector<UwbSetApplicationConfigurationParameterStatus> results{};
     // TODO: session exclusive mutex
 
     // Partition the parameters into those that are expressly disallowed and those that require further checking.
@@ -210,7 +210,7 @@ UwbSimulatorDdiCallbacks::SetApplicationConfigurationParameters(uint32_t session
 
     // Update result container with all disallowed parameters.
     std::ranges::transform(disallowed, std::back_inserter(results), [&](const auto &applicationConfigurationParameter) {
-        return std::make_tuple(applicationConfigurationParameter.Type, UwbStatusSession::Active);
+        return { UwbStatusSession::Active, applicationConfigurationParameter.Type };
     });
 
     // Process remaining entries.
@@ -244,7 +244,7 @@ UwbSimulatorDdiCallbacks::SetApplicationConfigurationParameters(uint32_t session
         session->ApplicationConfigurationParameters.insert(std::move(node));
 
         // Update result container indicating setting the parameter was successful.
-        return std::make_tuple(type, UwbStatusGeneric::Ok);
+        return { UwbStatusGeneric::Ok, type };
     });
 
     applicationConfigurationParameterResults = std::move(results);

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
@@ -183,7 +183,7 @@ UwbSimulatorDdiCallbacks::SessionDeninitialize(uint32_t sessionId)
 }
 
 UwbStatus
-UwbSimulatorDdiCallbacks::SetApplicationConfigurationParameters(uint32_t sessionId, const std::vector<UwbApplicationConfigurationParameter> & /* applicationConfigurationParameters */, std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>> &applicationConfigurationParameterResults)
+UwbSimulatorDdiCallbacks::SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<UwbApplicationConfigurationParameter> applicationConfigurationParameters, std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>> &applicationConfigurationParameterResults)
 {
     TraceLoggingWrite(
         UwbSimulatorTraceloggingProvider,

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
@@ -177,7 +177,7 @@ UwbSimulatorDdiCallbacks::SessionDeninitialize(uint32_t sessionId)
 }
 
 UwbStatus
-UwbSimulatorDdiCallbacks::SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> &uwbApplicationConfigurationParameters, std::vector<UwbCxDdi::UwbSetApplicationConfigurationParameterStatus> &uwbSetApplicationConfigurationParameterStatuses)
+UwbSimulatorDdiCallbacks::SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> &uwbApplicationConfigurationParameters, std::vector<::uwb::protocol::fira::UwbSetApplicationConfigurationParameterStatus> &uwbSetApplicationConfigurationParameterStatuses)
 {
     TraceLoggingWrite(
         UwbSimulatorTraceloggingProvider,

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
@@ -53,7 +53,7 @@ struct UwbSimulatorDdiCallbacks :
     SessionDeninitialize(uint32_t sessionId) override;
 
     virtual UwbStatus
-    SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<UwbApplicationConfigurationParameter> applicationConfigurationParameters, std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>> &applicationConfigurationParameterResults) override;
+    SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<UwbApplicationConfigurationParameter> applicationConfigurationParameters, std::vector<UwbStatus, std::tuple<UwbApplicationConfigurationParameterType>> &applicationConfigurationParameterResults) override;
 
     virtual UwbStatus
     GetApplicationConfigurationParameters(uint32_t sessionId, std::vector<UwbApplicationConfigurationParameterType> applicationConfigurationParameterTypes, std::vector<UwbApplicationConfigurationParameter> &applicationConfigurationParameters) override;

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
@@ -53,7 +53,7 @@ struct UwbSimulatorDdiCallbacks :
     SessionDeninitialize(uint32_t sessionId) override;
 
     virtual UwbStatus
-    SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> &uwbApplicationConfigurationParameters, std::vector<UwbCxDdi::UwbSetApplicationConfigurationParameterStatus> &uwbSetApplicationConfigurationParameterStatuses) override;
+    SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> &uwbApplicationConfigurationParameters, std::vector<::uwb::protocol::fira::UwbSetApplicationConfigurationParameterStatus> &uwbSetApplicationConfigurationParameterStatuses) override;
 
     virtual UwbStatus
     GetApplicationConfigurationParameters(uint32_t sessionId, std::vector<UwbApplicationConfigurationParameterType> applicationConfigurationParameterTypes, std::vector<UwbApplicationConfigurationParameter> &applicationConfigurationParameters) override;

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
@@ -6,8 +6,6 @@
 #include <memory>
 #include <mutex>
 #include <optional>
-#include <shared_mutex>
-#include <unordered_map>
 #include <vector>
 
 #include <windows.h>
@@ -123,10 +121,6 @@ private:
     // Static device information.
     UwbDeviceInformation m_deviceInformation{};
     UwbCapability m_deviceCapabilities{};
-
-    // Session state and associated lock that protects it.
-    std::shared_mutex m_sessionsGate;
-    std::unordered_map<uint32_t, UwbSimulatorSession> m_sessions{};
 
 private:
     UwbSimulatorCapabilities m_simulatorCapabilities{};

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
@@ -53,7 +53,7 @@ struct UwbSimulatorDdiCallbacks :
     SessionDeninitialize(uint32_t sessionId) override;
 
     virtual UwbStatus
-    SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<UwbApplicationConfigurationParameter> applicationConfigurationParameters, std::vector<UwbStatus, std::tuple<UwbApplicationConfigurationParameterType>> &applicationConfigurationParameterResults) override;
+    SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> &uwbApplicationConfigurationParameters, std::vector<UwbCxDdi::UwbSetApplicationConfigurationParameterStatus> &uwbSetApplicationConfigurationParameterStatuses) override;
 
     virtual UwbStatus
     GetApplicationConfigurationParameters(uint32_t sessionId, std::vector<UwbApplicationConfigurationParameterType> applicationConfigurationParameterTypes, std::vector<UwbApplicationConfigurationParameter> &applicationConfigurationParameters) override;

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
@@ -89,6 +89,16 @@ struct UwbSimulatorDdiCallbacks :
 
 protected:
     /**
+     * @brief Obtain a reference to the session context for the specified
+     * session id.
+     *
+     * @param sessionId The session id to obtain session context for.
+     * @return std::tuple<UwbStatus, std::shared_ptr<UwbSimulatorSession>>
+     */
+    std::tuple<UwbStatus, std::shared_ptr<UwbSimulatorSession>>
+    SessionGet(uint32_t sessionId);
+
+    /**
      * @brief Update the state of the specified session.
      *
      * This function will also generate a UWB notification associated with the change.

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
@@ -53,10 +53,10 @@ struct UwbSimulatorDdiCallbacks :
     SessionDeninitialize(uint32_t sessionId) override;
 
     virtual UwbStatus
-    SetApplicationConfigurationParameters(uint32_t sessionId, const std::vector<UwbApplicationConfigurationParameter> &applicationConfigurationParameters, std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>> &applicationConfigurationParameterResults) override;
+    SetApplicationConfigurationParameters(uint32_t sessionId, std::vector<UwbApplicationConfigurationParameter> applicationConfigurationParameters, std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>> &applicationConfigurationParameterResults) override;
 
     virtual UwbStatus
-    GetApplicationConfigurationParameters(uint32_t sessionId, const std::vector<UwbApplicationConfigurationParameterType> &applicationConfigurationParameterTypes, std::vector<UwbApplicationConfigurationParameter> &applicationConfigurationParameters) override;
+    GetApplicationConfigurationParameters(uint32_t sessionId, std::vector<UwbApplicationConfigurationParameterType> applicationConfigurationParameterTypes, std::vector<UwbApplicationConfigurationParameter> &applicationConfigurationParameters) override;
 
     virtual UwbStatus
     GetSessionCount(uint32_t &sessionCount) override;

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.cxx
@@ -15,12 +15,6 @@
 using namespace windows::devices::uwb::simulator;
 
 /**
- * @brief Namespace alias to reduce typing but preserve clarity regarding DDI
- * conversion.
- */
-namespace UwbCxDdi = windows::devices::uwb::ddi::lrp;
-
-/**
  * @brief Template function alias which partially specializes the
  * UwbSimulatorDispatchEntry template with ClassT = UwbSimulatorDdiHandler.
  * This reduces some typing.
@@ -239,11 +233,12 @@ UwbSimulatorDdiHandler::OnUwbSetApplicationConfigurationParameters(WDFREQUEST re
 
     // Convert DDI input type to neutral type.
     auto &applicationConfigurationParametersIn = *reinterpret_cast<UWB_SET_APP_CONFIG_PARAMS *>(std::data(inputBuffer));
-    std::vector<UwbApplicationConfigurationParameter> applicationConfigurationParameters{};
-    std::vector<UwbSetApplicationConfigurationParameterStatus> applicationConfigurationParameterResults{};
+    auto applicationConfigurationParameters = UwbCxDdi::To(applicationConfigurationParametersIn);
+
+    UwbCxDdi::UwbSetApplicationConfigurationParametersStatus uwbSetApplicationConfigurationParametersStatus;
 
     // Invoke callback.
-    auto statusUwb = m_callbacks->SetApplicationConfigurationParameters(applicationConfigurationParametersIn.sessionId, applicationConfigurationParameters, applicationConfigurationParameterResults);
+    auto statusUwb = m_callbacks->SetApplicationConfigurationParameters(applicationConfigurationParameters.SessionId, applicationConfigurationParameters.Parameters, uwbSetApplicationConfigurationParametersStatus.ParameterStatuses);
 
     // Convert neutral type to DDI output type.
     auto &outputValue = *reinterpret_cast<UWB_SET_APP_CONFIG_PARAMS_STATUS *>(std::data(outputBuffer));

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.cxx
@@ -242,10 +242,9 @@ UwbSimulatorDdiHandler::OnUwbSetApplicationConfigurationParameters(WDFREQUEST re
 
     // Convert neutral type to DDI output type.
     auto &outputValue = *reinterpret_cast<UWB_SET_APP_CONFIG_PARAMS_STATUS *>(std::data(outputBuffer));
-    outputValue.size = sizeof outputValue;
-    outputValue.status = UwbCxDdi::From(statusUwb);
-
-    // TODO: the output value needs to be filled in with applicationConfigurationParameterResults
+    auto setApplicationConfigurationParametersStatus = UwbCxDdi::From(uwbSetApplicationConfigurationParametersStatus);
+    auto setApplicationConfigurationParametersStatusBuffer = std::data(setApplicationConfigurationParametersStatus);
+    std::memcpy(std::data(outputBuffer), std::data(setApplicationConfigurationParametersStatusBuffer), std::size(setApplicationConfigurationParametersStatusBuffer));
 
     // Complete the request.
     WdfRequestCompleteWithInformation(request, status, outputValue.size);

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.cxx
@@ -214,7 +214,7 @@ UwbSimulatorDdiHandler::OnUwbGetApplicationConfigurationParameters(WDFREQUEST re
         auto applicationConfigurationParameterBuffer = std::data(applicationConfigurationParametersWrapper);
         std::ranges::copy(applicationConfigurationParameterBuffer, std::begin(outputBuffer));
     } else {
-        outputValue.size = sizeof outputValue;
+        outputValue.size = offsetof(UWB_APP_CONFIG_PARAMS, appConfigParams[0]);
         outputValue.status = UwbCxDdi::From(statusUwb);
         outputValue.appConfigParamsCount = 0;
     }

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.cxx
@@ -240,7 +240,7 @@ UwbSimulatorDdiHandler::OnUwbSetApplicationConfigurationParameters(WDFREQUEST re
     // Convert DDI input type to neutral type.
     auto &applicationConfigurationParametersIn = *reinterpret_cast<UWB_SET_APP_CONFIG_PARAMS *>(std::data(inputBuffer));
     std::vector<UwbApplicationConfigurationParameter> applicationConfigurationParameters{};
-    std::vector<std::tuple<UwbApplicationConfigurationParameterType, UwbStatus>> applicationConfigurationParameterResults{};
+    std::vector<UwbSetApplicationConfigurationParameterStatus> applicationConfigurationParameterResults{};
 
     // Invoke callback.
     auto statusUwb = m_callbacks->SetApplicationConfigurationParameters(applicationConfigurationParametersIn.sessionId, applicationConfigurationParameters, applicationConfigurationParameterResults);

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.hxx
@@ -23,8 +23,8 @@ class UwbSimulatorDdiHandler :
 public:
     /**
      * @brief Construct a new UwbSimulatorDdiHandler object.
-     * 
-     * @param deviceFile The file object context for this handler. 
+     *
+     * @param deviceFile The file object context for this handler.
      */
     explicit UwbSimulatorDdiHandler(UwbSimulatorDeviceFile *deviceFile);
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDevice.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDevice.hxx
@@ -7,7 +7,15 @@
 #include <wdf.h>
 #include <wdfrequest.h>
 
+#include <memory>
+#include <shared_mutex>
+#include <tuple>
+#include <unordered_map>
+
 #include "UwbSimulatorIoQueue.hxx"
+#include "UwbSimulatorSession.hxx"
+
+#include <uwb/protocols/fira/FiraDevice.hxx>
 
 /**
  * @brief
@@ -37,6 +45,18 @@ public:
      */
     NTSTATUS
     Uninitialize();
+
+    std::tuple<UwbStatus, std::shared_ptr<windows::devices::uwb::simulator::UwbSimulatorSession>>
+    SessionCreate(uint32_t sessionId, UwbSessionType sessionType);
+
+    std::tuple<UwbStatus, std::shared_ptr<windows::devices::uwb::simulator::UwbSimulatorSession>>
+    SessionDestroy(uint32_t sessionId);
+
+    std::shared_ptr<windows::devices::uwb::simulator::UwbSimulatorSession>
+    SessionGet(uint32_t sessionId);
+
+    std::size_t
+    GetSessionCount();
 
 public:
     static EVT_WDF_DRIVER_DEVICE_ADD OnWdfDeviceAdd;
@@ -86,6 +106,10 @@ private:
 private:
     WDFDEVICE m_wdfDevice;
     UwbSimulatorIoQueue *m_ioQueue{ nullptr };
+
+    // Session state and associated lock that protects it.
+    std::shared_mutex m_sessionsGate;
+    std::unordered_map<uint32_t, std::shared_ptr<windows::devices::uwb::simulator::UwbSimulatorSession>> m_sessions{};
 };
 
 WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(UwbSimulatorDevice, GetUwbSimulatorDevice)

--- a/windows/drivers/uwb/simulator/UwbSimulatorDevice.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDevice.hxx
@@ -46,15 +46,39 @@ public:
     NTSTATUS
     Uninitialize();
 
+    /**
+     * @brief Create a new uwb session.
+     *
+     * @param sessionId
+     * @param sessionType
+     * @return std::tuple<UwbStatus, std::shared_ptr<windows::devices::uwb::simulator::UwbSimulatorSession>>
+     */
     std::tuple<UwbStatus, std::shared_ptr<windows::devices::uwb::simulator::UwbSimulatorSession>>
     SessionCreate(uint32_t sessionId, UwbSessionType sessionType);
 
+    /**
+     * @brief Destroy an existing session.
+     *
+     * @param sessionId
+     * @return std::tuple<UwbStatus, std::shared_ptr<windows::devices::uwb::simulator::UwbSimulatorSession>>
+     */
     std::tuple<UwbStatus, std::shared_ptr<windows::devices::uwb::simulator::UwbSimulatorSession>>
     SessionDestroy(uint32_t sessionId);
 
+    /**
+     * @brief Get a shared reference to an existing session.
+     *
+     * @param sessionId
+     * @return std::shared_ptr<windows::devices::uwb::simulator::UwbSimulatorSession>
+     */
     std::shared_ptr<windows::devices::uwb::simulator::UwbSimulatorSession>
     SessionGet(uint32_t sessionId);
 
+    /**
+     * @brief Get the number of sessions.
+     *
+     * @return std::size_t
+     */
     std::size_t
     GetSessionCount();
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.cxx
@@ -8,8 +8,9 @@
 
 using windows::devices::uwb::simulator::IUwbSimulatorDdiHandler;
 
-UwbSimulatorDeviceFile::UwbSimulatorDeviceFile(WDFFILEOBJECT wdfFile) :
-    m_wdfFile(wdfFile)
+UwbSimulatorDeviceFile::UwbSimulatorDeviceFile(WDFFILEOBJECT wdfFile, UwbSimulatorDevice *uwbSimulatorDevice) :
+    m_wdfFile(wdfFile),
+    m_uwbSimulatorDevice(uwbSimulatorDevice)
 {}
 
 WDFFILEOBJECT
@@ -22,6 +23,12 @@ UwbSimulatorIoEventQueue *
 UwbSimulatorDeviceFile::GetIoEventQueue() noexcept
 {
     return m_ioEventQueue;
+}
+
+UwbSimulatorDevice *
+UwbSimulatorDeviceFile::GetDevice() noexcept
+{
+    return m_uwbSimulatorDevice;
 }
 
 NTSTATUS

--- a/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.hxx
@@ -55,15 +55,25 @@ public:
 
     /**
      * @brief Get the associated wdf file handle.
-     * 
-     * @return WDFFILEOBJECT 
+     *
+     * @return WDFFILEOBJECT
      */
     WDFFILEOBJECT
     GetWdfFile() const noexcept;
 
-    UwbSimulatorIoEventQueue*
+    /**
+     * @brief Get a pointer to the io event queue for this file object.
+     *
+     * @return UwbSimulatorIoEventQueue*
+     */
+    UwbSimulatorIoEventQueue *
     GetIoEventQueue() noexcept;
 
+    /**
+     * @brief Get a pointer to the simulator device that owns this file object.
+     *
+     * @return UwbSimulatorDevice*
+     */
     UwbSimulatorDevice *
     GetDevice() noexcept;
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.hxx
@@ -12,13 +12,15 @@
 #include "IUwbSimulatorDdiHandler.hxx"
 #include "UwbSimulatorIoEventQueue.hxx"
 
+class UwbSimulatorDevice;
+
 /**
  * @brief Device driver open file abstraction.
  */
 class UwbSimulatorDeviceFile
 {
 public:
-    explicit UwbSimulatorDeviceFile(WDFFILEOBJECT wdfFile);
+    explicit UwbSimulatorDeviceFile(WDFFILEOBJECT wdfFile, UwbSimulatorDevice *uwbSimulatorDevice);
 
     /**
      * @brief Initializes the file object for use.
@@ -62,6 +64,9 @@ public:
     UwbSimulatorIoEventQueue*
     GetIoEventQueue() noexcept;
 
+    UwbSimulatorDevice *
+    GetDevice() noexcept;
+
 public:
     static EVT_WDF_OBJECT_CONTEXT_DESTROY OnWdfDestroy;
     static EVT_WDF_REQUEST_CANCEL OnWdfRequestCancel;
@@ -83,6 +88,7 @@ private:
 
 private:
     WDFFILEOBJECT m_wdfFile;
+    UwbSimulatorDevice *m_uwbSimulatorDevice{ nullptr };
     UwbSimulatorIoEventQueue *m_ioEventQueue{ nullptr };
     std::vector<std::unique_ptr<windows::devices::uwb::simulator::IUwbSimulatorDdiHandler>> m_ddiHandlers{};
 };

--- a/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.cxx
@@ -16,12 +16,6 @@
 
 using ::uwb::protocol::fira::UwbNotificationData;
 
-/**
- * @brief Namespace alias to reduce typing but preserve clarity regarding DDI
- * conversion.
- */
-namespace UwbCxDdi = windows::devices::uwb::ddi::lrp;
-
 UwbSimulatorIoEventQueue::UwbSimulatorIoEventQueue(WDFQUEUE wdfQueue, std::size_t maximumQueueSize) :
     m_wdfQueue(wdfQueue),
     m_maximumQueueSize(maximumQueueSize)


### PR DESCRIPTION
### Type

- [X] Bug fix
- [X] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

* Ensure the simulator driver correctly responds to `IOCTL_UWB_GET_APP_CONFIG_PARAMS` and `IOCTL_UWB_SET_APP_CONFIG_PARAMS`.

### Technical Details

* Move simulator driver session management from file context to device context (bug fix).
* Debug-print set application configuration parameters for `start ranging` command.
* Add additional transitional types to bridge from the neutral types to the DDI input and output types, thus eliminating use of `std::tuple` from the simulator APIs.

### Test Results

All unit tests pass on both Linux and Windows.

### Reviewer Focus

There's a lot here, but no particular focus.

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
