### PR TITLE
Remove binaries from vcpkg distributed package

### DIFF
--- a/packaging/vcpkg/ports/nearobject-framework/portfile.cmake.in
+++ b/packaging/vcpkg/ports/nearobject-framework/portfile.cmake.in
@@ -24,5 +24,10 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE 
+    "${CURRENT_PACKAGES_DIR}/bin"
+    "${CURRENT_PACKAGES_DIR}/debug/bin"
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+)
+
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [X] Infrastructure

### Goals

Ensure no binaries are distributed with the vcpkg package.

### Technical Details

* Delete the installed binaries from the packaging directory in the vcpkg port file.

### Test Results

* Built the simulator driver and ensured vcpkg didn't spit out any warnings.

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
