### PR TITLE
Add ability to obtain session information directly from driver layer

### DIFF
--- a/lib/uwb/UwbDevice.cxx
+++ b/lib/uwb/UwbDevice.cxx
@@ -15,7 +15,7 @@ std::shared_ptr<UwbSession>
 UwbDevice::GetSession(uint32_t sessionId)
 {
     // First determine if the session is already in the cache.
-    auto session = FindSessionLocked(sessionId);
+    auto session = FindSession(sessionId);
     if (session != nullptr) {
         return session;
     }

--- a/lib/uwb/UwbDevice.cxx
+++ b/lib/uwb/UwbDevice.cxx
@@ -38,8 +38,7 @@ UwbDevice::GetSession(uint32_t sessionId)
     // function concurrently, resolved the session, and added it to the cache.
     std::unique_lock sessionExclusiveLock{ m_sessionsGate };
 
-    // Check if a concurrent call resolved this device concurrently and won the
-    // race to cache it.
+    // Check if a concurrent call resolved this device and won the race to cache it.
     auto sessionCached = FindSessionLocked(sessionId);
     if (sessionCached != nullptr) {
         return sessionCached;

--- a/lib/uwb/UwbSession.cxx
+++ b/lib/uwb/UwbSession.cxx
@@ -18,6 +18,31 @@ UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<UwbSessionEventCallback
     m_sessionId(sessionId)
 {}
 
+UwbSession::UwbSession(uint32_t sessionId, DeviceType deviceType) :
+    UwbSession(sessionId, std::weak_ptr<UwbSessionEventCallbacks>{}, deviceType)
+{}
+
+std::weak_ptr<UwbSessionEventCallbacks>
+UwbSession::GetEventCallbacks() const noexcept
+{
+    return m_callbacks.load();
+}
+
+void
+UwbSession::SetEventCallbacks(std::weak_ptr<UwbSessionEventCallbacks> callbacks) noexcept
+{
+    auto callbacksOld = m_callbacks.exchange(callbacks);
+    if (callbacksOld.lock() != nullptr) {
+        LOG_WARNING << "SetEventCallbacks existing callbacks were replaced";
+    }
+}
+
+std::shared_ptr<UwbSessionEventCallbacks>
+UwbSession::ResolveEventCallbacks() noexcept
+{
+    return m_callbacks.load().lock();
+}
+
 uwb::protocol::fira::DeviceType
 UwbSession::GetDeviceType() const noexcept
 {

--- a/lib/uwb/include/uwb/UwbDevice.hxx
+++ b/lib/uwb/include/uwb/UwbDevice.hxx
@@ -87,6 +87,18 @@ private:
     CreateSessionImpl(uint32_t sessionId, std::weak_ptr<UwbSessionEventCallbacks> callbacks) = 0;
 
     /**
+     * @brief Attempt to resolve a session from the underlying UWB device. 
+     * 
+     * This is used when a session may be pre-existing within the driver but
+     * this instance is not yet aware of.
+     * 
+     * @param sessionId The identifier of the session to resolve.
+     * @return std::shared_ptr<UwbSession> 
+     */
+    virtual std::shared_ptr<UwbSession>
+    ResolveSessionImpl(uint32_t sessionId) = 0;
+
+    /**
      * @brief Get the FiRa capabilities of the device.
      *
      * @return uwb::protocol::fira::UwbCapability

--- a/lib/uwb/include/uwb/UwbDevice.hxx
+++ b/lib/uwb/include/uwb/UwbDevice.hxx
@@ -31,6 +31,15 @@ public:
     CreateSession(uint32_t sessionId, std::weak_ptr<UwbSessionEventCallbacks> callbacks);
 
     /**
+     * @brief Obtains a shared reference to a pre-existing session.
+     * 
+     * @param sessionId The session identifier.
+     * @return std::shared_ptr<UwbSession> 
+     */
+    std::shared_ptr<UwbSession>
+    GetSession(uint32_t sessionId);
+
+    /**
      * @brief Get the FiRa capabilities of the device.
      *
      * @return uwb::protocol::fira::UwbCapability
@@ -130,13 +139,25 @@ private:
 
 protected:
     /**
-     * @brief Get a reference to the specified session.
+     * @brief Find the specified session in the session cache.
      *
-     * @param sessionId
+     * @param sessionId The identifier of the session to find.
      * @return std::shared_ptr<UwbSession>
      */
     std::shared_ptr<UwbSession>
-    GetSession(uint32_t sessionId);
+    FindSession(uint32_t sessionId);
+
+    /**
+     * @brief Internal function which finds the specified session but does not
+     * enforce any mutual exclusion. The caller must hold the m_sessionsGate
+     * mutex either in shared or exclusive mode in order to safely call this
+     * function. 
+     * 
+     * @param sessionId The identifier of the session to find.
+     * @return std::shared_ptr<UwbSession> 
+     */
+    std::shared_ptr<UwbSession>
+    FindSessionLocked(uint32_t sessionId);
 
     /**
      * @brief Invoked when a generic error occurs. TODO this callback needs to be invoked by a UwbConnector for the linux portion too

--- a/lib/uwb/include/uwb/UwbSession.hxx
+++ b/lib/uwb/include/uwb/UwbSession.hxx
@@ -22,19 +22,46 @@ namespace uwb
 class UwbSession
 {
 public:
+    static constexpr uwb::protocol::fira::DeviceType DeviceTypeDefault = uwb::protocol::fira::DeviceType::Controller;
+
+    /**
+     * @brief Construct a new UwbSession object without callbacks.
+     *
+     * @param sessionId The session identifier.
+     * @param deviceType The host device type in the session (controller, controlee).
+     */
+    UwbSession(uint32_t sessionId, uwb::protocol::fira::DeviceType deviceType = DeviceTypeDefault);
+
     /**
      * @brief Construct a new UwbSession object.
      *
-     * @param sessionId
-     * @param callbacks
-     * @param deviceType
+     *
+     * @param sessionId The session identifier.
+     * @param callbacks The event callbacks to use.
+     * @param deviceType The host device type in the session (controller, controlee).
      */
-    UwbSession(uint32_t sessionId, std::weak_ptr<UwbSessionEventCallbacks> callbacks, uwb::protocol::fira::DeviceType deviceType = uwb::protocol::fira::DeviceType::Controller);
+    UwbSession(uint32_t sessionId, std::weak_ptr<UwbSessionEventCallbacks> callbacks, uwb::protocol::fira::DeviceType deviceType = DeviceTypeDefault);
 
     /**
      * @brief Destroy the UwbSession object.
      */
     virtual ~UwbSession() = default;
+
+    /**
+     * @brief Get a weak reference to the event callbacks instance.
+     *
+     * @return std::weak_ptr<UwbSessionEventCallbacks>
+     */
+    std::weak_ptr<UwbSessionEventCallbacks>
+    GetEventCallbacks() const noexcept;
+
+    /**
+     * @brief Set the callbacks to be used for events.
+     *
+     * @param callbacks The event callbacks instance.
+     */
+    void
+    SetEventCallbacks(std::weak_ptr<UwbSessionEventCallbacks> callbacks) noexcept;
 
     /**
      * @brief Get the Device Type associated with the host of this UwbSession
@@ -114,6 +141,16 @@ public:
     void
     Destroy();
 
+protected:
+    /**
+     * @brief Attempt to resolve the event callbacks from a weak to a shared
+     * reference.
+     *
+     * @return std::shared_ptr<UwbSessionEventCallbacks>
+     */
+    std::shared_ptr<UwbSessionEventCallbacks>
+    ResolveEventCallbacks() noexcept;
+
 private:
     /**
      * @brief Internal function to insert a peer address to this session
@@ -174,7 +211,7 @@ protected:
     std::atomic<bool> m_rangingActive{ false };
     std::mutex m_peerGate;
     std::unordered_set<UwbMacAddress> m_peers{};
-    std::weak_ptr<UwbSessionEventCallbacks> m_callbacks;
+    std::atomic<std::weak_ptr<UwbSessionEventCallbacks>> m_callbacks;
 };
 
 } // namespace uwb

--- a/tests/unit/uwb/TestUwbDevice.cxx
+++ b/tests/unit/uwb/TestUwbDevice.cxx
@@ -26,6 +26,12 @@ struct UwbDeviceTestBase : public uwb::UwbDevice
         return nullptr;
     }
 
+    std::shared_ptr<UwbSession>
+    ResolveSessionImpl(uint32_t /* sessionId */) override
+    {
+        return nullptr;
+    }
+
     uwb::protocol::fira::UwbCapability
     GetCapabilitiesImpl() override
     {

--- a/windows/devices/uwb/UwbDevice.cxx
+++ b/windows/devices/uwb/UwbDevice.cxx
@@ -47,6 +47,14 @@ UwbDevice::CreateSessionImpl(uint32_t sessionId, std::weak_ptr<::uwb::UwbSession
 std::shared_ptr<::uwb::UwbSession>
 UwbDevice::ResolveSessionImpl([[maybe_unused]] uint32_t sessionId)
 {
+    // TODO: implement this
+    // One problem is that m_uwbDeviceConnector is of type
+    // IUwbDeviceDdiConnector, which prevents use of the session-based connector
+    // functionality. That is needed here to obtain information about the
+    // session in question. For example, we need to call
+    // IUwbSessionDdi::[SessionGetState, GetApplicationConfigurationParameters,
+    // SessionGetRangingCount]. So, we may need to change the type of
+    // m_uwbDeviceConnector to UwbConnector instead.
     return nullptr;
 }
 

--- a/windows/devices/uwb/UwbDevice.cxx
+++ b/windows/devices/uwb/UwbDevice.cxx
@@ -38,10 +38,16 @@ UwbDevice::DeviceName() const noexcept
     return m_deviceName;
 }
 
-std::shared_ptr<uwb::UwbSession>
+std::shared_ptr<::uwb::UwbSession>
 UwbDevice::CreateSessionImpl(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks)
 {
     return std::make_shared<UwbSession>(sessionId, std::move(callbacks), this);
+}
+
+std::shared_ptr<::uwb::UwbSession>
+UwbDevice::ResolveSessionImpl([[maybe_unused]] uint32_t sessionId)
+{
+    return nullptr;
 }
 
 UwbCapability

--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -10,8 +10,8 @@
 
 #include <uwb/protocols/fira/UwbException.hxx>
 #include <windows/devices/uwb/UwbCxDdiLrp.hxx>
-#include <windows/devices/uwb/UwbDeviceConnector.hxx>
 #include <windows/devices/uwb/UwbDevice.hxx>
+#include <windows/devices/uwb/UwbDeviceConnector.hxx>
 #include <windows/devices/uwb/UwbSession.hxx>
 
 using namespace windows::devices::uwb;
@@ -22,40 +22,40 @@ UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventC
 {
     m_registeredCallbacks = std::make_shared<::uwb::UwbRegisteredSessionEventCallbacks>(
         [this](::uwb::UwbSessionEndReason reason) {
-            auto callbacks = m_callbacks.lock();
-            if (not callbacks) {
+            auto callbacks = ResolveEventCallbacks();
+            if (callbacks == nullptr) {
                 PLOG_WARNING << "missing session event callback for UwbSessionEndReason, skipping";
                 // TODO deregister
             }
             return callbacks->OnSessionEnded(this, reason);
         },
         [this]() {
-            auto callbacks = m_callbacks.lock();
-            if (not callbacks) {
+            auto callbacks = ResolveEventCallbacks();
+            if (callbacks == nullptr) {
                 PLOG_WARNING << "missing session event callback for ranging started, skipping";
                 // TODO deregister
             }
             return callbacks->OnRangingStarted(this);
         },
         [this]() {
-            auto callbacks = m_callbacks.lock();
-            if (not callbacks) {
+            auto callbacks = ResolveEventCallbacks();
+            if (callbacks == nullptr) {
                 PLOG_WARNING << "missing session event callback for ranging stopped, skipping";
                 // TODO deregister
             }
             return callbacks->OnRangingStopped(this);
         },
         [this](const std::vector<::uwb::UwbPeer> peersChanged) {
-            auto callbacks = m_callbacks.lock();
-            if (not callbacks) {
+            auto callbacks = ResolveEventCallbacks();
+            if (callbacks == nullptr) {
                 PLOG_WARNING << "missing session event callback for ranging data, skipping";
                 // TODO deregister
             }
             return callbacks->OnPeerPropertiesChanged(this, peersChanged);
         },
         [this](const std::vector<::uwb::UwbPeer> peersAdded, const std::vector<::uwb::UwbPeer> peersRemoved) {
-            auto callbacks = m_callbacks.lock();
-            if (not callbacks) {
+            auto callbacks = ResolveEventCallbacks();
+            if (callbacks == nullptr) {
                 PLOG_WARNING << "missing session event callback for peer list changes, skipping";
                 // TODO deregister
             }

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
@@ -73,6 +73,18 @@ private:
     CreateSessionImpl(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks) override;
 
     /**
+     * @brief Attempt to resolve a session from the underlying UWB device. 
+     * 
+     * This is used when a session may be pre-existing within the driver but
+     * this instance is not yet aware of.
+     * 
+     * @param sessionId The identifier of the session to resolve.
+     * @return std::shared_ptr<UwbSession> 
+     */
+    virtual std::shared_ptr<::uwb::UwbSession>
+    ResolveSessionImpl(uint32_t sessionId) override;
+
+    /**
      * @brief Get the capabilities of the device.
      *
      * @return uwb::protocol::fira::UwbCapability


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

* Allow creating a `UwbSession` from a session identifier alone.
* Allow service layer to query the driver layer for active session information.

### Technical Details
 
 * Expose `UwbSession::GetSession()` function which allows clients with a-priori information to obtain a `UwbSession` reference.
 * Add `UwbSession::ResolveSessionImpl()` function which allows higher-layer code to resolve pre-existing sessions from the driver layer.
* Add ability to retrieve and change the `UwbSession` event callbacks.
* Add helper to resolve session event callbacks form derived classes.
* Update session event callbacks checks to avoid implicit conversion to `bool`.
 
### Test Results

Performed some ad-hoc scenarios exercising full ranging using the simulator driver and ensured there were no regressions.

### Reviewer Focus

None

### Future Work

* The Windows derived `ResolveSessionImpl()` must be implemented. This requires allowing access to `IUwbSessionDdi` through the device connector, which is not currently possible without changing the containing type.
* The `GetSession()` function will be used from the raw commands involving sessions.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
