### PR TITLE
UWB Simulator driver fixes

### DIFF
--- a/lib/uwb/UwbSession.cxx
+++ b/lib/uwb/UwbSession.cxx
@@ -102,3 +102,10 @@ UwbSession::GetApplicationConfigurationParameters()
     PLOG_VERBOSE << "get application configuration parameters";
     return GetApplicationConfigurationParametersImpl();
 }
+
+void
+UwbSession::Destroy()
+{
+    PLOG_VERBOSE << "destroy session with id " << m_sessionId;
+    DestroyImpl();
+}

--- a/lib/uwb/include/uwb/UwbSession.hxx
+++ b/lib/uwb/include/uwb/UwbSession.hxx
@@ -108,6 +108,12 @@ public:
     std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter>
     GetApplicationConfigurationParameters();
 
+    /**
+     * @brief Destroy the session, making it unusable.
+     */
+    void
+    Destroy();
+
 private:
     /**
      * @brief Internal function to insert a peer address to this session
@@ -152,6 +158,12 @@ private:
      */
     virtual std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter>
     GetApplicationConfigurationParametersImpl() = 0;
+
+    /**
+     * @brief Destroy the session, making it unusable.
+     */
+    virtual void 
+    DestroyImpl() = 0;
 
 protected:
     uwb::protocol::fira::DeviceType m_deviceType{ uwb::protocol::fira::DeviceType::Controller };

--- a/lib/uwb/include/uwb/UwbSession.hxx
+++ b/lib/uwb/include/uwb/UwbSession.hxx
@@ -102,8 +102,8 @@ public:
 
     /**
      * @brief Get the application configuration parameters for this session.
-     * 
-     * @return std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> 
+     *
+     * @return std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter>
      */
     std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter>
     GetApplicationConfigurationParameters();
@@ -153,8 +153,8 @@ private:
 
     /**
      * @brief Get the application configuration parameters for this session.
-     * 
-     * @return std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> 
+     *
+     * @return std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter>
      */
     virtual std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter>
     GetApplicationConfigurationParametersImpl() = 0;
@@ -162,7 +162,7 @@ private:
     /**
      * @brief Destroy the session, making it unusable.
      */
-    virtual void 
+    virtual void
     DestroyImpl() = 0;
 
 protected:

--- a/lib/uwb/protocols/fira/FiraDevice.cxx
+++ b/lib/uwb/protocols/fira/FiraDevice.cxx
@@ -286,7 +286,7 @@ uwb::protocol::fira::ToString(const UwbApplicationConfigurationParameterValue& u
         } else if constexpr (std::is_same_v<T, ::uwb::UwbMacAddress>) {
             ss << arg;
         } else if constexpr (std::is_same_v<T, std::unordered_set<::uwb::UwbMacAddress>>) {
-            for (const auto &uwbMacAddress : arg) {
+            for (const auto& uwbMacAddress : arg) {
                 ss << uwbMacAddress << ' ';
             }
         } else if constexpr (std::is_same_v<T, std::unordered_set<ResultReportConfiguration>>) {

--- a/lib/uwb/protocols/fira/FiraDevice.cxx
+++ b/lib/uwb/protocols/fira/FiraDevice.cxx
@@ -281,7 +281,19 @@ uwb::protocol::fira::ToString(const UwbApplicationConfigurationParameterValue& u
         using T = std::decay_t<decltype(arg)>;
         if constexpr (std::is_enum_v<T>) {
             ss << magic_enum::enum_name(arg);
-        } else if constexpr (std::is_integral_v<T> || std::is_same_v<T, ::uwb::UwbMacAddress>) {
+        } else if constexpr (std::is_integral_v<T>) {
+            ss << +arg;
+        } else if constexpr (std::is_same_v<T, ::uwb::UwbMacAddress>) {
+            ss << arg;
+        } else if constexpr (std::is_same_v<T, std::unordered_set<::uwb::UwbMacAddress>>) {
+            for (const auto &uwbMacAddress : arg) {
+                ss << uwbMacAddress << ' ';
+            }
+        } else if constexpr (std::is_same_v<T, std::unordered_set<ResultReportConfiguration>>) {
+            ss << ToString(arg);
+        } else if constexpr (std::is_same_v<T, std::array<uint8_t, StaticStsInitializationVectorLength>>) {
+            ss << std::showbase << std::hex << +arg[0] << +arg[1] << +arg[2] << +arg[3] << +arg[4] << +arg[5];
+        } else {
             ss << arg;
         }
     },

--- a/tools/cli/NearObjectCliControlFlowContext.cxx
+++ b/tools/cli/NearObjectCliControlFlowContext.cxx
@@ -9,7 +9,9 @@ using namespace nearobject::cli;
 NearObjectCliControlFlowContext::NearObjectCliControlFlowContext(std::ptrdiff_t numOperations) :
     m_operationsCompleteLatchCount(numOperations),
     m_operationCompleteLatch(numOperations),
-    m_stopCallback(m_stopSource.get_token(), [&]{ OnStop(); })
+    m_stopCallback(m_stopSource.get_token(), [&] {
+        OnStop();
+    })
 {}
 
 std::stop_token

--- a/tools/cli/NearObjectCliControlFlowContext.cxx
+++ b/tools/cli/NearObjectCliControlFlowContext.cxx
@@ -8,7 +8,8 @@ using namespace nearobject::cli;
 
 NearObjectCliControlFlowContext::NearObjectCliControlFlowContext(std::ptrdiff_t numOperations) :
     m_operationsCompleteLatchCount(numOperations),
-    m_operationCompleteLatch(numOperations)
+    m_operationCompleteLatch(numOperations),
+    m_stopCallback(m_stopSource.get_token(), [&]{ OnStop(); })
 {}
 
 std::stop_token
@@ -43,4 +44,19 @@ void
 NearObjectCliControlFlowContext::OperationsWaitForComplete()
 {
     m_operationCompleteLatch.wait();
+    OnStop();
+}
+
+void
+NearObjectCliControlFlowContext::RegisterStopCallback(std::function<void()> stopCallback)
+{
+    m_stopCallbacks.push_back(std::move(stopCallback));
+}
+
+void
+NearObjectCliControlFlowContext::OnStop()
+{
+    for (auto &stopCallback : m_stopCallbacks) {
+        stopCallback();
+    }
 }

--- a/tools/cli/NearObjectCliHandler.cxx
+++ b/tools/cli/NearObjectCliHandler.cxx
@@ -46,11 +46,15 @@ try {
         PLOG_DEBUG << " > " << applicationConfigurationParameter.ToString();
     }
     session->StartRanging();
+    bool destroySessionOnClose = true; // TODO: allow overriding this
 
     // Register a stop callback such that 
     if (controlFlowContext != nullptr) {
         controlFlowContext->RegisterStopCallback([=](){
-            session->Destroy();
+            session->StopRanging();
+            if (destroySessionOnClose) {
+                session->Destroy();
+            }
         });
     }
 

--- a/tools/cli/NearObjectCliHandler.cxx
+++ b/tools/cli/NearObjectCliHandler.cxx
@@ -49,9 +49,9 @@ try {
     session->StartRanging();
     bool destroySessionOnClose = true; // TODO: allow overriding this
 
-    // Register a stop callback such that 
+    // Register a stop callback such that
     if (controlFlowContext != nullptr) {
-        controlFlowContext->RegisterStopCallback([=](){
+        controlFlowContext->RegisterStopCallback([=]() {
             session->StopRanging();
             if (destroySessionOnClose) {
                 session->Destroy();

--- a/tools/cli/NearObjectCliHandler.cxx
+++ b/tools/cli/NearObjectCliHandler.cxx
@@ -37,6 +37,7 @@ try {
         }
         m_activeSession.reset();
     });
+
     auto session = uwbDevice->CreateSession(rangingParameters.SessionId, callbacks);
     session->Configure(rangingParameters.ApplicationConfigurationParameters);
     auto applicationConfigurationParameters = session->GetApplicationConfigurationParameters();
@@ -45,6 +46,13 @@ try {
         PLOG_DEBUG << " > " << applicationConfigurationParameter.ToString();
     }
     session->StartRanging();
+
+    // Register a stop callback such that 
+    if (controlFlowContext != nullptr) {
+        controlFlowContext->RegisterStopCallback([=](){
+            session->Destroy();
+        });
+    }
 
     // Save the session reference so it stays alive while the session is active.
     m_activeSession = std::move(session);

--- a/tools/cli/include/nearobject/cli/NearObjectCliControlFlowContext.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliControlFlowContext.hxx
@@ -2,8 +2,10 @@
 #ifndef NEAR_OBJECT_CLI_CONTROL_FLOW_CONTEXT_HXX
 #define NEAR_OBJECT_CLI_CONTROL_FLOW_CONTEXT_HXX
 
+#include <functional>
 #include <latch>
 #include <stop_token>
+#include <vector>
 
 namespace nearobject::cli
 {
@@ -58,10 +60,28 @@ public:
     void
     OperationsWaitForComplete();
 
+    /**
+     * @brief Register a callback to be invoked when a stop is requested. 
+     * 
+     * @param stopCallback 
+     */
+    void
+    RegisterStopCallback(std::function<void()> stopCallback);
+
+private:
+    /**
+     * @brief Function which runs when `stop_requested()` is called on the stop
+     * source.
+     */
+    void
+    OnStop();
+
 private:
     std::ptrdiff_t m_operationsCompleteLatchCount;
     std::latch m_operationCompleteLatch;
     std::stop_source m_stopSource;
+    std::stop_callback<std::function<void()>> m_stopCallback;
+    std::vector<std::function<void()>> m_stopCallbacks;
 };
 } // namespace nearobject::cli
 

--- a/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
@@ -7,9 +7,9 @@
 
 #include <nearobject/cli/NearObjectCliControlFlowContext.hxx>
 #include <nearobject/cli/NearObjectCliData.hxx>
-#include <uwb/UwbSessionEventCallbacks.hxx>
 #include <uwb/UwbDevice.hxx>
 #include <uwb/UwbSession.hxx>
+#include <uwb/UwbSessionEventCallbacks.hxx>
 #include <uwb/protocols/fira/UwbSessionData.hxx>
 
 namespace nearobject::cli

--- a/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
@@ -7,6 +7,7 @@
 
 #include <nearobject/cli/NearObjectCliControlFlowContext.hxx>
 #include <nearobject/cli/NearObjectCliData.hxx>
+#include <uwb/UwbSessionEventCallbacks.hxx>
 #include <uwb/UwbDevice.hxx>
 #include <uwb/UwbSession.hxx>
 #include <uwb/protocols/fira/UwbSessionData.hxx>
@@ -99,6 +100,7 @@ struct NearObjectCliHandler
 private:
     NearObjectCli* m_parent;
     std::shared_ptr<::uwb::UwbSession> m_activeSession;
+    std::shared_ptr<::uwb::UwbSessionEventCallbacks> m_sessionEventCallbacks;
 };
 
 } // namespace nearobject::cli

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -103,7 +103,7 @@ UwbDeviceConnector::GetDeviceInformation()
     // the case, the first attempt will succeed. Otherwise, the buffer is grown
     // to account for the vendor specific information, and the IOCTL attempted a
     // second time.
-    for (const auto i : std::ranges::iota_view{ 1, 2 }) {
+    for (const auto i : std::ranges::iota_view{ 0, 2 }) {
         deviceInformationBuffer.resize(bytesRequired);
         PLOG_DEBUG << "IOCTL_UWB_GET_DEVICE_INFO attempt #" << i << " with " << std::size(deviceInformationBuffer) << "-byte buffer";
         BOOL ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_GET_DEVICE_INFO, nullptr, 0, std::data(deviceInformationBuffer), std::size(deviceInformationBuffer), &bytesRequired, nullptr);
@@ -399,7 +399,7 @@ UwbDeviceConnector::GetApplicationConfigurationParameters(uint32_t sessionId, st
     DWORD bytesRequired = 0;
     std::vector<uint8_t> getAppConfigParamsResultBuffer{};
 
-    for (const auto i : std::ranges::iota_view{ 1, 2 }) {
+    for (const auto i : std::ranges::iota_view{ 0, 2 }) {
         getAppConfigParamsResultBuffer.resize(bytesRequired);
         PLOG_DEBUG << "IOCTL_UWB_GET_APP_CONFIG_PARAMS attempt #" << i << " with " << std::size(getAppConfigParamsResultBuffer) << "-byte buffer";
         BOOL ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_GET_APP_CONFIG_PARAMS, std::data(getAppConfigParamsBuffer), std::size(getAppConfigParamsBuffer), std::data(getAppConfigParamsResultBuffer), std::size(getAppConfigParamsResultBuffer), &bytesRequired, nullptr);
@@ -486,7 +486,7 @@ UwbDeviceConnector::HandleNotifications(std::stop_token stopToken)
 
     while (!stopToken.stop_requested()) {
         m_notificationOverlapped = {};
-        for (const auto i : std::ranges::iota_view{ 1, 2 }) {
+        for (const auto i : std::ranges::iota_view{ 0, 2 }) {
             uwbNotificationDataBuffer.resize(bytesRequired);
             PLOG_DEBUG << "IOCTL_UWB_NOTIFICATION attempt #" << i << " with " << std::size(uwbNotificationDataBuffer) << "-byte buffer";
             BOOL ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_NOTIFICATION, nullptr, 0, std::data(uwbNotificationDataBuffer), std::size(uwbNotificationDataBuffer), &bytesRequired, &m_notificationOverlapped);

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -110,7 +110,7 @@ UwbDeviceConnector::GetDeviceInformation()
         if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
             DWORD lastError = GetLastError();
             // Treat all errors other than insufficient buffer size as fatal.
-            if (lastError != ERROR_INSUFFICIENT_BUFFER) {
+            if (lastError != ERROR_MORE_DATA) {
                 HRESULT hr = HRESULT_FROM_WIN32(lastError);
                 PLOG_ERROR << "error when sending IOCTL_UWB_GET_DEVICE_INFO, hr=" << std::showbase << std::hex << hr;
                 resultPromise.set_exception(std::make_exception_ptr(UwbException(UwbStatusGeneric::Failed)));
@@ -501,7 +501,7 @@ UwbDeviceConnector::HandleNotifications(std::stop_token stopToken)
                             << "error waiting for IOCTL_UWB_NOTIFICATION completion, hr=" << std::showbase << std::hex << hr;
                         break; // for({1,2})
                     }
-                } else if (lastError == ERROR_INSUFFICIENT_BUFFER) {
+                } else if (lastError == ERROR_MORE_DATA) {
                     // Attempt to retry the ioctl with the appropriate buffer size, which is now held in bytesRequired.
                     continue;
                 } else {

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -406,7 +406,7 @@ UwbDeviceConnector::GetApplicationConfigurationParameters(uint32_t sessionId, st
         if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
             DWORD lastError = GetLastError();
             // Treat all errors other than insufficient buffer size as fatal.
-            if (lastError != ERROR_INSUFFICIENT_BUFFER) {
+            if (lastError != ERROR_MORE_DATA) {
                 HRESULT hr = HRESULT_FROM_WIN32(lastError);
                 PLOG_ERROR << "error when sending IOCTL_UWB_GET_APP_CONFIG_PARAMS, hr=" << std::showbase << std::hex << hr;
                 resultPromise.set_exception(std::make_exception_ptr(UwbException(UwbStatusGeneric::Failed)));

--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -245,3 +245,24 @@ UwbSession::GetApplicationConfigurationParametersImpl()
         throw e;
     }
 }
+
+void
+UwbSession::DestroyImpl()
+{
+    uint32_t sessionId = GetId();
+    auto resultFuture = m_uwbDeviceConnector->SessionDeinitialize(sessionId);
+    if (!resultFuture.valid()) {
+        PLOG_ERROR << "failed to issue device deinitialization request for session id " << sessionId;
+        throw UwbException(UwbStatusGeneric::Rejected);
+    }
+
+    try {
+        resultFuture.get();
+    } catch (UwbException &uwbException) {
+        PLOG_ERROR << "caught exception attempting to to deinitialize for session id " << sessionId << " (" << ToString(uwbException.Status) << ")";
+        throw uwbException;
+    } catch (std::exception &e) {
+        PLOG_ERROR << "caught unexpected exception attempting to deinitialize for session id " << sessionId << " (" << e.what() << ")";
+        throw e;
+    }
+}

--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -238,10 +238,10 @@ UwbSession::GetApplicationConfigurationParametersImpl()
         }
         return applicationConfigurationParameters;
     } catch (UwbException &uwbException) {
-        PLOG_ERROR << "caught exception attempting to obtain application configuration parameters for session id " << sessionId << "(" << ToString(uwbException.Status) << ")";
+        PLOG_ERROR << "caught exception attempting to obtain application configuration parameters for session id " << sessionId << " (" << ToString(uwbException.Status) << ")";
         throw uwbException;
     } catch (std::exception &e) {
-        PLOG_ERROR << "caught unexpected exception attempting to obtain application configuration parameters for session id " << sessionId << "(" << e.what() << ")";
+        PLOG_ERROR << "caught unexpected exception attempting to obtain application configuration parameters for session id " << sessionId << " (" << e.what() << ")";
         throw e;
     }
 }

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
@@ -30,7 +30,7 @@ class RegisteredCallbackToken;
  * This class exposes functions which map 1-1 to the UWB LRP DDI as defined in
  * UwbCxLrpDevice.h, using neutral C++ types instead of the the raw C ABI
  * types.
- /
+ */
 class UwbDeviceConnector :
     public IUwbDeviceDdi
 {

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
@@ -21,10 +21,16 @@ namespace windows::devices::uwb
 {
 /**
  * @brief Opaque class forward declaration to help with the deregistration
- *
  */
 class RegisteredCallbackToken;
 
+/**
+ * @brief Class representing a logical communication channel with a UWB driver. 
+ * 
+ * This class exposes functions which map 1-1 to the UWB LRP DDI as defined in
+ * UwbCxLrpDevice.h, using neutral C++ types instead of the the raw C ABI
+ * types.
+ /
 class UwbDeviceConnector :
     public IUwbDeviceDdi
 {

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
@@ -25,8 +25,8 @@ namespace windows::devices::uwb
 class RegisteredCallbackToken;
 
 /**
- * @brief Class representing a logical communication channel with a UWB driver. 
- * 
+ * @brief Class representing a logical communication channel with a UWB driver.
+ *
  * This class exposes functions which map 1-1 to the UWB LRP DDI as defined in
  * UwbCxLrpDevice.h, using neutral C++ types instead of the the raw C ABI
  * types.

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
@@ -66,6 +66,12 @@ private:
     virtual std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter>
     GetApplicationConfigurationParametersImpl() override;
 
+    /**
+     * @brief Destroy the session, making it unusable.
+     */
+    void
+    DestroyImpl() override;
+
 protected:
     /**
      * @brief Obtain a shared instance of the device driver connector.

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.cxx
@@ -105,7 +105,7 @@ UwbSimulatorDdiHandler::OnUwbGetDeviceInformation(WDFREQUEST request, std::span<
     if (std::size(outputBuffer) >= outputSize) {
         std::memcpy(std::data(outputBuffer), std::data(std::data(uwbDeviceInformation)), outputSize);
     } else {
-        status = STATUS_BUFFER_TOO_SMALL;
+        status = STATUS_BUFFER_OVERFLOW;
     }
 
     // Complete the request.
@@ -133,7 +133,7 @@ UwbSimulatorDdiHandler::OnUwbGetDeviceCapabilities(WDFREQUEST request, std::span
     if (std::size(outputBuffer) >= outputSize) {
         std::memcpy(std::data(outputBuffer), std::data(std::data(uwbCapabilities)), outputSize);
     } else {
-        status = STATUS_BUFFER_TOO_SMALL;
+        status = STATUS_BUFFER_OVERFLOW;
     }
 
     // Complete the request.
@@ -171,7 +171,7 @@ UwbSimulatorDdiHandler::OnUwbGetDeviceConfigurationParameters(WDFREQUEST request
     if (std::size(outputBuffer) >= outputSize) {
         // TODO: std::memcpy(std::data(outputBuffer), std::data(std::data(<neutal wrapper>)), outputBufferSize);
     } else {
-        status = STATUS_BUFFER_TOO_SMALL;
+        status = STATUS_BUFFER_OVERFLOW;
     }
 
     // Complete the request.

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.cxx
@@ -191,6 +191,7 @@ UwbSimulatorDdiHandler::OnUwbSetDeviceConfigurationParameters(WDFREQUEST /*reque
 NTSTATUS
 UwbSimulatorDdiHandler::OnUwbGetApplicationConfigurationParameters(WDFREQUEST request, std::span<uint8_t> inputBuffer, std::span<uint8_t> outputBuffer)
 {
+    std::size_t outputSize = 0;
     NTSTATUS status = STATUS_SUCCESS;
 
     // Convert DDI input type to neutral type.
@@ -212,15 +213,25 @@ UwbSimulatorDdiHandler::OnUwbGetApplicationConfigurationParameters(WDFREQUEST re
     if (IsUwbStatusOk(statusUwb)) {
         auto applicationConfigurationParametersWrapper = UwbCxDdi::From(uwbApplicationConfigurationParameters);
         auto applicationConfigurationParameterBuffer = std::data(applicationConfigurationParametersWrapper);
-        std::ranges::copy(applicationConfigurationParameterBuffer, std::begin(outputBuffer));
+        outputSize = std::size(applicationConfigurationParameterBuffer);
+        if (std::size(outputBuffer) >= outputSize) {
+            std::ranges::copy(applicationConfigurationParameterBuffer, std::begin(outputBuffer));
+        } else {
+            status = STATUS_BUFFER_TOO_SMALL;
+        }
     } else {
-        outputValue.size = offsetof(UWB_APP_CONFIG_PARAMS, appConfigParams[0]);
-        outputValue.status = UwbCxDdi::From(statusUwb);
-        outputValue.appConfigParamsCount = 0;
+        outputSize = offsetof(UWB_APP_CONFIG_PARAMS, appConfigParams[0]);
+        if (std::size(outputBuffer) >= outputSize) {
+            outputValue.size = offsetof(UWB_APP_CONFIG_PARAMS, appConfigParams[0]);
+            outputValue.status = UwbCxDdi::From(statusUwb);
+            outputValue.appConfigParamsCount = 0;
+        } else {
+            status = STATUS_BUFFER_TOO_SMALL;
+        }
     }
 
     // Complete the request.
-    WdfRequestCompleteWithInformation(request, status, outputValue.size);
+    WdfRequestCompleteWithInformation(request, status, outputSize);
 
     return status;
 }

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.cxx
@@ -217,7 +217,7 @@ UwbSimulatorDdiHandler::OnUwbGetApplicationConfigurationParameters(WDFREQUEST re
         if (std::size(outputBuffer) >= outputSize) {
             std::ranges::copy(applicationConfigurationParameterBuffer, std::begin(outputBuffer));
         } else {
-            status = STATUS_BUFFER_TOO_SMALL;
+            status = STATUS_BUFFER_OVERFLOW;
         }
     } else {
         outputSize = offsetof(UWB_APP_CONFIG_PARAMS, appConfigParams[0]);
@@ -226,7 +226,7 @@ UwbSimulatorDdiHandler::OnUwbGetApplicationConfigurationParameters(WDFREQUEST re
             outputValue.status = UwbCxDdi::From(statusUwb);
             outputValue.appConfigParamsCount = 0;
         } else {
-            status = STATUS_BUFFER_TOO_SMALL;
+            status = STATUS_BUFFER_OVERFLOW;
         }
     }
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.cxx
@@ -148,7 +148,7 @@ UwbSimulatorDeviceFile::OnRequest(WDFREQUEST request, ULONG ioControlCode, size_
     switch (status) {
     case STATUS_SUCCESS:
         break;
-    case STATUS_BUFFER_TOO_SMALL:
+    case STATUS_BUFFER_OVERFLOW:
         WdfRequestCompleteWithInformation(request, status, outputBufferLength);
         return status;
     default:

--- a/windows/drivers/uwb/simulator/UwbSimulatorDispatchEntry.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDispatchEntry.hxx
@@ -68,7 +68,7 @@ struct UwbSimulatorDispatchEntry
         if (inputBufferSize < (InputSizeMinimum + inputBufferVariableSize)) {
             return STATUS_INVALID_PARAMETER;
         } else if (outputBufferSize < (OutputSizeMinimum + outputBufferVariableSize)) {
-            return STATUS_BUFFER_TOO_SMALL;
+            return STATUS_BUFFER_OVERFLOW;
         } else {
             return STATUS_SUCCESS;
         }

--- a/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.cxx
@@ -51,7 +51,7 @@ UwbSimulatorIoEventQueue::HandleNotificationRequest(WDFREQUEST request, std::opt
         auto converted = UwbCxDdi::From(notificationData);
         auto outputBufferSizeRequired = converted.size();
         if (outputBufferSize < outputBufferSizeRequired) {
-            status = STATUS_BUFFER_TOO_SMALL;
+            status = STATUS_BUFFER_OVERFLOW;
         } else {
             notificationDataOpt = std::move(notificationData);
             m_notificationQueue.pop();


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Ensure the simulator driver correctly implements `IOCTL_UWB_GET_APP_CONFIG_PARAMS`.

### Technical Details

* Add `UwbSession::Destroy` function to allow clients to destroy the session at will.
* Add ability to register callbacks to run when the `nocli` tool is finished running.
* Register stop callback to stop ranging and destroy the active ranging session upon `nocli` exit.
* Fix `DeviceIoControl` off-by-one loop exit conditions.
* Fix `DeviceIoControl` buffer size check to use correct value `ERROR_MORE_DATA` instead of `ERROR_INSUFFICIENT_BUFFER`.
* Fix simulator driver code to update existing application configuration parameters.
* Fix simulator driver code that partitions application configuration parameters per session state (logic was flipped).
* Fix simulator driver dispatch functions to complete requests with insufficient buffer size with `STATUS_BUFFER_OVERFLOW` instead of `STATUS_BUFFER_TOO_SMALL`. The latter is an error and so will not update the `lpBytesReturned` argument with the required number of bytes.
* Add output buffer size check for `UwbSimulatorDdiHandler::OnUwbGetApplicationConfigurationParameters`.
* Add documentation for `UwbDeviceConnector`.
* Add missing pieces for`UwbApplicationConfigurationParameterValue` `ToString()`

### Test Results

* All unit tests pass on both Linux and Windows.
* Ran `uwb range --SessionId 1234 start --DeviceRole 1 --MultiNodeMode 0 --NumberOfControlees 1 --DeviceMacAddress 12:34 --DestinationMacAddress 67:89 --DeviceType 1` with the following output:

```
Selected parameters:
DeviceRole: Initiator
MultiNodeMode: Unicast
NumberOfControlees: 1
DeviceMacAddress: 12:34
DestinationMacAddresses: 67:89
DeviceType: Controller
Initialize
configure session with id 1234
ConfigureImpl
IOCTL_UWB_NOTIFICATION attempt #0 with 0-byte buffer
IOCTL_UWB_SESSION_INIT succeeded
IOCTL_UWB_SET_APP_CONFIG_PARAMS succeeded
get application configuration parameters
IOCTL_UWB_GET_APP_CONFIG_PARAMS attempt #0 with 0-byte buffer
IOCTL_UWB_GET_APP_CONFIG_PARAMS attempt #1 with 92-byte buffer
IOCTL_UWB_GET_APP_CONFIG_PARAMS succeeded
Session Application Configuration Parameters:
 > DeviceType: Controller
 > MultiNodeMode: Unicast
 > NumberOfControlees: 1
 > DeviceMacAddress: 12:34
 > DestinationMacAddresses: 67:89
 > DeviceRole: Initiator
start ranging
IOCTL_UWB_START_RANGING_SESSION succeeded
```


### Reviewer Focus

None

### Future Work

* Allow overriding close-session-on-exit using a `nocli` flag.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
