### PR TITLE
Fix session callbacks issue in nocli

### DIFF
--- a/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
@@ -7,6 +7,7 @@
 
 #include <nearobject/cli/NearObjectCliControlFlowContext.hxx>
 #include <nearobject/cli/NearObjectCliData.hxx>
+#include <nearobject/cli/NearObjectCliUwbSessionEventCallbacks.hxx>
 #include <uwb/UwbDevice.hxx>
 #include <uwb/UwbSession.hxx>
 #include <uwb/protocols/fira/UwbSessionData.hxx>
@@ -21,7 +22,7 @@ class NearObjectCli;
  */
 struct NearObjectCliHandler
 {
-    NearObjectCliHandler() = default;
+    NearObjectCliHandler();
 
     virtual ~NearObjectCliHandler() = default;
 
@@ -99,6 +100,7 @@ struct NearObjectCliHandler
 private:
     NearObjectCli* m_parent;
     std::shared_ptr<::uwb::UwbSession> m_activeSession;
+    std::shared_ptr<NearObjectCliUwbSessionEventCallbacks> m_sessionEventCallbacks;
 };
 
 } // namespace nearobject::cli

--- a/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
@@ -22,7 +22,7 @@ class NearObjectCli;
  */
 struct NearObjectCliHandler
 {
-    NearObjectCliHandler();
+    NearObjectCliHandler() = default;
 
     virtual ~NearObjectCliHandler() = default;
 

--- a/windows/devices/uwb/UwbDevice.cxx
+++ b/windows/devices/uwb/UwbDevice.cxx
@@ -41,7 +41,7 @@ UwbDevice::DeviceName() const noexcept
 std::shared_ptr<uwb::UwbSession>
 UwbDevice::CreateSessionImpl(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks)
 {
-    return std::make_shared<UwbSession>(sessionId, std::move(callbacks), std::dynamic_pointer_cast<UwbConnector>(m_uwbDeviceConnector));
+    return std::make_shared<UwbSession>(sessionId, std::move(callbacks), this);
 }
 
 UwbCapability

--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -17,7 +17,7 @@
 using namespace windows::devices::uwb;
 using namespace ::uwb::protocol::fira;
 
-UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, UwbDevice* uwbDevice, ::uwb::protocol::fira::DeviceType deviceType) :
+UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, UwbDevice *uwbDevice, ::uwb::protocol::fira::DeviceType deviceType) :
     ::uwb::UwbSession(sessionId, std::move(callbacks), deviceType)
 {
     m_registeredCallbacks = std::make_shared<::uwb::UwbRegisteredSessionEventCallbacks>(

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
@@ -50,11 +50,6 @@ public:
     /**
      * @brief Start listening for notifications.
      *
-     * Note: this is a rudimentary implementation and is only present to
-     * preserve existing behavior. It will eventually be replaced by a
-     * fine-grained publication/subscription model.
-     *
-     * @param onNotification The handler to invoke for each notification.
      * @return true If listening for notifications started successfully.
      * @return false If listening for notifications could not be started.
      */

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
@@ -14,6 +14,8 @@
 
 namespace windows::devices::uwb
 {
+class UwbDevice;
+
 /**
  * @brief Windows concrete implementation of a UWB session.
  */
@@ -27,9 +29,9 @@ public:
      *
      * @param sessionId
      * @param callbacks The event callback instance.
-     * @param uwbDeviceConnector The connector to the UWB-CX driver instance.
+     * @param uwbDevice The uwb device tied to the session.
      */
-    UwbSession(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, std::shared_ptr<IUwbSessionDdiConnector> uwbDeviceConnector, ::uwb::protocol::fira::DeviceType deviceType = ::uwb::protocol::fira::DeviceType::Controller);
+    UwbSession(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, UwbDevice* uwbDevice, ::uwb::protocol::fira::DeviceType deviceType = ::uwb::protocol::fira::DeviceType::Controller);
 
 private:
     /**

--- a/windows/devices/uwbsimulator/UwbDeviceSimulator.cxx
+++ b/windows/devices/uwbsimulator/UwbDeviceSimulator.cxx
@@ -39,7 +39,7 @@ UwbDeviceSimulator::Initialize()
 std::shared_ptr<::uwb::UwbSession>
 UwbDeviceSimulator::CreateSessionImpl(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks)
 {
-    return std::make_shared<UwbSessionSimulator>(sessionId, std::move(callbacks), std::dynamic_pointer_cast<UwbConnector>(m_uwbDeviceConnector), m_uwbDeviceSimulatorConnector);
+    return std::make_shared<UwbSessionSimulator>(sessionId, std::move(callbacks), this, m_uwbDeviceSimulatorConnector);
 }
 
 UwbSimulatorCapabilities

--- a/windows/devices/uwbsimulator/UwbSessionSimulator.cxx
+++ b/windows/devices/uwbsimulator/UwbSessionSimulator.cxx
@@ -3,7 +3,7 @@
 
 using namespace windows::devices::uwb::simulator;
 
-UwbSessionSimulator::UwbSessionSimulator(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, std::shared_ptr<IUwbSessionDdiConnector> uwbDeviceConnector, std::shared_ptr<UwbDeviceSimulatorConnector> uwbDeviceSimulatorConnector) :
-    UwbSession(sessionId, std::move(callbacks), std::move(uwbDeviceConnector)),
+UwbSessionSimulator::UwbSessionSimulator(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, UwbDevice* uwbDevice, std::shared_ptr<UwbDeviceSimulatorConnector> uwbDeviceSimulatorConnector) :
+    UwbSession(sessionId, std::move(callbacks), uwbDevice),
     m_uwbDeviceSimulatorConnector(std::move(uwbDeviceSimulatorConnector))
 {}

--- a/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbSessionSimulator.hxx
+++ b/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbSessionSimulator.hxx
@@ -18,7 +18,7 @@ class UwbSessionSimulator :
     public windows::devices::uwb::UwbSession
 {
 public:
-    UwbSessionSimulator(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, std::shared_ptr<IUwbSessionDdiConnector> uwbDeviceConnector, std::shared_ptr<UwbDeviceSimulatorConnector> uwbDeviceSimulatorConnector);
+    UwbSessionSimulator(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, UwbDevice* uwbDevice, std::shared_ptr<UwbDeviceSimulatorConnector> uwbDeviceSimulatorConnector);
 
     virtual ~UwbSessionSimulator() = default;
 


### PR DESCRIPTION
### Type

- [x] Bug fix
- [ ] Feature addition
- [x] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

This PR fixes an issue where session callbacks for ranging data were not firing.

### Technical Details

- Changed UwbSession constructor to take a UwbDevice pointer instead of std::shared_ptr<UwbDeviceConnector>.
- Create new uwb device connector in UwbSession to register session event callbacks and call NotificationListenerStart in UwbSession.
- Save NearObjectCliSessionEventCallbacks in NearObjectCliHandler.
- Update outdated comment for NotificationListenerStart.

### Test Results

Ran nocli with TestClient driver and can successfully get multiple range data notifications without "missing callback" warnings.

### Reviewer Focus

None.

### Future Work

- Update UwbDevice to be created with shared references to avoid passing in a raw UwbDevice pointer

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
