### PR TITLE
Expose raw command to deinitialize a ranging session

### DIFF
--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -380,12 +380,14 @@ NearObjectCli::AddSubcommandUwbRawSessionDeinitialize(CLI::App* parent)
 {
     // top-level command
     auto rawSessionDeinitializeApp = parent->add_subcommand("sessiondeinit", "Deinitialize a pre-existing session")->fallthrough();
+    rawSessionDeinitializeApp->add_option("Session Id, --SessionId", m_cliData->SessionId)->required();
 
-    rawSessionDeinitializeApp->parse_complete_callback([this] {
-        std::cout << "get device info" << std::endl;
+    rawSessionDeinitializeApp->parse_complete_callback([this, rawSessionDeinitializeApp] {
+        RegisterCliAppWithOperation(rawSessionDeinitializeApp);
+        std::cout << "deinitialize session " << m_cliData->SessionId << std::endl;
     });
 
-    rawSessionDeinitializeApp->final_callback([this] {
+    rawSessionDeinitializeApp->final_callback([this, rawSessionDeinitializeApp] {
         auto uwbDevice = GetUwbDevice();
         if (!uwbDevice) {
             std::cerr << "no device found" << std::endl;
@@ -395,7 +397,9 @@ NearObjectCli::AddSubcommandUwbRawSessionDeinitialize(CLI::App* parent)
             std::cerr << "device not initialized" << std::endl;
         }
 
-        // TODO: m_cliHandler->HandleSessionDeinitialize(uwbDevice);
+        m_cliHandler->HandleSessionDeinitialize(uwbDevice, m_cliData->SessionId);
+
+        SignalCliAppOperationCompleted(rawSessionDeinitializeApp);
     });
 
     return rawSessionDeinitializeApp;

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -284,6 +284,7 @@ NearObjectCli::AddSubcommandUwbRaw(CLI::App* parent)
     // sub-commands
     AddSubcommandUwbRawDeviceReset(rawApp);
     AddSubcommandUwbRawGetDeviceInfo(rawApp);
+    AddSubcommandUwbRawSessionDeinitialize(rawApp);
 
     return rawApp;
 }
@@ -372,6 +373,32 @@ NearObjectCli::AddSubcommandUwbRawGetDeviceInfo(CLI::App* parent)
     });
 
     return rawGetDeviceInfoApp;
+}
+
+CLI::App*
+NearObjectCli::AddSubcommandUwbRawSessionDeinitialize(CLI::App* parent)
+{
+    // top-level command
+    auto rawSessionDeinitializeApp = parent->add_subcommand("sessiondeinit", "Deinitialize a pre-existing session")->fallthrough();
+
+    rawSessionDeinitializeApp->parse_complete_callback([this] {
+        std::cout << "get device info" << std::endl;
+    });
+
+    rawSessionDeinitializeApp->final_callback([this] {
+        auto uwbDevice = GetUwbDevice();
+        if (!uwbDevice) {
+            std::cerr << "no device found" << std::endl;
+            return;
+        }
+        if (!uwbDevice->Initialize()) {
+            std::cerr << "device not initialized" << std::endl;
+        }
+
+        // TODO: m_cliHandler->HandleSessionDeinitialize(uwbDevice);
+    });
+
+    return rawSessionDeinitializeApp;
 }
 
 CLI::App*

--- a/tools/cli/NearObjectCliHandler.cxx
+++ b/tools/cli/NearObjectCliHandler.cxx
@@ -128,7 +128,13 @@ try {
 void
 NearObjectCliHandler::HandleSessionDeinitialize(std::shared_ptr<::uwb::UwbDevice> uwbDevice, uint32_t sessionId) noexcept
 try {
-    // TODO
+    auto session = uwbDevice->GetSession(sessionId);
+    if (session == nullptr) {
+        PLOG_WARNING << "no session found with id " << sessionId;
+        return;
+    }
+
+    session->Destroy();
 } catch (...) {
     PLOG_ERROR << "failed to deinitialize session";
 }

--- a/tools/cli/NearObjectCliHandler.cxx
+++ b/tools/cli/NearObjectCliHandler.cxx
@@ -124,3 +124,11 @@ try {
 } catch (...) {
     PLOG_ERROR << "failed to obtain device information";
 }
+
+void
+NearObjectCliHandler::HandleSessionDeinitialize(std::shared_ptr<::uwb::UwbDevice> uwbDevice, uint32_t sessionId) noexcept
+try {
+    // TODO
+} catch (...) {
+    PLOG_ERROR << "failed to deinitialize session";
+}

--- a/tools/cli/NearObjectCliUwbSessionEventCallbacks.cxx
+++ b/tools/cli/NearObjectCliUwbSessionEventCallbacks.cxx
@@ -4,6 +4,8 @@
 #include <nearobject/cli/NearObjectCliUwbSessionEventCallbacks.hxx>
 #include <notstd/tostring.hxx>
 
+#include <magic_enum.hpp>
+
 using namespace nearobject::cli;
 using namespace strings::ostream_operators;
 
@@ -48,9 +50,9 @@ operator<<(std::ostream& out, LogPrefix logPrefix)
 } // namespace
 
 void
-NearObjectCliUwbSessionEventCallbacks::OnSessionEnded(::uwb::UwbSession* session, ::uwb::UwbSessionEndReason /* reason */)
+NearObjectCliUwbSessionEventCallbacks::OnSessionEnded(::uwb::UwbSession* session, ::uwb::UwbSessionEndReason reason)
 {
-    std::cout << LogPrefix(session->GetId()) << "Session Ended" << std::endl;
+    std::cout << LogPrefix(session->GetId()) << "Session Ended (" << magic_enum::enum_name(reason) << ")" << std::endl;
 
     if (m_onSessionEndedCallback) {
         m_onSessionEndedCallback();

--- a/tools/cli/include/nearobject/cli/NearObjectCli.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCli.hxx
@@ -268,6 +268,15 @@ private:
     AddSubcommandUwbRawGetDeviceInfo(CLI::App* parent);
 
     /**
+     * @brief Add the 'uwb raw sessiondeinit' sub-command. 
+     * 
+     * @param parent The parent app to add the command.
+     * @return CLI::App* 
+     */
+    CLI::App*
+    AddSubcommandUwbRawSessionDeinitialize(CLI::App* parent);
+
+    /**
      * @brief Add the 'uwb range start' sub-command.
      *
      * @param parent

--- a/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
@@ -110,6 +110,7 @@ struct NearObjectCliData
     uwb::protocol::fira::StaticRangingInfo StaticRanging{};
     uwb::protocol::fira::UwbSessionData SessionData{};
     UwbRangingParameters RangingParameters{};
+    uint32_t SessionId{0};
 };
 
 } // namespace nearobject::cli

--- a/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
@@ -70,8 +70,8 @@ struct UwbConfigurationData
 
     /**
      * @brief Convert the staging data to a complete UwbConfiguration object.
-     * 
-     * @return uwb::protocol::fira::UwbConfiguration 
+     *
+     * @return uwb::protocol::fira::UwbConfiguration
      */
     operator uwb::protocol::fira::UwbConfiguration() const noexcept;
 };
@@ -110,7 +110,7 @@ struct NearObjectCliData
     uwb::protocol::fira::StaticRangingInfo StaticRanging{};
     uwb::protocol::fira::UwbSessionData SessionData{};
     UwbRangingParameters RangingParameters{};
-    uint32_t SessionId{0};
+    uint32_t SessionId{ 0 };
 };
 
 } // namespace nearobject::cli

--- a/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
@@ -98,6 +98,15 @@ struct NearObjectCliHandler
     virtual void
     HandleGetDeviceInfo(std::shared_ptr<uwb::UwbDevice> uwbDevice) noexcept;
 
+    /**
+     * @brief Invoked by the command-line driver when the request is to deinitialize a pre-existing session. 
+     * 
+     * @param uwbDevice 
+     * @param sessionId 
+     */
+    virtual void
+    HandleSessionDeinitialize(std::shared_ptr<::uwb::UwbDevice> uwbDevice, uint32_t sessionId) noexcept;
+
 private:
     NearObjectCli* m_parent;
     std::shared_ptr<::uwb::UwbDevice> m_activeDevice;

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include <uwb/UwbRegisteredCallbacks.hxx>
+#include <uwb/UwbSessionEventCallbacks.hxx>
 #include <uwb/protocols/fira/UwbCapability.hxx>
 #include <wil/resource.h>
 #include <windows/devices/uwb/IUwbDeviceDdi.hxx>
@@ -165,6 +166,15 @@ private:
      */
     void
     DispatchCallbacks(::uwb::protocol::fira::UwbNotificationData uwbNotificationData);
+
+    /**
+     * @brief Response for calling the relevant registered callbacks for the session ended event.
+     *
+     * @param sessionId The session identifier of the session that ended.
+     * @param sessionEndReason The reason the session ended.
+     */
+    void
+    OnSessionEnded(uint32_t sessionId, ::uwb::UwbSessionEndReason sessionEndReason);
 
     /**
      * @brief Internal function that prepares the notification for processing by the m_sessionEventCallbacks


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Allow a ranging session to be de-initialized via `nocli` with only a session id as put. 

### Technical Details

* Add new `uwb raw sessiondeinit` command.

### Test Results

* Ran two instances of `nocli.exe`, one starting a ranging session, the second one calling `uwb raw sessiondeinit` and observed the session was deinitialzied.
* Ran a single instance of `nocli.exe` passing an invalid session id and observed the expected error message.

### Reviewer Focus

None

### Future Work

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
