### PR TITLE
Store session event state with device instead of open file handle

### DIFF
--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -11,9 +11,9 @@
 #include <uwb/UwbPeer.hxx>
 #include <uwb/protocols/fira/UwbException.hxx>
 #include <windows/devices/DeviceHandle.hxx>
-#include <windows/devices/uwb/UwbDeviceConnector.hxx>
 #include <windows/devices/uwb/UwbCxAdapterDdiLrp.hxx>
 #include <windows/devices/uwb/UwbCxDdiLrp.hxx>
+#include <windows/devices/uwb/UwbDeviceConnector.hxx>
 
 using namespace windows::devices;
 using namespace windows::devices::uwb;
@@ -105,7 +105,7 @@ UwbConnector::GetDeviceInformation()
     // second time.
     for (const auto i : std::ranges::iota_view{ 0, 2 }) {
         deviceInformationBuffer.resize(bytesRequired);
-        PLOG_DEBUG << "IOCTL_UWB_GET_DEVICE_INFO attempt #" << (i+1) << " with " << std::size(deviceInformationBuffer) << "-byte buffer";
+        PLOG_DEBUG << "IOCTL_UWB_GET_DEVICE_INFO attempt #" << (i + 1) << " with " << std::size(deviceInformationBuffer) << "-byte buffer";
         BOOL ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_GET_DEVICE_INFO, nullptr, 0, std::data(deviceInformationBuffer), std::size(deviceInformationBuffer), &bytesRequired, nullptr);
         if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
             DWORD lastError = GetLastError();
@@ -401,7 +401,7 @@ UwbConnector::GetApplicationConfigurationParameters(uint32_t sessionId, std::vec
 
     for (const auto i : std::ranges::iota_view{ 0, 2 }) {
         getAppConfigParamsResultBuffer.resize(bytesRequired);
-        PLOG_DEBUG << "IOCTL_UWB_GET_APP_CONFIG_PARAMS attempt #" << (i+1) << " with " << std::size(getAppConfigParamsResultBuffer) << "-byte buffer";
+        PLOG_DEBUG << "IOCTL_UWB_GET_APP_CONFIG_PARAMS attempt #" << (i + 1) << " with " << std::size(getAppConfigParamsResultBuffer) << "-byte buffer";
         BOOL ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_GET_APP_CONFIG_PARAMS, std::data(getAppConfigParamsBuffer), std::size(getAppConfigParamsBuffer), std::data(getAppConfigParamsResultBuffer), std::size(getAppConfigParamsResultBuffer), &bytesRequired, nullptr);
         if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
             DWORD lastError = GetLastError();

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -105,7 +105,7 @@ UwbConnector::GetDeviceInformation()
     // second time.
     for (const auto i : std::ranges::iota_view{ 0, 2 }) {
         deviceInformationBuffer.resize(bytesRequired);
-        PLOG_DEBUG << "IOCTL_UWB_GET_DEVICE_INFO attempt #" << i << " with " << std::size(deviceInformationBuffer) << "-byte buffer";
+        PLOG_DEBUG << "IOCTL_UWB_GET_DEVICE_INFO attempt #" << (i+1) << " with " << std::size(deviceInformationBuffer) << "-byte buffer";
         BOOL ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_GET_DEVICE_INFO, nullptr, 0, std::data(deviceInformationBuffer), std::size(deviceInformationBuffer), &bytesRequired, nullptr);
         if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
             DWORD lastError = GetLastError();
@@ -401,7 +401,7 @@ UwbConnector::GetApplicationConfigurationParameters(uint32_t sessionId, std::vec
 
     for (const auto i : std::ranges::iota_view{ 0, 2 }) {
         getAppConfigParamsResultBuffer.resize(bytesRequired);
-        PLOG_DEBUG << "IOCTL_UWB_GET_APP_CONFIG_PARAMS attempt #" << i << " with " << std::size(getAppConfigParamsResultBuffer) << "-byte buffer";
+        PLOG_DEBUG << "IOCTL_UWB_GET_APP_CONFIG_PARAMS attempt #" << (i+1) << " with " << std::size(getAppConfigParamsResultBuffer) << "-byte buffer";
         BOOL ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_GET_APP_CONFIG_PARAMS, std::data(getAppConfigParamsBuffer), std::size(getAppConfigParamsBuffer), std::data(getAppConfigParamsResultBuffer), std::size(getAppConfigParamsResultBuffer), &bytesRequired, nullptr);
         if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
             DWORD lastError = GetLastError();

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
@@ -16,7 +16,7 @@
 
 #include "IUwbSimulatorDdiCallbacksLrp.hxx"
 #include "IUwbSimulatorDdiCallbacksSimulator.hxx"
-#include "UwbSimulatorDeviceFile.hxx"
+#include "UwbSimulatorDevice.hxx"
 #include "UwbSimulatorSession.hxx"
 
 #include <uwb/protocols/fira/UwbCapability.hxx>
@@ -27,7 +27,7 @@ struct UwbSimulatorDdiCallbacks :
     public IUwbSimulatorDdiCallbacksLrp,
     public IUwbSimulatorDdiCallbacksSimulator
 {
-    UwbSimulatorDdiCallbacks(UwbSimulatorDeviceFile *deviceFile);
+    UwbSimulatorDdiCallbacks(UwbSimulatorDevice *device);
 
     // IUwbSimulatorDdiCallbacksLrp
 
@@ -134,7 +134,7 @@ private:
 
 private:
     UwbSimulatorCapabilities m_simulatorCapabilities{};
-    UwbSimulatorDeviceFile *m_deviceFile;
+    UwbSimulatorDevice *m_device{ nullptr };
 };
 } // namespace windows::devices::uwb::simulator
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.hxx
@@ -12,6 +12,7 @@
 
 #include "IUwbSimulatorDdiHandler.hxx"
 #include "UwbSimulatorDdiCallbacks.hxx"
+#include "UwbSimulatorDevice.hxx"
 #include "UwbSimulatorDeviceFile.hxx"
 #include "UwbSimulatorDispatchEntry.hxx"
 
@@ -21,12 +22,8 @@ class UwbSimulatorDdiHandler :
     public IUwbSimulatorDdiHandler
 {
 public:
-    /**
-     * @brief Construct a new UwbSimulatorDdiHandler object.
-     *
-     * @param deviceFile The file object context for this handler.
-     */
-    explicit UwbSimulatorDdiHandler(UwbSimulatorDeviceFile *deviceFile);
+    // TODO: docs
+    explicit UwbSimulatorDdiHandler(UwbSimulatorDevice *device);
 
     /**
      * @brief Indicates whether the specified i/o control code is handled by
@@ -129,7 +126,7 @@ private:
     static const std::initializer_list<windows::devices::uwb::simulator::UwbSimulatorDispatchEntry<UwbSimulatorDdiHandler>> Dispatch;
 
 private:
-    UwbSimulatorDeviceFile *m_deviceFile;
+    UwbSimulatorDevice *m_device;
     std::unique_ptr<windows::devices::uwb::simulator::UwbSimulatorDdiCallbacks> m_callbacks;
 };
 } // namespace windows::devices::uwb::simulator

--- a/windows/drivers/uwb/simulator/UwbSimulatorDevice.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDevice.cxx
@@ -12,7 +12,8 @@ using windows::devices::uwb::simulator::UwbSimulatorDdiHandler;
 using windows::devices::uwb::simulator::UwbSimulatorSession;
 
 UwbSimulatorDevice::UwbSimulatorDevice(WDFDEVICE wdfDevice) :
-    m_wdfDevice(wdfDevice)
+    m_wdfDevice(wdfDevice),
+    m_ddiHandler(std::make_shared<UwbSimulatorDdiHandler>(nullptr /* FIXME */))
 {}
 
 /* static */
@@ -175,8 +176,7 @@ UwbSimulatorDevice::OnFileCreate(WDFDEVICE device, WDFREQUEST request, WDFFILEOB
     auto uwbSimulatorFile = new (uwbSimulatorFileBuffer) UwbSimulatorDeviceFile(file, this);
     auto uwbSimulatorFileStatus = uwbSimulatorFile->Initialize();
     if (uwbSimulatorFileStatus == STATUS_SUCCESS) {
-        auto uwbSimulatorHandler = std::make_unique<UwbSimulatorDdiHandler>(uwbSimulatorFile);
-        uwbSimulatorFile->RegisterHandler(std::move(uwbSimulatorHandler));
+        uwbSimulatorFile->RegisterHandler(m_ddiHandler);
     } else {
         uwbSimulatorFile->~UwbSimulatorDeviceFile();
     }

--- a/windows/drivers/uwb/simulator/UwbSimulatorDevice.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDevice.hxx
@@ -14,6 +14,7 @@
 
 #include "UwbSimulatorIoQueue.hxx"
 #include "UwbSimulatorSession.hxx"
+#include "IUwbSimulatorDdiHandler.hxx"
 
 #include <uwb/protocols/fira/FiraDevice.hxx>
 
@@ -130,6 +131,7 @@ private:
 private:
     WDFDEVICE m_wdfDevice;
     UwbSimulatorIoQueue *m_ioQueue{ nullptr };
+    std::shared_ptr<windows::devices::uwb::simulator::IUwbSimulatorDdiHandler> m_ddiHandler;
 
     // Session state and associated lock that protects it.
     std::shared_mutex m_sessionsGate;

--- a/windows/drivers/uwb/simulator/UwbSimulatorDevice.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDevice.hxx
@@ -12,9 +12,10 @@
 #include <tuple>
 #include <unordered_map>
 
+#include "IUwbSimulatorDdiHandler.hxx"
+#include "UwbSimulatorIoEventQueue.hxx"
 #include "UwbSimulatorIoQueue.hxx"
 #include "UwbSimulatorSession.hxx"
-#include "IUwbSimulatorDdiHandler.hxx"
 
 #include <uwb/protocols/fira/FiraDevice.hxx>
 
@@ -46,6 +47,10 @@ public:
      */
     NTSTATUS
     Uninitialize();
+
+    // TODO: docs
+    std::weak_ptr<UwbSimulatorIoEventQueue>
+    GetIoEventQueue() noexcept;
 
     /**
      * @brief Create a new uwb session.
@@ -131,6 +136,7 @@ private:
 private:
     WDFDEVICE m_wdfDevice;
     UwbSimulatorIoQueue *m_ioQueue{ nullptr };
+    std::shared_ptr<UwbSimulatorIoEventQueue> m_ioEventQueue{ nullptr };
     std::shared_ptr<windows::devices::uwb::simulator::IUwbSimulatorDdiHandler> m_ddiHandler;
 
     // Session state and associated lock that protects it.

--- a/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.cxx
@@ -75,7 +75,7 @@ UwbSimulatorDeviceFile::Initialize()
 }
 
 void
-UwbSimulatorDeviceFile::RegisterHandler(std::unique_ptr<IUwbSimulatorDdiHandler> handler)
+UwbSimulatorDeviceFile::RegisterHandler(std::shared_ptr<IUwbSimulatorDdiHandler> handler)
 {
     m_ddiHandlers.push_back(std::move(handler));
 }

--- a/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.cxx
@@ -19,12 +19,6 @@ UwbSimulatorDeviceFile::GetWdfFile() const noexcept
     return m_wdfFile;
 }
 
-UwbSimulatorIoEventQueue *
-UwbSimulatorDeviceFile::GetIoEventQueue() noexcept
-{
-    return m_ioEventQueue;
-}
-
 UwbSimulatorDevice *
 UwbSimulatorDeviceFile::GetDevice() noexcept
 {
@@ -34,44 +28,7 @@ UwbSimulatorDeviceFile::GetDevice() noexcept
 NTSTATUS
 UwbSimulatorDeviceFile::Initialize()
 {
-    // Create a manual dispatch queue for event handling.
-    WDF_IO_QUEUE_CONFIG queueConfig;
-    WDF_IO_QUEUE_CONFIG_INIT(&queueConfig, WdfIoQueueDispatchManual);
-    queueConfig.PowerManaged = WdfFalse;
-
-    // Set the parent to this file such that the queue's lifetime is tied to it.
-    WDF_OBJECT_ATTRIBUTES queueAttributes;
-    queueAttributes.ParentObject = m_wdfFile;
-    WDF_OBJECT_ATTRIBUTES_INIT_CONTEXT_TYPE(&queueAttributes, UwbSimulatorIoEventQueue);
-
-    WDFQUEUE wdfQueue;
-    WDFDEVICE wdfDevice = WdfFileObjectGetDevice(m_wdfFile);
-    NTSTATUS status = WdfIoQueueCreate(wdfDevice, &queueConfig, &queueAttributes, &wdfQueue);
-    if (!NT_SUCCESS(status)) {
-        TraceLoggingWrite(
-            UwbSimulatorTraceloggingProvider,
-            "WdfIoQueueCreate failed",
-            TraceLoggingLevel(TRACE_LEVEL_FATAL),
-            TraceLoggingNTStatus(status));
-        return status;
-    }
-
-    // Construct a new UwbSimulatorIoEventQueue instance using the WDF pre-allocated buffer.
-    auto ioEventQueueBuffer = GetUwbSimulatorIoEventQueue(wdfQueue);
-    auto ioEventQueue = new (ioEventQueueBuffer) UwbSimulatorIoEventQueue(wdfQueue);
-    if (ioEventQueue == nullptr) {
-        return STATUS_INSUFFICIENT_RESOURCES;
-    }
-
-    status = ioEventQueue->Initialize();
-    if (!NT_SUCCESS(status)) {
-        ioEventQueue->~UwbSimulatorIoEventQueue();
-        return status;
-    }
-
-    m_ioEventQueue = ioEventQueue;
-
-    return status;
+    return STATUS_SUCCESS;
 }
 
 void
@@ -110,11 +67,6 @@ UwbSimulatorDeviceFile::OnWdfRequestCancel(WDFREQUEST request)
 void
 UwbSimulatorDeviceFile::OnDestroy()
 {
-    if (m_ioEventQueue != nullptr) {
-        m_ioEventQueue->Uninitialize();
-        m_ioEventQueue->~UwbSimulatorIoEventQueue();
-        m_ioEventQueue = nullptr;
-    }
 }
 
 void

--- a/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.hxx
@@ -36,7 +36,7 @@ public:
      * @param handler The handler to register.
      */
     void
-    RegisterHandler(std::unique_ptr<windows::devices::uwb::simulator::IUwbSimulatorDdiHandler> handler);
+    RegisterHandler(std::shared_ptr<windows::devices::uwb::simulator::IUwbSimulatorDdiHandler> handler);
 
     /**
      * @brief Device i/o control handler function.
@@ -100,7 +100,7 @@ private:
     WDFFILEOBJECT m_wdfFile;
     UwbSimulatorDevice *m_uwbSimulatorDevice{ nullptr };
     UwbSimulatorIoEventQueue *m_ioEventQueue{ nullptr };
-    std::vector<std::unique_ptr<windows::devices::uwb::simulator::IUwbSimulatorDdiHandler>> m_ddiHandlers{};
+    std::vector<std::shared_ptr<windows::devices::uwb::simulator::IUwbSimulatorDdiHandler>> m_ddiHandlers{};
 };
 
 WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(UwbSimulatorDeviceFile, GetUwbSimulatorFile);

--- a/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.hxx
@@ -10,7 +10,6 @@
 #include <wdf.h>
 
 #include "IUwbSimulatorDdiHandler.hxx"
-#include "UwbSimulatorIoEventQueue.hxx"
 
 class UwbSimulatorDevice;
 
@@ -61,19 +60,6 @@ public:
     WDFFILEOBJECT
     GetWdfFile() const noexcept;
 
-    /**
-     * @brief Get a pointer to the io event queue for this file object.
-     *
-     * @return UwbSimulatorIoEventQueue*
-     */
-    UwbSimulatorIoEventQueue *
-    GetIoEventQueue() noexcept;
-
-    /**
-     * @brief Get a pointer to the simulator device that owns this file object.
-     *
-     * @return UwbSimulatorDevice*
-     */
     UwbSimulatorDevice *
     GetDevice() noexcept;
 
@@ -99,7 +85,6 @@ private:
 private:
     WDFFILEOBJECT m_wdfFile;
     UwbSimulatorDevice *m_uwbSimulatorDevice{ nullptr };
-    UwbSimulatorIoEventQueue *m_ioEventQueue{ nullptr };
     std::vector<std::shared_ptr<windows::devices::uwb::simulator::IUwbSimulatorDdiHandler>> m_ddiHandlers{};
 };
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.cxx
@@ -115,5 +115,7 @@ UwbSimulatorIoEventQueue::PushNotificationData(UwbNotificationData notificationD
         status = STATUS_SUCCESS;
     }
 
+    WdfWaitLockRelease(m_wdfQueueLock);
+
     return status;
 }


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Ensure random measurement generation can be instrumented externally and across open file handles.

### Technical Details

* Move i/o event queue state from file context to device context.
* Fix ioctl attempt count log output (was off-by-1).
 
### Test Results

Concurrently executed `nocli.exe uwb range start <args>` with `uwbsim.exe trigger startrandomgeneration` followed by `"" .. stoprandomgeneration` and successfully observed random measurements printed to the console.

### Reviewer Focus

None

### Future Work

* Use proper smart pointers instead of raw pointers for device context structures and lifetime management.
* Expose more knobs to configure how the random measurements are generated.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
