### PR TITLE
Bug fix: Ensure control flow context is available to cli handlers

### DIFF
--- a/tools/cli/NearObjectCliHandler.cxx
+++ b/tools/cli/NearObjectCliHandler.cxx
@@ -16,9 +16,8 @@ void
 NearObjectCliHandler::SetParent(NearObjectCli* parent)
 {
     m_parent = parent;
-
-    auto controlFlowContext = (m_parent != nullptr) ? m_parent->GetControlFlowContext() : nullptr;
-    m_sessionEventCallbacks = std::make_shared<NearObjectCliUwbSessionEventCallbacks>([this, controlFlowContext = std::move(controlFlowContext)]() {
+    m_sessionEventCallbacks = std::make_shared<NearObjectCliUwbSessionEventCallbacks>([this, parent]() {
+        auto controlFlowContext = (m_parent != nullptr) ? m_parent->GetControlFlowContext() : nullptr;
         if (controlFlowContext != nullptr) {
             controlFlowContext->OperationSignalComplete();
         }

--- a/tools/cli/NearObjectCliHandler.cxx
+++ b/tools/cli/NearObjectCliHandler.cxx
@@ -16,7 +16,7 @@ void
 NearObjectCliHandler::SetParent(NearObjectCli* parent)
 {
     m_parent = parent;
-    m_sessionEventCallbacks = std::make_shared<NearObjectCliUwbSessionEventCallbacks>([this, parent]() {
+    m_sessionEventCallbacks = std::make_shared<NearObjectCliUwbSessionEventCallbacks>([this]() {
         auto controlFlowContext = (m_parent != nullptr) ? m_parent->GetControlFlowContext() : nullptr;
         if (controlFlowContext != nullptr) {
             controlFlowContext->OperationSignalComplete();


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Ensure the control flow context can be used by `nocli` handlers to instrument graceful shutdown.

The prior code attempted to bind to it when the parent was set, however, the control flow context isn't constructed until CLI parsing is complete. Thus, the control flow context was empty and the handler is unable to signal that its operation is complete.

### Technical Details

* Delay binding the control flow context until it is needed via the parent device which is not captured in the session-end callback, instead of the control flow context directly.

### Test Results

* Verified the callback is invoked when the session ends.

### Reviewer Focus

None

### Future Work

* The simulator driver needs to complete all concurrent pending requests for notifications. Currently, it complete only the first one in the queue, yet there are 2 connectors with pending notification requests (`UwbSession`, `UwbDevice`). This means only one of them will receive the pending notification, and the other one will stay blocked and never receive that notification. This requires non-trivial changes in the simulator driver's manual dispatch queue processing, so will be done in another PR.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
