### PR TITLE
Make nocli output for session events consistent

### DIFF
--- a/lib/uwb/UwbMacAddress.cxx
+++ b/lib/uwb/UwbMacAddress.cxx
@@ -109,12 +109,15 @@ UwbMacAddress::ToString() const
 {
     std::ostringstream macString{};
 
-    for (const auto& b : m_view.first(m_view.size() - 1)) {
-        macString << std::hex << +b << ':';
+    for (const auto& b : m_view) {
+        macString << std::hex << std::setw(2) << std::setfill('0') << +b << ':';
     }
-    macString << std::hex << +m_view[m_view.size() - 1];
 
-    return macString.str();
+    // Remove the trailing ':'.
+    auto str = macString.str();
+    str.pop_back();
+
+    return str;
 }
 
 bool

--- a/lib/uwb/UwbPeer.cxx
+++ b/lib/uwb/UwbPeer.cxx
@@ -107,7 +107,7 @@ std::string
 UwbPeer::ToString() const
 {
     std::ostringstream ss;
-    ss << "Mac: " << m_address << ", Spatial Properties: " << m_spatialProperties;
+    ss << "[" << std::setw((8*3)-1) << std::internal << std::setfill(' ') << m_address << "] " << m_spatialProperties;
     return ss.str();
 }
 

--- a/lib/uwb/UwbPeer.cxx
+++ b/lib/uwb/UwbPeer.cxx
@@ -13,20 +13,24 @@ using namespace strings::ostream_operators;
 std::string
 UwbPeerSpatialProperties::ToString() const
 {
-    std::initializer_list<std::tuple<std::string, std::optional<double>>> name2value{ { "Distance", Distance },
+    static const std::initializer_list<std::tuple<std::string, std::optional<double>>> name2value{
+        { "Distance", Distance },
         { "AngleAzimuth", AngleAzimuth },
         { "AngleElevation", AngleElevation },
-        { "Elevation", Elevation } };
+        { "Elevation", Elevation }
+    };
 
     std::ostringstream ss;
 
     for (const auto& [name, value] : name2value) {
-        if (value.has_value()) {
-            ss << name << ": " << std::to_string(*value) << std::endl;
-        }
+        ss << name << ": " << std::to_string(value.value_or(0)) << ", ";
     }
 
-    return ss.str();
+    // Remove the trailing ", "
+    auto str = ss.str();
+    str.resize(std::size(str) - 2);
+
+    return str;
 }
 
 UwbPeer::UwbPeer(UwbMacAddress address) :
@@ -48,7 +52,7 @@ double
 ConvertQ97FormatToIEEE(uint16_t q97)
 {
     static const double pow2 = std::pow(2, -7);
-    static const uint16_t signMask =            0b1000'0000'0000'0000U;
+    static const uint16_t signMask = 0b1000'0000'0000'0000U;
     static const uint16_t unsignedIntegerMask = 0b0111'1111'1000'0000U;
     static const uint16_t fractionMask = ~(signMask | unsignedIntegerMask);
 

--- a/lib/uwb/UwbPeer.cxx
+++ b/lib/uwb/UwbPeer.cxx
@@ -107,7 +107,7 @@ std::string
 UwbPeer::ToString() const
 {
     std::ostringstream ss;
-    ss << "[" << std::setw((8*3)-1) << std::internal << std::setfill(' ') << m_address << "] " << m_spatialProperties;
+    ss << "[" << m_address << "] " << m_spatialProperties;
     return ss.str();
 }
 

--- a/lib/uwb/UwbPeer.cxx
+++ b/lib/uwb/UwbPeer.cxx
@@ -107,10 +107,7 @@ std::string
 UwbPeer::ToString() const
 {
     std::ostringstream ss;
-    ss << "{" << std::endl;
-    ss << "mac: " << m_address << std::endl;
-    ss << m_spatialProperties << std::endl;
-    ss << "}" << std::endl;
+    ss << "Mac: " << m_address << ", Spatial Properties: " << m_spatialProperties;
     return ss.str();
 }
 

--- a/tools/cli/NearObjectCliUwbSessionEventCallbacks.cxx
+++ b/tools/cli/NearObjectCliUwbSessionEventCallbacks.cxx
@@ -11,11 +11,47 @@ NearObjectCliUwbSessionEventCallbacks::NearObjectCliUwbSessionEventCallbacks(std
     m_onSessionEndedCallback(std::move(onSessionEndedCallback))
 {}
 
+namespace
+{
+/**
+ * @brief Helper stream manipulator to add a common log prefix.
+ */
+class LogPrefix
+{
+public:
+    LogPrefix(uint32_t sessionId) :
+        m_sessionId(sessionId) {}
+
+    std::ostream&
+    operator()(std::ostream& out) const
+    {
+        return out << "[Session " << std::showbase << std::hex << std::setw(sizeof(m_sessionId)) << std::internal << m_sessionId << "]: ";
+    }
+
+private:
+    uint32_t m_sessionId;
+};
+
+/**
+ * @brief Stream specialization taking a LogPrefix argument, allowing
+ * std::ostream << LogPrefix(value).
+ *
+ * @param out The stream to manipulate.
+ * @param logPrefix The instance to manipulate the stream.
+ * @return std::ostream&
+ */
+std::ostream&
+operator<<(std::ostream& out, LogPrefix logPrefix)
+{
+    return logPrefix(out);
+}
+} // namespace
+
 void
 NearObjectCliUwbSessionEventCallbacks::OnSessionEnded(::uwb::UwbSession* session, ::uwb::UwbSessionEndReason /* reason */)
 {
-    std::cout << "Session with id="
-              << std::hex << std::setw(8) << std::setfill('0') << std::showbase << std::internal << session->GetId() << ": Session Ended" << std::endl;
+    std::cout << LogPrefix(session->GetId()) << "Session Ended" << std::endl;
+
     if (m_onSessionEndedCallback) {
         m_onSessionEndedCallback();
     }
@@ -24,22 +60,19 @@ NearObjectCliUwbSessionEventCallbacks::OnSessionEnded(::uwb::UwbSession* session
 void
 NearObjectCliUwbSessionEventCallbacks::OnRangingStarted(::uwb::UwbSession* session)
 {
-    std::cout << "Session with id="
-              << std::hex << std::setw(8) << std::setfill('0') << std::showbase << std::internal << session->GetId() << ": Ranging Started" << std::endl;
+    std::cout << LogPrefix(session->GetId()) << "Ranging Started" << std::endl;
 }
 
 void
 NearObjectCliUwbSessionEventCallbacks::OnRangingStopped(::uwb::UwbSession* session)
 {
-    std::cout << "Session with id="
-              << std::hex << std::setw(8) << std::setfill('0') << std::showbase << std::internal << session->GetId() << ": Ranging Stopped" << std::endl;
+    std::cout << LogPrefix(session->GetId()) << "Ranging Stopped" << std::endl;
 }
 
 void
 NearObjectCliUwbSessionEventCallbacks::OnPeerPropertiesChanged(::uwb::UwbSession* session, const std::vector<::uwb::UwbPeer> peersChanged)
 {
-    std::cout << "Session with id="
-              << std::hex << std::setw(8) << std::setfill('0') << std::showbase << std::internal << session->GetId() << ": Peer Properties Changed" << std::endl;
+    std::cout << LogPrefix(session->GetId()) << "Peer Properties Changed" << std::endl;
 
     for (const auto& peer : peersChanged) {
         std::cout << " > " << peer << std::endl;
@@ -49,8 +82,7 @@ NearObjectCliUwbSessionEventCallbacks::OnPeerPropertiesChanged(::uwb::UwbSession
 void
 NearObjectCliUwbSessionEventCallbacks::OnSessionMembershipChanged(::uwb::UwbSession* session, const std::vector<::uwb::UwbPeer> peersAdded, const std::vector<::uwb::UwbPeer> peersRemoved)
 {
-    std::cout << "Session with id="
-              << std::hex << std::setw(8) << std::setfill('0') << std::showbase << std::internal << session->GetId() << ": Membership Changed" << std::endl;
+    std::cout << LogPrefix(session->GetId()) << "Membership Changed" << std::endl;
 
     for (const auto& peer : peersAdded) {
         std::cout << "+" << peer.GetAddress() << std::endl;

--- a/tools/cli/NearObjectCliUwbSessionEventCallbacks.cxx
+++ b/tools/cli/NearObjectCliUwbSessionEventCallbacks.cxx
@@ -25,7 +25,7 @@ public:
     std::ostream&
     operator()(std::ostream& out) const
     {
-        return out << "[Session " << std::showbase << std::hex << std::setw(sizeof(m_sessionId)) << std::setfill('0') << std::internal << m_sessionId << "]: ";
+        return out << "[Session " << std::setw(10) << std::setfill(' ') << std::right << m_sessionId << "]: ";
     }
 
 private:

--- a/tools/cli/NearObjectCliUwbSessionEventCallbacks.cxx
+++ b/tools/cli/NearObjectCliUwbSessionEventCallbacks.cxx
@@ -42,7 +42,7 @@ NearObjectCliUwbSessionEventCallbacks::OnPeerPropertiesChanged(::uwb::UwbSession
               << std::hex << std::setw(8) << std::setfill('0') << std::showbase << std::internal << session->GetId() << ": Peer Properties Changed" << std::endl;
 
     for (const auto& peer : peersChanged) {
-        std::cout << peer << std::endl;
+        std::cout << " > " << peer << std::endl;
     }
 }
 

--- a/tools/cli/NearObjectCliUwbSessionEventCallbacks.cxx
+++ b/tools/cli/NearObjectCliUwbSessionEventCallbacks.cxx
@@ -25,7 +25,7 @@ public:
     std::ostream&
     operator()(std::ostream& out) const
     {
-        return out << "[Session " << std::showbase << std::hex << std::setw(sizeof(m_sessionId)) << std::internal << m_sessionId << "]: ";
+        return out << "[Session " << std::showbase << std::hex << std::setw(sizeof(m_sessionId)) << std::setfill('0') << std::internal << m_sessionId << "]: ";
     }
 
 private:

--- a/tools/cli/NearObjectCliUwbSessionEventCallbacks.cxx
+++ b/tools/cli/NearObjectCliUwbSessionEventCallbacks.cxx
@@ -75,7 +75,7 @@ NearObjectCliUwbSessionEventCallbacks::OnPeerPropertiesChanged(::uwb::UwbSession
     std::cout << LogPrefix(session->GetId()) << "Peer Properties Changed" << std::endl;
 
     for (const auto& peer : peersChanged) {
-        std::cout << " > " << peer << std::endl;
+        std::cout << ' ' << peer << std::endl;
     }
 }
 

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -587,14 +587,14 @@ UwbConnector::OnSessionRangingData(::uwb::protocol::fira::UwbRangingData ranging
     uint32_t sessionId = rangingData.SessionId;
     auto it = m_sessionEventCallbacks.find(sessionId);
     if (it == std::end(m_sessionEventCallbacks)) {
-        PLOG_WARNING << "Ignoring RangingData event due to missing session callback";
+        PLOG_VERBOSE << "Ignoring RangingData event due to missing session callback";
         return;
     }
 
     auto& [_, callbacksWeak] = *it;
     auto callbacks = callbacksWeak.lock();
     if (not(callbacks->OnPeerPropertiesChanged)) {
-        PLOG_WARNING << "Ignoring RangingData event due to missing session callback";
+        PLOG_WARNING << "Ignoring RangingData event due to expired session callback";
         m_sessionEventCallbacks.erase(it);
         return;
     }


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Ensure the output of `nocli` for ranging events has a consistent format. This will later allow tools to parse the output data easier. 

### Technical Details

* Change mac string to fill missing bytes with zeroes. This ensures that the high byte doesn't get omitted from output, eg. with the old code: `00 aa` would show up as `0 aa`, but with the updated code, it will show up as `00 aa`. This extends for any number of leading zero bits.
* Remove newlines from `UwbPeerSpatialProperties` string output to allow greater format control for the caller.
* Add consistent log prefix and helper i/o manipulator to generate as such, to `NearObjectCliUwbSessionEventCallbacks` output.

### Test Results

New output looks like this:
![image](https://user-images.githubusercontent.com/2082148/228568075-7a4fc84b-f426-427a-a463-1fec2c897d36.png)

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
