### PR TITLE
Implement UwbDevice::ResolveSessionImpl

### DIFF
--- a/lib/uwb/UwbSession.cxx
+++ b/lib/uwb/UwbSession.cxx
@@ -38,7 +38,7 @@ UwbSession::SetEventCallbacks(std::weak_ptr<UwbSessionEventCallbacks> callbacks)
     }
 
     if (callbacks.lock() != nullptr) {
-        LOG_WARNING << "Session with id " << m_sessionId << " callbacks were replaced"; 
+        LOG_WARNING << "Session with id " << m_sessionId << " callbacks were replaced";
     }
 }
 

--- a/lib/uwb/UwbSession.cxx
+++ b/lib/uwb/UwbSession.cxx
@@ -45,6 +45,7 @@ UwbSession::SetEventCallbacks(std::weak_ptr<UwbSessionEventCallbacks> callbacks)
 std::shared_ptr<UwbSessionEventCallbacks>
 UwbSession::ResolveEventCallbacks() noexcept
 {
+    std::shared_lock callbacksLockShared{ m_callbacksGate };
     return m_callbacks.lock();
 }
 

--- a/lib/uwb/UwbSession.cxx
+++ b/lib/uwb/UwbSession.cxx
@@ -32,13 +32,13 @@ UwbSession::GetEventCallbacks() noexcept
 void
 UwbSession::SetEventCallbacks(std::weak_ptr<UwbSessionEventCallbacks> callbacks) noexcept
 {
-    std::unique_lock<std::shared_mutex> callbacksLockExclusive;
-    decltype(m_callbacks) callbacksOld = m_callbacks;
-    m_callbacks = std::move(callbacks);
+    {
+        std::unique_lock<std::shared_mutex> callbacksLockExclusive;
+        m_callbacks.swap(callbacks);
+    }
 
-    std::swap(callbacksOld, callbacks);
-    if (callbacksOld.lock() != nullptr) {
-        LOG_WARNING << "SetEventCallbacks existing callbacks were replaced";
+    if (callbacks.lock() != nullptr) {
+        LOG_WARNING << "Session with id " << m_sessionId << " callbacks were replaced"; 
     }
 }
 

--- a/lib/uwb/include/uwb/UwbSession.hxx
+++ b/lib/uwb/include/uwb/UwbSession.hxx
@@ -6,7 +6,7 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
-#include <ranges>
+#include <shared_mutex>
 #include <unordered_set>
 
 #include <uwb/UwbMacAddress.hxx>
@@ -53,7 +53,7 @@ public:
      * @return std::weak_ptr<UwbSessionEventCallbacks>
      */
     std::weak_ptr<UwbSessionEventCallbacks>
-    GetEventCallbacks() const noexcept;
+    GetEventCallbacks() noexcept;
 
     /**
      * @brief Set the callbacks to be used for events.
@@ -211,7 +211,8 @@ protected:
     std::atomic<bool> m_rangingActive{ false };
     std::mutex m_peerGate;
     std::unordered_set<UwbMacAddress> m_peers{};
-    std::atomic<std::weak_ptr<UwbSessionEventCallbacks>> m_callbacks;
+    std::shared_mutex m_callbacksGate;
+    std::weak_ptr<UwbSessionEventCallbacks> m_callbacks;
 };
 
 } // namespace uwb

--- a/windows/devices/uwb/UwbDevice.cxx
+++ b/windows/devices/uwb/UwbDevice.cxx
@@ -2,6 +2,7 @@
 #include <future>
 #include <ios>
 #include <stdexcept>
+#include <tuple>
 
 #include <uwb/protocols/fira/FiraDevice.hxx>
 #include <uwb/protocols/fira/UwbException.hxx>
@@ -46,15 +47,41 @@ UwbDevice::CreateSessionImpl(uint32_t sessionId, std::weak_ptr<::uwb::UwbSession
 std::shared_ptr<::uwb::UwbSession>
 UwbDevice::ResolveSessionImpl(uint32_t sessionId)
 {
-    // TODO: implement this
-    // One problem is that m_uwbDeviceConnector is of type
-    // IUwbDeviceDdiConnector, which prevents use of the session-based connector
-    // functionality. That is needed here to obtain information about the
-    // session in question. For example, we need to call
-    // IUwbSessionDdi::[SessionGetState, GetApplicationConfigurationParameters,
-    // SessionGetRangingCount]. So, we may need to change the type of
-    // m_uwbDeviceConnector to UwbConnector instead.
-    return nullptr;
+    std::vector<UwbApplicationConfigurationParameterType> applicationConfigurationParameterTypes({ UwbApplicationConfigurationParameterType::DeviceType });
+
+    auto resultFuture = m_uwbConnector->GetApplicationConfigurationParameters(sessionId, applicationConfigurationParameterTypes);
+    if (!resultFuture.valid()) {
+        PLOG_ERROR << "failed to obtain application configuration parameters for session id " << sessionId;
+        throw UwbException(UwbStatusGeneric::Failed);
+    }
+
+    UwbStatus uwbStatus;
+    std::vector<UwbApplicationConfigurationParameter> applicationConfigurationParameters;
+    try {
+        std::tie(uwbStatus, applicationConfigurationParameters) = resultFuture.get();
+        if (!IsUwbStatusOk(uwbStatus)) {
+            PLOG_ERROR << "failed to obtain device type for session id " << sessionId << " (" << ToString(uwbStatus) << ")";
+            throw UwbException(uwbStatus);
+        }
+    } catch (UwbException& uwbException) {
+        PLOG_ERROR << "caught exception attempting to obtain application configuration parameters for session id " << sessionId << " (" << ToString(uwbException.Status) << ")";
+        throw uwbException;
+    } catch (std::exception& e) {
+        PLOG_ERROR << "caught unexpected exception attempting to obtain application configuration parameters for session id " << sessionId << " (" << e.what() << ")";
+        throw e;
+    }
+
+    // Validate the call provided the expected DeviceType parameter.
+    if (std::size(applicationConfigurationParameters) < 1 || !std::holds_alternative<DeviceType>(applicationConfigurationParameters.front().Value)) {
+        PLOG_FATAL << "invalid application configuration parameters returned";
+        throw std::runtime_error("GetApplicationConfigurationParameters() returned bad data; this is a bug!");
+    }
+
+    // Create an instance of the session.
+    auto deviceType = std::get<DeviceType>(applicationConfigurationParameters.front().Value);
+    auto session = std::make_shared<UwbSession>(sessionId, this, deviceType);
+
+    return session;
 }
 
 UwbCapability

--- a/windows/devices/uwb/UwbDevice.cxx
+++ b/windows/devices/uwb/UwbDevice.cxx
@@ -8,7 +8,6 @@
 #include <windows/devices/uwb/UwbCxAdapterDdiLrp.hxx>
 #include <windows/devices/uwb/UwbCxDdiLrp.hxx>
 #include <windows/devices/uwb/UwbDevice.hxx>
-#include <windows/devices/uwb/UwbDeviceConnector.hxx>
 #include <windows/devices/uwb/UwbSession.hxx>
 
 #include <plog/Log.h>
@@ -45,7 +44,7 @@ UwbDevice::CreateSessionImpl(uint32_t sessionId, std::weak_ptr<::uwb::UwbSession
 }
 
 std::shared_ptr<::uwb::UwbSession>
-UwbDevice::ResolveSessionImpl([[maybe_unused]] uint32_t sessionId)
+UwbDevice::ResolveSessionImpl(uint32_t sessionId)
 {
     // TODO: implement this
     // One problem is that m_uwbDeviceConnector is of type
@@ -61,7 +60,7 @@ UwbDevice::ResolveSessionImpl([[maybe_unused]] uint32_t sessionId)
 UwbCapability
 UwbDevice::GetCapabilitiesImpl()
 {
-    auto resultFuture = m_uwbDeviceConnector->GetCapabilities();
+    auto resultFuture = m_uwbConnector->GetCapabilities();
     if (!resultFuture.valid()) {
         // TODO: need to do something different than just return a default-constructed object here
         PLOG_ERROR << "failed to obtain capabilities from driver";
@@ -84,7 +83,7 @@ UwbDevice::GetCapabilitiesImpl()
 UwbDeviceInformation
 UwbDevice::GetDeviceInformationImpl()
 {
-    auto resultFuture = m_uwbDeviceConnector->GetDeviceInformation();
+    auto resultFuture = m_uwbConnector->GetDeviceInformation();
     if (!resultFuture.valid()) {
         PLOG_ERROR << "failed to obtain capabilities from driver";
         throw std::make_exception_ptr(UwbException(UwbStatusGeneric::Rejected));
@@ -102,7 +101,7 @@ UwbDevice::GetDeviceInformationImpl()
 void
 UwbDevice::ResetImpl()
 {
-    auto resultFuture = m_uwbDeviceConnector->Reset();
+    auto resultFuture = m_uwbConnector->Reset();
     if (!resultFuture.valid()) {
         // TODO: need to do something different than just return a default-constructed object here
         PLOG_ERROR << "failed to reset the uwb device";
@@ -120,9 +119,9 @@ UwbDevice::ResetImpl()
 bool
 UwbDevice::InitializeImpl()
 {
-    m_uwbDeviceConnector = std::make_shared<UwbConnector>(m_deviceName);
-    m_callbacksToken = m_uwbDeviceConnector->RegisterDeviceEventCallbacks(m_callbacks);
-    m_uwbDeviceConnector->NotificationListenerStart();
+    m_uwbConnector = std::make_shared<UwbConnector>(m_deviceName);
+    m_callbacksToken = m_uwbConnector->RegisterDeviceEventCallbacks(m_callbacks);
+    m_uwbConnector->NotificationListenerStart();
     return true;
 }
 

--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -68,7 +68,7 @@ UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventC
     m_registeredCallbacksToken = m_uwbDeviceConnector->RegisterSessionEventCallbacks(m_sessionId, m_registeredCallbacks);
 }
 
-UwbSession::UwbSession(uint32_t sessionId, UwbDevice* uwbDevice, ::uwb::protocol::fira::DeviceType deviceType) :
+UwbSession::UwbSession(uint32_t sessionId, UwbDevice *uwbDevice, ::uwb::protocol::fira::DeviceType deviceType) :
     UwbSession(sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks>{}, uwbDevice, deviceType)
 {}
 

--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -68,6 +68,10 @@ UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventC
     m_registeredCallbacksToken = m_uwbDeviceConnector->RegisterSessionEventCallbacks(m_sessionId, m_registeredCallbacks);
 }
 
+UwbSession::UwbSession(uint32_t sessionId, UwbDevice* uwbDevice, ::uwb::protocol::fira::DeviceType deviceType) :
+    UwbSession(sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks>{}, uwbDevice, deviceType)
+{}
+
 std::shared_ptr<IUwbSessionDdiConnector>
 UwbSession::GetUwbDeviceConnector() noexcept
 {

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
@@ -19,7 +19,8 @@
 #include <uwb/UwbSession.hxx>
 #include <uwb/protocols/fira/FiraDevice.hxx>
 #include <windows/devices/DeviceResource.hxx>
-#include <windows/devices/uwb/UwbDeviceConnector.hxx>
+#include <windows/devices/uwb/IUwbDeviceDdi.hxx>
+#include <windows/devices/uwb/IUwbSessionDdi.hxx>
 
 namespace uwb
 {
@@ -116,7 +117,8 @@ private:
 
 private:
     const std::string m_deviceName;
-    std::shared_ptr<UwbConnector> m_uwbConnector;
+    std::shared_ptr<IUwbDeviceDdiConnector> m_uwbDeviceConnector;
+    std::shared_ptr<IUwbSessionDdiConnector> m_uwbSessionConnector;
     std::shared_ptr<::uwb::UwbRegisteredDeviceEventCallbacks> m_callbacks;
     ::uwb::RegisteredCallbackToken* m_callbacksToken;
 };

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
@@ -19,7 +19,7 @@
 #include <uwb/UwbSession.hxx>
 #include <uwb/protocols/fira/FiraDevice.hxx>
 #include <windows/devices/DeviceResource.hxx>
-#include <windows/devices/uwb/IUwbDeviceDdi.hxx>
+#include <windows/devices/uwb/UwbDeviceConnector.hxx>
 
 namespace uwb
 {
@@ -73,13 +73,13 @@ private:
     CreateSessionImpl(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks) override;
 
     /**
-     * @brief Attempt to resolve a session from the underlying UWB device. 
-     * 
+     * @brief Attempt to resolve a session from the underlying UWB device.
+     *
      * This is used when a session may be pre-existing within the driver but
      * this instance is not yet aware of.
-     * 
+     *
      * @param sessionId The identifier of the session to resolve.
-     * @return std::shared_ptr<UwbSession> 
+     * @return std::shared_ptr<UwbSession>
      */
     virtual std::shared_ptr<::uwb::UwbSession>
     ResolveSessionImpl(uint32_t sessionId) override;
@@ -116,7 +116,7 @@ private:
 
 private:
     const std::string m_deviceName;
-    std::shared_ptr<IUwbDeviceDdiConnector> m_uwbDeviceConnector;
+    std::shared_ptr<UwbConnector> m_uwbConnector;
     std::shared_ptr<::uwb::UwbRegisteredDeviceEventCallbacks> m_callbacks;
     ::uwb::RegisteredCallbackToken* m_callbacksToken;
 };

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
@@ -24,10 +24,18 @@ class UwbSession :
 {
 public:
     /**
+     * @brief Construct a new UwbSession object without callbacks.
+     *
+     * @param sessionId The session identifier.
+     * @param uwbDevice The uwb device tied to the session.
+     */
+    UwbSession(uint32_t sessionId, UwbDevice* uwbDevice, ::uwb::protocol::fira::DeviceType deviceType = ::uwb::protocol::fira::DeviceType::Controller);
+
+    /**
      * @brief Construct a new UwbSession object.
      * This also registers the callbacks with the UwbConnector
      *
-     * @param sessionId
+     * @param sessionId The session identifier.
      * @param callbacks The event callback instance.
      * @param uwbDevice The uwb device tied to the session.
      */
@@ -62,8 +70,8 @@ private:
 
     /**
      * @brief Get the application configuration parameters for this session.
-     * 
-     * @return std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> 
+     *
+     * @return std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter>
      */
     virtual std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter>
     GetApplicationConfigurationParametersImpl() override;


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Allow resolving a pre-existing session using `UwbDevice`.

### Technical Details

* Store separate connectors in `UwbDevice`, each corresponding to the DDI needed (device, session).
* Implement `UwbDevice::ResolveSessionImpl`.
* Enable creation of callback-less `UwbSession` on WIndows.

### Test Results

TBD

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
