### PR TITLE
Improve app configuration parameter display and vector building code in nocli

### DIFF
--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -243,23 +243,23 @@ ProcessApplicationConfigurationParameters(UwbApplicationConfigurationParameterDa
     std::vector<uwb::protocol::fira::UwbApplicationConfigurationParameter> applicationConfigurationParameters;
 
     std::cout << "Selected parameters:" << std::endl;
-    for (const auto& [applicationConfigurationParameter, applicationConfigurationParameterValue] : applicationConfigurationParameterData.GetValueMap()) {
-        std::visit([&applicationConfigurationParameter, &applicationConfigurationParameters](auto&& arg)
-        {
+    const auto applicationConfigurationParameterValues = applicationConfigurationParameterData.GetValueMap();
+    for (const auto& [applicationConfigurationParameter, applicationConfigurationParameterValue] : applicationConfigurationParameterValues) {
+        std::visit([&applicationConfigurationParameter, &applicationConfigurationParameters](auto&& arg) {
             applicationConfigurationParameters.push_back({ applicationConfigurationParameter, arg });
 
             using ParameterValueT = std::decay_t<decltype(arg)>;
             if constexpr (std::is_enum_v<ParameterValueT>) {
                 std::cout << magic_enum::enum_name(applicationConfigurationParameter) << "::" << magic_enum::enum_name(arg) << std::endl;
             } else if constexpr (std::is_same_v<ParameterValueT, uint8_t>) {
-                std::cout << magic_enum::enum_name(applicationConfigurationParameter) << "::" << static_cast<int>(arg) << std::endl;
+                std::cout << magic_enum::enum_name(applicationConfigurationParameter) << "::" << +arg << std::endl;
             } else if constexpr (std::is_same_v<ParameterValueT, ::uwb::UwbMacAddress>) {
                 std::cout << magic_enum::enum_name(applicationConfigurationParameter) << "::" << ToString(arg) << std::endl;
             } else if constexpr (std::is_same_v<ParameterValueT, std::unordered_set<::uwb::UwbMacAddress>>) {
                 for (const auto& address : arg) {
                     std::cout << magic_enum::enum_name(applicationConfigurationParameter) << "::" << ToString(arg) << std::endl;
                 }
-            } 
+            }
         },
             applicationConfigurationParameterValue);
     }

--- a/tools/cli/NearObjectCliData.cxx
+++ b/tools/cli/NearObjectCliData.cxx
@@ -3,6 +3,7 @@
 #include <uwb/protocols/fira/UwbConfigurationBuilder.hxx>
 
 using namespace nearobject::cli;
+using uwb::protocol::fira::UwbApplicationConfigurationParameterType;
 using uwb::protocol::fira::UwbConfiguration;
 
 UwbConfigurationData::operator UwbConfiguration() const noexcept
@@ -113,4 +114,29 @@ UwbConfigurationData::operator UwbConfiguration() const noexcept
     }
 
     return builder;
+}
+
+std::unordered_map<uwb::protocol::fira::UwbApplicationConfigurationParameterType, UwbApplicationConfigurationParameterData::ParameterTypesVariant>
+UwbApplicationConfigurationParameterData::GetValueMap() const
+{
+    std::unordered_map<UwbApplicationConfigurationParameterType, ParameterTypesVariant> valuesMap;
+    if (deviceRole.has_value()) {
+        valuesMap[UwbApplicationConfigurationParameterType::DeviceRole] = deviceRole.value();
+    }
+    if (multiNodeMode.has_value()) {
+        valuesMap[UwbApplicationConfigurationParameterType::MultiNodeMode] = multiNodeMode.value();
+    }
+    if (numberOfControlees.has_value()) {
+        valuesMap[UwbApplicationConfigurationParameterType::NumberOfControlees] = numberOfControlees.value();
+    }
+    if (deviceMacAddress.has_value()) {
+        valuesMap[UwbApplicationConfigurationParameterType::DeviceMacAddress] = deviceMacAddress.value();
+    }
+    if (destinationMacAddresses.has_value()) {
+        valuesMap[UwbApplicationConfigurationParameterType::DestinationMacAddresses] = destinationMacAddresses.value();
+    }
+    if (deviceType.has_value()) {
+        valuesMap[UwbApplicationConfigurationParameterType::DeviceType] = deviceType.value();
+    }
+    return valuesMap;
 }

--- a/tools/cli/NearObjectCliData.cxx
+++ b/tools/cli/NearObjectCliData.cxx
@@ -116,7 +116,7 @@ UwbConfigurationData::operator UwbConfiguration() const noexcept
     return builder;
 }
 
-std::unordered_map<uwb::protocol::fira::UwbApplicationConfigurationParameterType, UwbApplicationConfigurationParameterData::ParameterTypesVariant>
+std::unordered_map<UwbApplicationConfigurationParameterType, UwbApplicationConfigurationParameterData::ParameterTypesVariant>
 UwbApplicationConfigurationParameterData::GetValueMap() const
 {
     std::unordered_map<UwbApplicationConfigurationParameterType, ParameterTypesVariant> valuesMap;

--- a/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
@@ -108,6 +108,9 @@ struct UwbApplicationConfigurationParameterData
         ::uwb::UwbMacAddressType,
         std::unordered_set<::uwb::UwbMacAddress>>;
 
+    /**
+     * @brief Map of application configuration parameter type to the parameter's value.
+     */
     std::unordered_map<UwbApplicationConfigurationParameterType, ParameterTypesVariant>
     GetValueMap() const
     {

--- a/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
@@ -3,7 +3,6 @@
 #define NEAR_OBJECT_CLI_DATA_HXX
 
 #include <cstdint>
-#include <any>
 #include <optional>
 #include <string>
 

--- a/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
@@ -11,8 +11,6 @@
 #include <uwb/protocols/fira/UwbConfiguration.hxx>
 #include <uwb/protocols/fira/UwbSessionData.hxx>
 
-using namespace uwb::protocol::fira;
-
 namespace nearobject::cli
 {
 /**
@@ -111,30 +109,8 @@ struct UwbApplicationConfigurationParameterData
     /**
      * @brief Map of application configuration parameter type to the parameter's value.
      */
-    std::unordered_map<UwbApplicationConfigurationParameterType, ParameterTypesVariant>
-    GetValueMap() const
-    {
-        std::unordered_map<UwbApplicationConfigurationParameterType, ParameterTypesVariant> valuesMap;
-        if (deviceRole.has_value()) {
-            valuesMap[UwbApplicationConfigurationParameterType::DeviceRole] = deviceRole.value();
-        }
-        if (multiNodeMode.has_value()) {
-            valuesMap[UwbApplicationConfigurationParameterType::MultiNodeMode] = multiNodeMode.value();
-        }
-        if (numberOfControlees.has_value()) {
-            valuesMap[UwbApplicationConfigurationParameterType::NumberOfControlees] = numberOfControlees.value();
-        }
-        if (deviceMacAddress.has_value()) {
-            valuesMap[UwbApplicationConfigurationParameterType::DeviceMacAddress] = deviceMacAddress.value();
-        }
-        if (destinationMacAddresses.has_value()) {
-            valuesMap[UwbApplicationConfigurationParameterType::DestinationMacAddresses] = destinationMacAddresses.value();
-        }
-        if (deviceType.has_value()) {
-            valuesMap[UwbApplicationConfigurationParameterType::DeviceType] = deviceType.value();
-        }
-        return valuesMap;
-    }
+    std::unordered_map<uwb::protocol::fira::UwbApplicationConfigurationParameterType, ParameterTypesVariant>
+    GetValueMap() const;
 };
 
 /**

--- a/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
@@ -3,6 +3,7 @@
 #define NEAR_OBJECT_CLI_DATA_HXX
 
 #include <cstdint>
+#include <any>
 #include <optional>
 #include <string>
 
@@ -10,6 +11,8 @@
 #include <uwb/protocols/fira/FiraDevice.hxx>
 #include <uwb/protocols/fira/UwbConfiguration.hxx>
 #include <uwb/protocols/fira/UwbSessionData.hxx>
+
+using namespace uwb::protocol::fira;
 
 namespace nearobject::cli
 {
@@ -93,6 +96,43 @@ struct UwbApplicationConfigurationParameterData
     std::optional<std::unordered_set<uwb::UwbMacAddress>> destinationMacAddresses;
     std::optional<uwb::protocol::fira::DeviceType> deviceType;
     std::optional<uwb::UwbMacAddressType> macAddressMode;
+
+    /**
+     * @brief Variant for all possible property types.
+     */
+    using ParameterTypesVariant = std::variant<
+        uint8_t,
+        ::uwb::protocol::fira::DeviceRole,
+        ::uwb::protocol::fira::DeviceType,
+        ::uwb::protocol::fira::MultiNodeMode,
+        ::uwb::UwbMacAddress,
+        ::uwb::UwbMacAddressType,
+        std::unordered_set<::uwb::UwbMacAddress>>;
+
+    std::unordered_map<UwbApplicationConfigurationParameterType, ParameterTypesVariant>
+    GetValueMap() const
+    {
+        std::unordered_map<UwbApplicationConfigurationParameterType, ParameterTypesVariant> valuesMap;
+        if (deviceRole.has_value()) {
+            valuesMap[UwbApplicationConfigurationParameterType::DeviceRole] = deviceRole.value();
+        }
+        if (multiNodeMode.has_value()) {
+            valuesMap[UwbApplicationConfigurationParameterType::MultiNodeMode] = multiNodeMode.value();
+        }
+        if (numberOfControlees.has_value()) {
+            valuesMap[UwbApplicationConfigurationParameterType::NumberOfControlees] = numberOfControlees.value();
+        }
+        if (deviceMacAddress.has_value()) {
+            valuesMap[UwbApplicationConfigurationParameterType::DeviceMacAddress] = deviceMacAddress.value();
+        }
+        if (destinationMacAddresses.has_value()) {
+            valuesMap[UwbApplicationConfigurationParameterType::DestinationMacAddresses] = destinationMacAddresses.value();
+        }
+        if (deviceType.has_value()) {
+            valuesMap[UwbApplicationConfigurationParameterType::DeviceType] = deviceType.value();
+        }
+        return valuesMap;
+    }
 };
 
 /**


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [x] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

This PR improves the code that displays the selected application configuration parameters and constructs a vector of these parameters.

### Technical Details

- Add ParameterTypesVariant and GetValueMap() to UwbApplicationConfigurationParameterData struct in NearObjectCliData.hxx 
- Move parameter displaying/parameter vector building code into its own function
- Improve display/vector building code to use new map instead of manually handling each parameter individually

### Test Results

nocli still works and displays the parameters as expected.

### Reviewer Focus

None.

### Future Work

None.

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
