### PR TITLE
Implement client side uwb simulator event trigger

### DIFF
--- a/windows/devices/uwbsimulator/UwbDeviceSimulator.cxx
+++ b/windows/devices/uwbsimulator/UwbDeviceSimulator.cxx
@@ -3,6 +3,7 @@
 
 #include <plog/Log.h>
 
+#include <uwb/protocols/fira/FiraDevice.hxx>
 #include <uwb/protocols/fira/UwbException.hxx>
 #include <windows/devices/uwb/UwbDeviceConnector.hxx>
 #include <windows/devices/uwb/simulator/UwbDeviceSimulator.hxx>
@@ -56,6 +57,24 @@ UwbDeviceSimulator::GetSimulatorCapabilities()
         return std::move(simulatorCapabilities);
     } catch (const UwbException& e) {
         PLOG_ERROR << "caught exception obtaining simulator capabilities";
+        throw e;
+    }
+}
+
+UwbSimulatorTriggerSessionEventResult
+UwbDeviceSimulator::TriggerSessionEvent(const UwbSimulatorTriggerSessionEventArgs& triggerSessionEventArgs)
+{
+    auto resultFuture = m_uwbDeviceSimulatorConnector->TriggerSessionEvent(triggerSessionEventArgs);
+    if (!resultFuture.valid()) {
+        PLOG_ERROR << "failed to trigger session event";
+        throw UwbException(UwbStatusGeneric::Failed);
+    }
+
+    try {
+        auto uwbSimulatorTriggerSessionEventResult = resultFuture.get();
+        return std::move(uwbSimulatorTriggerSessionEventResult);
+    } catch (const UwbException& e) {
+        PLOG_ERROR << "caught exception triggering session event (" << ToString(e.Status) << ")";
         throw e;
     }
 }

--- a/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbDeviceSimulator.hxx
+++ b/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbDeviceSimulator.hxx
@@ -59,6 +59,15 @@ public:
     UwbSimulatorCapabilities
     GetSimulatorCapabilities();
 
+    /**
+     * @brief Trigger an event for a session. 
+     * 
+     * @param triggerSessionEventArgs 
+     * @return UwbSimulatorTriggerSessionEventResult 
+     */
+    UwbSimulatorTriggerSessionEventResult
+    TriggerSessionEvent(const UwbSimulatorTriggerSessionEventArgs& triggerSessionEventArgs);
+
 private:
     virtual std::shared_ptr<::uwb::UwbSession>
     CreateSessionImpl(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks) override;

--- a/windows/tools/uwb/simulator/Main.cxx
+++ b/windows/tools/uwb/simulator/Main.cxx
@@ -126,6 +126,7 @@ main(int argc, char* argv[])
 
     if (appTrigger->parsed()) {
         try {
+            uwbSimulatorTriggerSessionEventArgs.SessionId = sessionId;
             auto result = uwbDeviceSimulator->TriggerSessionEvent(uwbSimulatorTriggerSessionEventArgs);
         } catch (UwbException& e) {
             std::cerr << "failed to trigger session event (error=" << ::ToString(e.Status) << ")";


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Allow the `uwb` cli tool to trigger session  events.

### Technical Details

* Implement `IOCTL_UWB_DEVICE_SIM_TRIGGER_SESSION_EVENT` simulator DDI in `UwbDeviceSimulatorConnector`.
* Expose `TriggerSessionEvent` from `UwbDeviceSimulator`.
* Add `trigger` sub-command to `uwbsim.exe` cli tool.

### Test Results

* Ran `nocli.exe uwb range --SessionId 1234 start --DeviceRole 1 --MultiNodeMode 0 --NumberOfControlees 1 --DeviceMacAddress 12:34 --DestinationMacAddress 67:89 --DeviceType 1` in one instance, and `uwbsim.exe trigger --sessionId 1234 -e 1` in another instance and observed the driver toggle random measurement generation.

### Reviewer Focus

None

### Future Work

The driver currently session-event information in file-specific state, which means it is lost when the associated file handle is closed. This state should instead be stored in the `UwbSimulatorSession` object.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
