### PR TITLE
Bug fix: Fix simulator driver heap overrun

### DIFF
--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -453,7 +453,7 @@ UwbConnector::SetApplicationConfigurationParameters(uint32_t sessionId, std::vec
     auto paramsDdi = UwbCxDdi::From(uwbSetApplicationConfigurationParameters);
     auto paramsBuffer = std::data(paramsDdi);
 
-    auto statusSize = offsetof(UWB_SET_APP_CONFIG_PARAMS_STATUS, appConfigParamsStatus[std::size(applicationConfigurationParameters)]);
+    auto statusSize = offsetof(UWB_SET_APP_CONFIG_PARAMS_STATUS, appConfigParamsStatus[std::size(uwbSetApplicationConfigurationParameters.Parameters)]);
     std::vector<uint8_t> statusBuffer(statusSize);
     BOOL ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_SET_APP_CONFIG_PARAMS, std::data(paramsBuffer), std::size(paramsBuffer), std::data(statusBuffer), statusSize, nullptr, nullptr);
     if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -522,6 +522,11 @@ UwbConnector::HandleNotifications(std::stop_token stopToken)
                 }
             }
 
+            // Ensure some data was provided by the driver.
+            if (uwbNotificationDataBuffer.empty()) {
+                continue;
+            }
+
             // Convert to neutral type and process the notification.
             const UWB_NOTIFICATION_DATA& notificationData = *reinterpret_cast<UWB_NOTIFICATION_DATA*>(std::data(uwbNotificationDataBuffer));
             auto uwbNotificationData = UwbCxDdi::To(notificationData);


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Ensure the simulator driver doesn't crash sometime after setting application configuration parameters. 

The existing code was determining the size of the `SetApplicationConfigurationParameters` output array by using the direct input argument. However, the data was moved from the input argument into an intermediary variable, and therefore had zero size, causing a buffer overrun both in the service code and in the simulator driver.

### Technical Details

* Use the intermediate input buffer to determine number of entries in output buffer size calculation.
* Validate that the driver actually returned some notification data prior to processing it.

### Test Results

Ran the standard full-ranging scenario with `nocli.exe` and ensured that no critical errors were detected in the simulator driver running under a debugger.

### Reviewer Focus

None

### Future Work

* Additional buffer bounds checking is needed in the simulator driver to avoid such an issue. This will be done in a separate PR.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.

