### PR TITLE
Use smart pointers to control lifetimes of context objects in simulator driver

### DIFF
--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
@@ -21,7 +21,7 @@ UwbSimulatorDdiCallbacks::UwbSimulatorDdiCallbacks(UwbSimulatorDevice *device) :
     m_device(device)
 {}
 
-NTSTATUS
+void
 UwbSimulatorDdiCallbacks::RaiseUwbNotification(UwbNotificationData uwbNotificationData)
 {
     TraceLoggingWrite(
@@ -31,16 +31,8 @@ UwbSimulatorDdiCallbacks::RaiseUwbNotification(UwbNotificationData uwbNotificati
         TraceLoggingString("EventRaised", "Action"),
         TraceLoggingString(std::data(ToString(uwbNotificationData)), "Data"));
 
-    auto ioEventQueueWeak = m_device->GetIoEventQueue();
-    auto ioEventQueue = ioEventQueueWeak.lock();
-    if (ioEventQueue == nullptr) {
-        // TODO: log
-        return STATUS_INVALID_DEVICE_STATE;
-    }
-
-    ioEventQueue->PushNotificationData(std::move(uwbNotificationData));
-
-    return STATUS_SUCCESS;
+    // Dispatch the notification to the device.
+    m_device->PushUwbNotification(std::move(uwbNotificationData));
 }
 
 std::tuple<UwbStatus, std::shared_ptr<UwbSimulatorSession>>

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
@@ -16,7 +16,7 @@
 using namespace windows::devices::uwb;
 using namespace windows::devices::uwb::simulator;
 
-UwbSimulatorDdiCallbacks::UwbSimulatorDdiCallbacks(UwbSimulatorDevice *device) :
+UwbSimulatorDdiCallbacks::UwbSimulatorDdiCallbacks(std::weak_ptr<UwbSimulatorDevice> device) :
     m_simulatorCapabilities({ IUwbSimulator::Version }),
     m_device(device)
 {}
@@ -31,14 +31,27 @@ UwbSimulatorDdiCallbacks::RaiseUwbNotification(UwbNotificationData uwbNotificati
         TraceLoggingString("EventRaised", "Action"),
         TraceLoggingString(std::data(ToString(uwbNotificationData)), "Data"));
 
+    auto device = m_device.lock();
+    if (device == nullptr) {
+        DbgPrint("device instance expired; dropping uwb notification\n");
+        return;
+    }
+
     // Dispatch the notification to the device.
-    m_device->PushUwbNotification(std::move(uwbNotificationData));
+    device->PushUwbNotification(std::move(uwbNotificationData));
 }
 
 std::tuple<UwbStatus, std::shared_ptr<UwbSimulatorSession>>
 UwbSimulatorDdiCallbacks::SessionGet(uint32_t sessionId)
 {
-    auto session = m_device->SessionGet(sessionId);
+    auto device = m_device.lock();
+    if (device == nullptr) {
+        return {
+            UwbStatusGeneric::Rejected, nullptr
+        };
+    }
+
+    auto session = device->SessionGet(sessionId);
     if (session == nullptr) {
         return { UwbStatusSession::NotExist, nullptr };
     }
@@ -134,8 +147,13 @@ UwbSimulatorDdiCallbacks::SessionInitialize(uint32_t sessionId, UwbSessionType s
         TraceLoggingUInt32(sessionId, "Session Id"),
         TraceLoggingString(std::data(magic_enum::enum_name(sessionType)), "Session Type"));
 
+    auto device = m_device.lock();
+    if (device == nullptr) {
+        return UwbStatusGeneric::Rejected;
+    }
+
     // Create a new session.
-    auto [uwbStatus, session] = m_device->SessionCreate(sessionId, sessionType);
+    auto [uwbStatus, session] = device->SessionCreate(sessionId, sessionType);
     if (!IsUwbStatusOk(uwbStatus)) {
         return uwbStatus;
     }
@@ -263,7 +281,12 @@ UwbSimulatorDdiCallbacks::GetApplicationConfigurationParameters(uint32_t session
 UwbStatus
 UwbSimulatorDdiCallbacks::GetSessionCount(uint32_t &sessionCount)
 {
-    sessionCount = static_cast<uint32_t>(m_device->GetSessionCount());
+    auto device = m_device.lock();
+    if (device == nullptr) {
+        return UwbStatusGeneric::Rejected;
+    }
+
+    sessionCount = static_cast<uint32_t>(device->GetSessionCount());
 
     TraceLoggingWrite(
         UwbSimulatorTraceloggingProvider,

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.cxx
@@ -61,6 +61,19 @@ UwbSimulatorDdiCallbacks::SessionGet(uint32_t sessionId)
     };
 }
 
+std::tuple<UwbStatus, std::shared_ptr<UwbSimulatorSession>>
+UwbSimulatorDdiCallbacks::SessionDestroy(uint32_t sessionId)
+{
+    auto device = m_device.lock();
+    if (device == nullptr) {
+        return {
+            UwbStatusGeneric::Rejected, nullptr
+        };
+    }
+
+    return device->SessionDestroy(sessionId);
+}
+
 void
 UwbSimulatorDdiCallbacks::SessionUpdateState(UwbSimulatorSession &session, UwbSessionState sessionState, std::optional<UwbSessionReasonCode> reasonCode = std::nullopt)
 {
@@ -179,7 +192,9 @@ UwbSimulatorDdiCallbacks::SessionDeninitialize(uint32_t sessionId)
 
     SessionUpdateState(*session, UwbSessionState::Deinitialized);
 
-    return UwbStatusOk;
+    std::tie(uwbStatus, session) = SessionDestroy(sessionId);
+
+    return uwbStatus;
 }
 
 UwbStatus

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
@@ -124,7 +124,7 @@ protected:
      *
      * @param uwbNotificationData The notification data to provide with the event.
      */
-    NTSTATUS
+    void
     RaiseUwbNotification(UwbNotificationData uwbNotificationData);
 
 private:

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
@@ -27,7 +27,7 @@ struct UwbSimulatorDdiCallbacks :
     public IUwbSimulatorDdiCallbacksLrp,
     public IUwbSimulatorDdiCallbacksSimulator
 {
-    UwbSimulatorDdiCallbacks(UwbSimulatorDevice *device);
+    UwbSimulatorDdiCallbacks(std::weak_ptr<UwbSimulatorDevice> device);
 
     // IUwbSimulatorDdiCallbacksLrp
 
@@ -134,7 +134,7 @@ private:
 
 private:
     UwbSimulatorCapabilities m_simulatorCapabilities{};
-    UwbSimulatorDevice *m_device{ nullptr };
+    std::weak_ptr<UwbSimulatorDevice> m_device;
 };
 } // namespace windows::devices::uwb::simulator
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiCallbacks.hxx
@@ -99,6 +99,15 @@ protected:
     SessionGet(uint32_t sessionId);
 
     /**
+     * @brief Destroy session context for the specified sesion id.
+     * 
+     * @param sessionId The session id to destroy session context for. 
+     * @return std::tuple<UwbStatus, std::shared_ptr<UwbSimulatorSession>> 
+     */
+    std::tuple<UwbStatus, std::shared_ptr<UwbSimulatorSession>>
+    SessionDestroy(uint32_t sessionId);
+
+    /**
      * @brief Update the state of the specified session.
      *
      * This function will also generate a UWB notification associated with the change.

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.cxx
@@ -462,7 +462,7 @@ UwbSimulatorDdiHandler::OnUwbNotification(WDFREQUEST request, std::span<uint8_t>
     NTSTATUS status = STATUS_SUCCESS;
 
     auto file = WdfRequestGetFileObject(request);
-    auto uwbDeviceFile = GetUwbSimulatorDeviceFile(file);
+    auto uwbDeviceFile = GetUwbSimulatorDeviceFileWdfContext(file)->File;
     auto ioEventQueue = uwbDeviceFile->GetIoEventQueue();
     if (ioEventQueue == nullptr) {
         DbgPrint("failed to obtain io event queue for request %p", request);

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.cxx
@@ -462,7 +462,7 @@ UwbSimulatorDdiHandler::OnUwbNotification(WDFREQUEST request, std::span<uint8_t>
     NTSTATUS status = STATUS_SUCCESS;
 
     auto file = WdfRequestGetFileObject(request);
-    auto uwbDeviceFile = GetUwbSimulatorFile(file);
+    auto uwbDeviceFile = GetUwbSimulatorDeviceFile(file);
     auto ioEventQueue = uwbDeviceFile->GetIoEventQueue();
     if (ioEventQueue == nullptr) {
         DbgPrint("failed to obtain io event queue for request %p", request);

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.cxx
@@ -61,7 +61,7 @@ const std::initializer_list<UwbSimulatorDispatchEntry<UwbSimulatorDdiHandler>> U
     MakeLrpDispatchEntry<UwbSimulatorTriggerSessionEventArgs, Unrestricted>(IOCTL_UWB_DEVICE_SIM_TRIGGER_SESSION_EVENT, &UwbSimulatorDdiHandler::OnUwbSimulatorTriggerSessionEvent),
 };
 
-UwbSimulatorDdiHandler::UwbSimulatorDdiHandler(UwbSimulatorDevice *device) :
+UwbSimulatorDdiHandler::UwbSimulatorDdiHandler(std::weak_ptr<UwbSimulatorDevice> device) :
     m_device(device),
     m_callbacks(std::make_unique<UwbSimulatorDdiCallbacks>(device))
 {

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.cxx
@@ -457,33 +457,23 @@ UwbSimulatorDdiHandler::OnUwbSessionGetRangingCount(WDFREQUEST request, std::spa
 
 // IOCTL_UWB_NOTIFICATION
 NTSTATUS
-UwbSimulatorDdiHandler::OnUwbNotification(WDFREQUEST request, std::span<uint8_t> /*inputBuffer*/, std::span<uint8_t> outputBuffer)
+UwbSimulatorDdiHandler::OnUwbNotification(WDFREQUEST request, std::span<uint8_t> /*inputBuffer*/, std::span<uint8_t> /*outputBuffer*/)
 {
     NTSTATUS status = STATUS_SUCCESS;
 
-    // Obtain a reference to the io event queue.
-    auto ioEventQueueWeak = m_device->GetIoEventQueue();
-    auto ioEventQueue = ioEventQueueWeak.lock();
+    auto file = WdfRequestGetFileObject(request);
+    auto uwbDeviceFile = GetUwbSimulatorFile(file);
+    auto ioEventQueue = uwbDeviceFile->GetIoEventQueue();
     if (ioEventQueue == nullptr) {
-        // TODO: log
+        DbgPrint("failed to obtain io event queue for request %p", request);
         status = STATUS_INVALID_DEVICE_STATE;
         WdfRequestComplete(request, status);
         return status;
     }
 
-    // Process the notification request.
-    std::size_t outputBufferSize = std::size(outputBuffer);
-    std::optional<UwbNotificationData> uwbNotificationData;
-    status = ioEventQueue->HandleNotificationRequest(request, uwbNotificationData, outputBufferSize);
-    if (status == STATUS_SUCCESS) {
-        // Convert neutral type to DDI output type, and copy to output buffer.
-        auto notificationData = UwbCxDdi::From(uwbNotificationData.value());
-        std::memcpy(std::data(outputBuffer), std::data(std::data(notificationData)), outputBufferSize);
-    }
-
-    // Complete the request only if it has not been pended by the driver.
+    status = ioEventQueue->EnqueueRequest(request);
     if (status != STATUS_PENDING) {
-        WdfRequestCompleteWithInformation(request, status, outputBufferSize);
+        WdfRequestComplete(request, status);
     }
 
     return status;

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.hxx
@@ -22,8 +22,12 @@ class UwbSimulatorDdiHandler :
     public IUwbSimulatorDdiHandler
 {
 public:
-    // TODO: docs
-    explicit UwbSimulatorDdiHandler(UwbSimulatorDevice *device);
+    /**
+     * @brief Construct a new UwbSimulatorDdiHandler object.
+     *
+     * @param device The owning parent device.
+     */
+    explicit UwbSimulatorDdiHandler(std::weak_ptr<UwbSimulatorDevice> device);
 
     /**
      * @brief Indicates whether the specified i/o control code is handled by
@@ -126,7 +130,7 @@ private:
     static const std::initializer_list<windows::devices::uwb::simulator::UwbSimulatorDispatchEntry<UwbSimulatorDdiHandler>> Dispatch;
 
 private:
-    UwbSimulatorDevice *m_device;
+    std::weak_ptr<UwbSimulatorDevice> m_device;
     std::unique_ptr<windows::devices::uwb::simulator::UwbSimulatorDdiCallbacks> m_callbacks;
 };
 } // namespace windows::devices::uwb::simulator

--- a/windows/drivers/uwb/simulator/UwbSimulatorDevice.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDevice.cxx
@@ -200,7 +200,7 @@ UwbSimulatorDevice::OnFileClose(WDFFILEOBJECT file)
         return (uwbSimulatorFile == uwbSimulatorFileClosed);
     });
 
-    DbgPrint("%p %s file object %p", m_wdfDevice, (removed ? "removed" : "failed to remove"), file);
+    DbgPrint("%p %s file object %p\n", m_wdfDevice, (removed ? "removed" : "failed to remove"), file);
 }
 
 NTSTATUS

--- a/windows/drivers/uwb/simulator/UwbSimulatorDevice.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDevice.cxx
@@ -172,7 +172,7 @@ UwbSimulatorDevice::OnFileCreate(WDFDEVICE device, WDFREQUEST request, WDFFILEOB
         TraceLoggingPointer(request, "Request"),
         TraceLoggingPointer(file, "File"));
 
-    auto uwbSimulatorFileBuffer = GetUwbSimulatorFile(file);
+    auto uwbSimulatorFileBuffer = GetUwbSimulatorDeviceFile(file);
     auto uwbSimulatorFile = new (uwbSimulatorFileBuffer) UwbSimulatorDeviceFile(file, this);
     auto uwbSimulatorFileStatus = uwbSimulatorFile->Initialize();
     if (uwbSimulatorFileStatus == STATUS_SUCCESS) {
@@ -198,7 +198,7 @@ UwbSimulatorDevice::OnFileClose(WDFFILEOBJECT file)
         TraceLoggingPointer(file, "File"));
 
     std::unique_lock deviceFilesLockExclusive{ m_deviceFilesGate };
-    const auto uwbSimulatorFileClosed = GetUwbSimulatorFile(file);
+    const auto uwbSimulatorFileClosed = GetUwbSimulatorDeviceFile(file);
     const auto removed = std::erase_if(m_deviceFiles, [&](const auto &uwbSimulatorFile) {
         return (uwbSimulatorFile == uwbSimulatorFileClosed);
     });

--- a/windows/drivers/uwb/simulator/UwbSimulatorDevice.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDevice.cxx
@@ -14,7 +14,7 @@ using windows::devices::uwb::simulator::UwbSimulatorSession;
 
 UwbSimulatorDevice::UwbSimulatorDevice(WDFDEVICE wdfDevice) :
     m_wdfDevice(wdfDevice),
-    m_ddiHandler(std::make_shared<UwbSimulatorDdiHandler>(this))
+    m_ddiHandler(std::make_shared<UwbSimulatorDdiHandler>(weak_from_this()))
 {}
 
 /* static */
@@ -60,7 +60,7 @@ UwbSimulatorDevice::OnWdfDeviceAdd(WDFDRIVER /* driver */, PWDFDEVICE_INIT devic
     auto uwbSimulatorDeviceContext = new (uwbSimulatorDeviceContextBuffer) UwbSimulatorDeviceWdfContext{
         .Device = std::make_shared<notstd::enable_make_protected<UwbSimulatorDevice>>(device)
     };
-    
+
     auto uwbSimulatorDevice = uwbSimulatorDeviceContext->Device;
     status = uwbSimulatorDevice->Initialize();
     return status;

--- a/windows/drivers/uwb/simulator/UwbSimulatorDevice.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDevice.cxx
@@ -65,6 +65,13 @@ UwbSimulatorDevice::OnWdfDeviceAdd(WDFDRIVER /* driver */, PWDFDEVICE_INIT devic
 
     auto uwbSimulatorDevice = uwbSimulatorDeviceContext->Device;
     status = uwbSimulatorDevice->Initialize();
+    if (!NT_STATUS(status)) {
+        uwbSimulatorDeviceContext->~UwbSimulatorDeviceWdfContext();
+        DbgPrint("failed to initialize device context with status 0x%08x\n", status);
+    } else {
+        DbgPrint("successfully initialize simulator device context\n");
+    }
+
     return status;
 }
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDevice.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDevice.cxx
@@ -322,9 +322,6 @@ UwbSimulatorDevice::PushUwbNotification(UwbNotificationData uwbNotificationData)
     constexpr auto resolveWeak = [](auto deviceFileWeak) {
         return deviceFileWeak.lock();
     };
-    constexpr auto nonNull = [](auto deviceFileStrong) {
-        return deviceFileStrong != nullptr;
-    };
 
     DbgPrint("%p received push notification payload %s\n", m_wdfDevice, std::data(ToString(uwbNotificationData)));
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDevice.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDevice.cxx
@@ -65,11 +65,11 @@ UwbSimulatorDevice::OnWdfDeviceAdd(WDFDRIVER /* driver */, PWDFDEVICE_INIT devic
 
     auto uwbSimulatorDevice = uwbSimulatorDeviceContext->Device;
     status = uwbSimulatorDevice->Initialize();
-    if (!NT_STATUS(status)) {
+    if (!NT_SUCCESS(status)) {
         uwbSimulatorDeviceContext->~UwbSimulatorDeviceWdfContext();
         DbgPrint("failed to initialize device context with status 0x%08x\n", status);
     } else {
-        DbgPrint("successfully initialize simulator device context\n");
+        DbgPrint("successfully initialized simulator device context\n");
     }
 
     return status;

--- a/windows/drivers/uwb/simulator/UwbSimulatorDevice.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDevice.cxx
@@ -189,11 +189,12 @@ UwbSimulatorDevice::OnFileCreate(WDFDEVICE device, WDFREQUEST request, WDFFILEOB
     if (uwbSimulatorFileStatus == STATUS_SUCCESS) {
         uwbSimulatorFile->RegisterHandler(m_ddiHandler);
 
-        std::unique_lock deviceFilesLockExclusive{ m_deviceFilesGate };
+        std::scoped_lock deviceFilesLockExclusive{ m_deviceFilesGate };
         m_deviceFiles.push_back(uwbSimulatorFile);
         DbgPrint("%p added file object %p\n", m_wdfDevice, file);
     } else {
         uwbSimulatorFileContext->~UwbSimulatorDeviceFileWdfContext();
+        DbgPrint("%p failed to initialize file context object with status 0x%08x\n", uwbSimulatorFileStatus);
     }
 
     WdfRequestComplete(request, uwbSimulatorFileStatus);

--- a/windows/drivers/uwb/simulator/UwbSimulatorDevice.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDevice.cxx
@@ -15,8 +15,7 @@ using windows::devices::uwb::simulator::UwbSimulatorDdiHandler;
 using windows::devices::uwb::simulator::UwbSimulatorSession;
 
 UwbSimulatorDevice::UwbSimulatorDevice(WDFDEVICE wdfDevice) :
-    m_wdfDevice(wdfDevice),
-    m_ddiHandler(std::make_shared<UwbSimulatorDdiHandler>(weak_from_this()))
+    m_wdfDevice(wdfDevice)
 {}
 
 /* static */
@@ -125,6 +124,8 @@ UwbSimulatorDevice::OnWdfFileClose(WDFFILEOBJECT file)
 NTSTATUS
 UwbSimulatorDevice::Initialize()
 {
+    m_ddiHandler = std::make_shared<UwbSimulatorDdiHandler>(weak_from_this());
+
     // Create a default queue for all requests that are not explicitly configured to go elsewhere.
     WDF_IO_QUEUE_CONFIG queueConfig;
     WDF_IO_QUEUE_CONFIG_INIT_DEFAULT_QUEUE(&queueConfig, WdfIoQueueDispatchParallel);

--- a/windows/drivers/uwb/simulator/UwbSimulatorDevice.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDevice.hxx
@@ -24,9 +24,10 @@ class UwbSimulatorDeviceFile;
 /**
  * @brief
  */
-class UwbSimulatorDevice
+class UwbSimulatorDevice :
+    public std::enable_shared_from_this<UwbSimulatorDevice>
 {
-public:
+protected:
     /**
      * @brief Construct a new UwbSimulatorDevice object.
      *
@@ -34,6 +35,7 @@ public:
      */
     explicit UwbSimulatorDevice(WDFDEVICE wdfDevice);
 
+public:
     /**
      * @brief
      *
@@ -155,6 +157,11 @@ private:
     std::vector<UwbSimulatorDeviceFile *> m_deviceFiles{};
 };
 
-WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(UwbSimulatorDevice, GetUwbSimulatorDevice)
+struct UwbSimulatorDeviceWdfContext
+{
+    std::shared_ptr<UwbSimulatorDevice> Device;
+};
+
+WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(UwbSimulatorDeviceWdfContext, GetUwbSimulatorDeviceWdfContext)
 
 #endif // UWB_SIMULATOR_DEVICE_HXX

--- a/windows/drivers/uwb/simulator/UwbSimulatorDevice.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDevice.hxx
@@ -154,7 +154,7 @@ private:
 
     // Open file handles
     std::shared_mutex m_deviceFilesGate;
-    std::vector<UwbSimulatorDeviceFile *> m_deviceFiles{};
+    std::vector<std::weak_ptr<UwbSimulatorDeviceFile>> m_deviceFiles;
 };
 
 struct UwbSimulatorDeviceWdfContext

--- a/windows/drivers/uwb/simulator/UwbSimulatorDevice.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDevice.hxx
@@ -19,6 +19,8 @@
 
 #include <uwb/protocols/fira/FiraDevice.hxx>
 
+class UwbSimulatorDeviceFile;
+
 /**
  * @brief
  */
@@ -47,10 +49,6 @@ public:
      */
     NTSTATUS
     Uninitialize();
-
-    // TODO: docs
-    std::weak_ptr<UwbSimulatorIoEventQueue>
-    GetIoEventQueue() noexcept;
 
     /**
      * @brief Create a new uwb session.
@@ -87,6 +85,9 @@ public:
      */
     std::size_t
     GetSessionCount();
+
+    void
+    PushUwbNotification(::uwb::protocol::fira::UwbNotificationData notificationData);
 
 public:
     static EVT_WDF_DRIVER_DEVICE_ADD OnWdfDeviceAdd;
@@ -136,12 +137,14 @@ private:
 private:
     WDFDEVICE m_wdfDevice;
     UwbSimulatorIoQueue *m_ioQueue{ nullptr };
-    std::shared_ptr<UwbSimulatorIoEventQueue> m_ioEventQueue{ nullptr };
     std::shared_ptr<windows::devices::uwb::simulator::IUwbSimulatorDdiHandler> m_ddiHandler;
 
     // Session state and associated lock that protects it.
     std::shared_mutex m_sessionsGate;
     std::unordered_map<uint32_t, std::shared_ptr<windows::devices::uwb::simulator::UwbSimulatorSession>> m_sessions{};
+
+    // Open file handles
+    std::vector<UwbSimulatorDeviceFile *> m_deviceFiles{};
 };
 
 WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(UwbSimulatorDevice, GetUwbSimulatorDevice)

--- a/windows/drivers/uwb/simulator/UwbSimulatorDevice.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDevice.hxx
@@ -86,6 +86,13 @@ public:
     std::size_t
     GetSessionCount();
 
+    /**
+     * @brief Push a simulated uwb notification.
+     *
+     * This distributes the event to all open-file handle i/o event queues.
+     *
+     * @param notificationData The notification data to distribute.
+     */
     void
     PushUwbNotification(::uwb::protocol::fira::UwbNotificationData notificationData);
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDevice.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDevice.hxx
@@ -144,6 +144,7 @@ private:
     std::unordered_map<uint32_t, std::shared_ptr<windows::devices::uwb::simulator::UwbSimulatorSession>> m_sessions{};
 
     // Open file handles
+    std::shared_mutex m_deviceFilesGate;
     std::vector<UwbSimulatorDeviceFile *> m_deviceFiles{};
 };
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.cxx
@@ -8,7 +8,7 @@
 
 using windows::devices::uwb::simulator::IUwbSimulatorDdiHandler;
 
-UwbSimulatorDeviceFile::UwbSimulatorDeviceFile(WDFFILEOBJECT wdfFile, UwbSimulatorDevice *uwbSimulatorDevice) :
+UwbSimulatorDeviceFile::UwbSimulatorDeviceFile(WDFFILEOBJECT wdfFile, std::weak_ptr<UwbSimulatorDevice> uwbSimulatorDevice) :
     m_wdfFile(wdfFile),
     m_uwbSimulatorDevice(uwbSimulatorDevice)
 {}
@@ -19,7 +19,7 @@ UwbSimulatorDeviceFile::GetWdfFile() const noexcept
     return m_wdfFile;
 }
 
-UwbSimulatorDevice *
+std::weak_ptr<UwbSimulatorDevice>
 UwbSimulatorDeviceFile::GetDevice() noexcept
 {
     return m_uwbSimulatorDevice;
@@ -78,7 +78,7 @@ UwbSimulatorDeviceFile::RegisterHandler(std::shared_ptr<IUwbSimulatorDdiHandler>
 VOID
 UwbSimulatorDeviceFile::OnWdfDestroy(WDFOBJECT wdfFile)
 {
-    auto instance = GetUwbSimulatorDeviceFile(wdfFile);
+    auto instance = GetUwbSimulatorDeviceFileWdfContext(wdfFile)->File;
     if (instance->m_wdfFile != wdfFile) {
         return;
     }
@@ -93,7 +93,7 @@ VOID
 UwbSimulatorDeviceFile::OnWdfRequestCancel(WDFREQUEST request)
 {
     auto wdfFile = WdfRequestGetFileObject(request);
-    auto instance = GetUwbSimulatorDeviceFile(wdfFile);
+    auto instance = GetUwbSimulatorDeviceFileWdfContext(wdfFile)->File;
     if (instance->m_wdfFile != wdfFile) {
         return;
     }

--- a/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.cxx
@@ -83,9 +83,7 @@ UwbSimulatorDeviceFile::OnWdfDestroy(WDFOBJECT wdfFile)
         return;
     }
 
-    // Explicitly invoke the destructor since the object was created with placement new.
     instance->OnDestroy();
-    instance->~UwbSimulatorDeviceFile();
 }
 
 /* static */
@@ -104,6 +102,7 @@ UwbSimulatorDeviceFile::OnWdfRequestCancel(WDFREQUEST request)
 void
 UwbSimulatorDeviceFile::OnDestroy()
 {
+    DbgPrint("%p destroyed\n", m_wdfFile);
 }
 
 void

--- a/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.cxx
@@ -78,7 +78,7 @@ UwbSimulatorDeviceFile::RegisterHandler(std::shared_ptr<IUwbSimulatorDdiHandler>
 VOID
 UwbSimulatorDeviceFile::OnWdfDestroy(WDFOBJECT wdfFile)
 {
-    auto instance = GetUwbSimulatorFile(wdfFile);
+    auto instance = GetUwbSimulatorDeviceFile(wdfFile);
     if (instance->m_wdfFile != wdfFile) {
         return;
     }
@@ -93,7 +93,7 @@ VOID
 UwbSimulatorDeviceFile::OnWdfRequestCancel(WDFREQUEST request)
 {
     auto wdfFile = WdfRequestGetFileObject(request);
-    auto instance = GetUwbSimulatorFile(wdfFile);
+    auto instance = GetUwbSimulatorDeviceFile(wdfFile);
     if (instance->m_wdfFile != wdfFile) {
         return;
     }

--- a/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.cxx
@@ -25,9 +25,46 @@ UwbSimulatorDeviceFile::GetDevice() noexcept
     return m_uwbSimulatorDevice;
 }
 
+std::shared_ptr<UwbSimulatorIoEventQueue>
+UwbSimulatorDeviceFile::GetIoEventQueue()
+{
+    return m_ioEventQueue;
+}
+
 NTSTATUS
 UwbSimulatorDeviceFile::Initialize()
 {
+    std::shared_ptr<UwbSimulatorIoEventQueue> ioEventQueue;
+
+    // Create a manual dispatch queue for event handling.
+    WDF_IO_QUEUE_CONFIG queueConfig;
+    WDF_IO_QUEUE_CONFIG_INIT(&queueConfig, WdfIoQueueDispatchManual);
+    queueConfig.PowerManaged = WdfFalse;
+
+    WDFQUEUE wdfQueue;
+    WDFDEVICE wdfDevice = WdfFileObjectGetDevice(m_wdfFile);
+    NTSTATUS status = WdfIoQueueCreate(wdfDevice, &queueConfig, WDF_NO_OBJECT_ATTRIBUTES, &wdfQueue);
+    if (!NT_SUCCESS(status)) {
+        TraceLoggingWrite(
+            UwbSimulatorTraceloggingProvider,
+            "WdfIoQueueCreate failed",
+            TraceLoggingLevel(TRACE_LEVEL_FATAL),
+            TraceLoggingNTStatus(status));
+        return status;
+    }
+
+    ioEventQueue = std::make_shared<UwbSimulatorIoEventQueue>(wdfQueue, MaximumQueueSizeDefault);
+    if (ioEventQueue == nullptr) {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    status = ioEventQueue->Initialize();
+    if (!NT_SUCCESS(status)) {
+        return status;
+    }
+
+    m_ioEventQueue = std::move(ioEventQueue);
+
     return STATUS_SUCCESS;
 }
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.hxx
@@ -17,11 +17,19 @@ class UwbSimulatorDevice;
 /**
  * @brief Device driver open file abstraction.
  */
-class UwbSimulatorDeviceFile
+class UwbSimulatorDeviceFile :
+    public std::enable_shared_from_this<UwbSimulatorDeviceFile>
 {
-public:
+protected:
+    /**
+     * @brief Construct a new UwbSimulatorDeviceFile object.
+     *
+     * @param wdfFile The WDF file object this context is associated with.
+     * @param uwbSimulatorDevice The parent device of the open file handle.
+     */
     explicit UwbSimulatorDeviceFile(WDFFILEOBJECT wdfFile, std::weak_ptr<UwbSimulatorDevice> uwbSimulatorDevice);
 
+public:
     /**
      * @brief Initializes the file object for use.
      *

--- a/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.hxx
@@ -10,6 +10,7 @@
 #include <wdf.h>
 
 #include "IUwbSimulatorDdiHandler.hxx"
+#include "UwbSimulatorIoEventQueue.hxx"
 
 class UwbSimulatorDevice;
 
@@ -63,6 +64,9 @@ public:
     UwbSimulatorDevice *
     GetDevice() noexcept;
 
+    std::shared_ptr<UwbSimulatorIoEventQueue>
+    GetIoEventQueue();
+
 public:
     static EVT_WDF_OBJECT_CONTEXT_DESTROY OnWdfDestroy;
     static EVT_WDF_REQUEST_CANCEL OnWdfRequestCancel;
@@ -86,6 +90,9 @@ private:
     WDFFILEOBJECT m_wdfFile;
     UwbSimulatorDevice *m_uwbSimulatorDevice{ nullptr };
     std::vector<std::shared_ptr<windows::devices::uwb::simulator::IUwbSimulatorDdiHandler>> m_ddiHandlers{};
+    std::shared_ptr<UwbSimulatorIoEventQueue> m_ioEventQueue;
+
+    static constexpr std::size_t MaximumQueueSizeDefault = 16;
 };
 
 WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(UwbSimulatorDeviceFile, GetUwbSimulatorFile);

--- a/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.hxx
@@ -61,9 +61,19 @@ public:
     WDFFILEOBJECT
     GetWdfFile() const noexcept;
 
+    /**
+     * @brief Get a pointer to the owning device instance.
+     *
+     * @return UwbSimulatorDevice*
+     */
     UwbSimulatorDevice *
     GetDevice() noexcept;
 
+    /**
+     * @brief Get a reference to the i/o event queue for this open file handle.
+     *
+     * @return std::shared_ptr<UwbSimulatorIoEventQueue>
+     */
     std::shared_ptr<UwbSimulatorIoEventQueue>
     GetIoEventQueue();
 
@@ -73,15 +83,19 @@ public:
 
 private:
     /**
-     * @brief
+     * @brief Destroy member function which is called in response to the
+     * EvtDestroyCallback WDF event (OnWdfDestroy) for the corresponding file
+     * object.
      */
     void
     OnDestroy();
 
     /**
-     * @brief
+     * @brief Request cancelation member function which is called in response to
+     * the EvtRequestCancel WDF event (OnWdfRequestCancel) for the corresponding
+     * file object.
      *
-     * @param request
+     * @param request The request that is being canceled.
      */
     void
     OnRequestCancel(WDFREQUEST request);
@@ -95,6 +109,6 @@ private:
     static constexpr std::size_t MaximumQueueSizeDefault = 16;
 };
 
-WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(UwbSimulatorDeviceFile, GetUwbSimulatorFile);
+WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(UwbSimulatorDeviceFile, GetUwbSimulatorDeviceFile);
 
 #endif // UWB_SIMULATOR_DEVICE_FILE_OBJECT

--- a/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDeviceFile.hxx
@@ -20,7 +20,7 @@ class UwbSimulatorDevice;
 class UwbSimulatorDeviceFile
 {
 public:
-    explicit UwbSimulatorDeviceFile(WDFFILEOBJECT wdfFile, UwbSimulatorDevice *uwbSimulatorDevice);
+    explicit UwbSimulatorDeviceFile(WDFFILEOBJECT wdfFile, std::weak_ptr<UwbSimulatorDevice> uwbSimulatorDevice);
 
     /**
      * @brief Initializes the file object for use.
@@ -66,7 +66,7 @@ public:
      *
      * @return UwbSimulatorDevice*
      */
-    UwbSimulatorDevice *
+    std::weak_ptr<UwbSimulatorDevice>
     GetDevice() noexcept;
 
     /**
@@ -102,13 +102,18 @@ private:
 
 private:
     WDFFILEOBJECT m_wdfFile;
-    UwbSimulatorDevice *m_uwbSimulatorDevice{ nullptr };
+    std::weak_ptr<UwbSimulatorDevice> m_uwbSimulatorDevice;
     std::vector<std::shared_ptr<windows::devices::uwb::simulator::IUwbSimulatorDdiHandler>> m_ddiHandlers{};
     std::shared_ptr<UwbSimulatorIoEventQueue> m_ioEventQueue;
 
     static constexpr std::size_t MaximumQueueSizeDefault = 16;
 };
 
-WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(UwbSimulatorDeviceFile, GetUwbSimulatorDeviceFile);
+struct UwbSimulatorDeviceFileWdfContext
+{
+    std::shared_ptr<UwbSimulatorDeviceFile> File;
+};
+
+WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(UwbSimulatorDeviceFileWdfContext, GetUwbSimulatorDeviceFileWdfContext);
 
 #endif // UWB_SIMULATOR_DEVICE_FILE_OBJECT

--- a/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.cxx
@@ -141,7 +141,9 @@ UwbSimulatorIoEventQueue::ProcessNotificationQueue(std::stop_token stopToken)
         auto notificationDdiBuffer = std::data(notificationDdi);
         auto notificationDdiSize = std::size(notificationDdiBuffer);
 
-        // Attempt to copy the notification data to the output buffer.
+        // Attempt to copy the notification data to the output buffer. Note that
+        // WdfRequestRetrieveOutBuffer() will return STATUS_BUFFER_TOO_SMALL if
+        // the request buffer is not large enough to contain available data.
         void *outputBuffer = nullptr;
         std::size_t outputBufferSize = 0;
         status = WdfRequestRetrieveOutputBuffer(request, notificationDdiSize, &outputBuffer, &outputBufferSize);

--- a/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.cxx
@@ -119,6 +119,7 @@ UwbSimulatorIoEventQueue::ProcessNotificationQueue(std::stop_token stopToken)
         if (!isNotificationDataAvailable) {
             assert(stopToken.stop_requested());
             DbgPrint("%p exiting notification processing thread due to stop request\n", m_wdfQueue);
+            break;
         }
 
         // Obtain the pended request from the queue.

--- a/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.cxx
@@ -84,7 +84,7 @@ UwbSimulatorIoEventQueue::PushNotification(UwbNotificationData notificationData)
     // Push the notification data into the queue.
     {
         std::unique_lock notificationLockExclusive{ m_notificationGate };
-        DbgPrint("%p pushing notification data with payload %s", ToString(notificationData).c_str());
+        DbgPrint("%p pushing notification data with payload %s\n", m_wdfQueue, std::data(ToString(notificationData)));
         m_notificationQueue.push(std::move(notificationData));
     }
     
@@ -107,7 +107,7 @@ UwbSimulatorIoEventQueue::ProcessNotificationQueue(std::stop_token stopToken)
         // If predicate returned false, wait() unblocked due to stop request.
         if (!isNotificationRequestPending) {
             assert(stopToken.stop_requested());
-            DbgPrint("%p exiting notification processing thread due to stop request", m_wdfQueue);
+            DbgPrint("%p exiting notification processing thread due to stop request\n", m_wdfQueue);
             break;
         }
 
@@ -118,7 +118,7 @@ UwbSimulatorIoEventQueue::ProcessNotificationQueue(std::stop_token stopToken)
 
         if (!isNotificationDataAvailable) {
             assert(stopToken.stop_requested());
-            DbgPrint("%p exiting notification processing thread due to stop request", m_wdfQueue);
+            DbgPrint("%p exiting notification processing thread due to stop request\n", m_wdfQueue);
         }
 
         // Obtain the pended request from the queue.
@@ -146,7 +146,7 @@ UwbSimulatorIoEventQueue::ProcessNotificationQueue(std::stop_token stopToken)
         std::size_t outputBufferSize = 0;
         status = WdfRequestRetrieveOutputBuffer(request, notificationDdiSize, &outputBuffer, &outputBufferSize);
         if (NT_SUCCESS(status)) {
-            DbgPrint("%p updating request %p with %llu byte payload %s\n", m_wdfQueue, request, notificationDdiSize, ToString(notification).c_str());
+            DbgPrint("%p completing request %p with %llu byte payload %s\n", m_wdfQueue, request, notificationDdiSize, ToString(notification).c_str());
             std::memcpy(outputBuffer, std::data(notificationDdiBuffer), notificationDdiSize);
         }
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.cxx
@@ -69,7 +69,7 @@ UwbSimulatorIoEventQueue::EnqueueRequest(WDFREQUEST request)
     if (!NT_SUCCESS(status)) {
         DbgPrint("%p failed to pend request %p with status 0x%08x\n", m_wdfQueue, status);
         return status;
-    } 
+    }
 
     // Notify the processing thread that a new request is pending.
     m_notificationRequestPending.notify_one();
@@ -87,7 +87,7 @@ UwbSimulatorIoEventQueue::PushNotification(UwbNotificationData notificationData)
         DbgPrint("%p pushing notification data with payload %s\n", m_wdfQueue, std::data(ToString(notificationData)));
         m_notificationQueue.push(std::move(notificationData));
     }
-    
+
     // Signal the processing thread that notification data is available.
     m_notificationDataAvailable.notify_one();
 }

--- a/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.cxx
@@ -10,6 +10,7 @@
 
 #include <windows.h>
 
+#include "UwbSimulatorDeviceFile.hxx"
 #include "UwbSimulatorIoEventQueue.hxx"
 #include "UwbSimulatorTracelogging.hxx"
 #include <windows/devices/uwb/UwbCxAdapterDdiLrp.hxx>
@@ -29,6 +30,15 @@ UwbSimulatorIoEventQueue::Initialize()
     lockAttributes.ParentObject = m_wdfQueue;
 
     NTSTATUS status = WdfWaitLockCreate(&lockAttributes, &m_wdfQueueLock);
+    if (!NT_SUCCESS(status)) {
+        return status;
+    }
+
+    // Start the notification processing thread.
+    m_notificationThread = std::jthread([this](std::stop_token stopToken) {
+        ProcessNotificationQueue(std::move(stopToken));
+    });
+
     return status;
 }
 
@@ -39,83 +49,108 @@ UwbSimulatorIoEventQueue::Uninitialize()
 }
 
 NTSTATUS
-UwbSimulatorIoEventQueue::HandleNotificationRequest(WDFREQUEST request, std::optional<UwbNotificationData> &notificationDataOpt, std::size_t &outputBufferSize)
+UwbSimulatorIoEventQueue::EnqueueRequest(WDFREQUEST request)
 {
-    NTSTATUS status = WdfWaitLockAcquire(m_wdfQueueLock, nullptr);
+    WDFREQUEST requestExisting = nullptr;
+    auto wdfFile = WdfRequestGetFileObject(request);
+    std::unique_lock notificationLockExclusive{ m_notificationGate };
+
+    // Check if a request is already pending.
+    NTSTATUS status = WdfIoQueueFindRequest(m_wdfQueue, nullptr, wdfFile, nullptr, &requestExisting);
+    if (requestExisting != nullptr) {
+        DbgPrint("%p an existing request already pending", m_wdfQueue);
+        WdfObjectDereference(requestExisting);
+        return STATUS_INVALID_DEVICE_STATE;
+    }
+
+    // Forward the request to the queue and indicate the i/o is pending.
+    DbgPrint("%p pending request %p\n", m_wdfQueue, request);
+    status = WdfRequestForwardToIoQueue(request, m_wdfQueue);
     if (!NT_SUCCESS(status)) {
+        DbgPrint("%p failed to pend request %p with status 0x%08x\n", m_wdfQueue, status);
         return status;
-    }
+    } 
 
-    if (!m_notificationQueue.empty()) {
-        auto &notificationData = m_notificationQueue.front();
-        auto converted = UwbCxDdi::From(notificationData);
-        auto outputBufferSizeRequired = converted.size();
-        if (outputBufferSize < outputBufferSizeRequired) {
-            outputBufferSize = outputBufferSizeRequired;
-            status = STATUS_BUFFER_TOO_SMALL;
-        } else {
-            notificationDataOpt = std::move(notificationData);
-            m_notificationQueue.pop();
-            status = STATUS_SUCCESS;
-        }
-    } else {
-        status = WdfRequestForwardToIoQueue(request, m_wdfQueue);
-        if (!NT_SUCCESS(status)) {
-            // TODO: log
-        }
-        status = STATUS_PENDING;
-    }
+    // Notify the processing thread that a new request is pending.
+    m_notificationRequestPending.notify_one();
 
-    WdfWaitLockRelease(m_wdfQueueLock);
-
-    return status;
+    // Return pending status so dispatch code won't complete the request.
+    return STATUS_PENDING;
 }
 
-NTSTATUS
-UwbSimulatorIoEventQueue::PushNotificationData(UwbNotificationData notificationData)
+void
+UwbSimulatorIoEventQueue::PushNotification(UwbNotificationData notificationData)
 {
-    // Convert the neutral notification type to the DDI type. This needed, at
-    // minimum, to determine the required buffer size since it will eventually
-    // contain the DDI type.
-    auto notificationDataDdi = UwbCxDdi::From(notificationData);
-    auto notificationDataDdiBuffer = std::data(notificationDataDdi);
-    auto notificationDataDdiBufferSize = std::size(notificationDataDdi);
-
-    NTSTATUS status = WdfWaitLockAcquire(m_wdfQueueLock, nullptr);
-    if (!NT_SUCCESS(status)) {
-        return status;
+    // Push the notification data into the queue.
+    {
+        std::unique_lock notificationLockExclusive{ m_notificationGate };
+        DbgPrint("%p pushing notification data with payload %s", ToString(notificationData).c_str());
+        m_notificationQueue.push(std::move(notificationData));
     }
+    
+    // Signal the processing thread that notification data is available.
+    m_notificationDataAvailable.notify_one();
+}
 
-    // TODO: could we easily support > 1 pending requests by draining the queue
-    // here in a loop instead of taking the top queue entry only?
+void
+UwbSimulatorIoEventQueue::ProcessNotificationQueue(std::stop_token stopToken)
+{
+    for (;;) {
+        // Wait for a notification request to be pended.
+        std::unique_lock notificationLock{ m_notificationGate };
+        DbgPrint("%p waiting for notification queue items\n", m_wdfQueue);
+        const auto isNotificationRequestPending = m_notificationRequestPending.wait(notificationLock, stopToken, [&] {
+            auto ioRequestQueueState = WdfIoQueueGetState(m_wdfQueue, nullptr, nullptr);
+            return !WDF_IO_QUEUE_IDLE(ioRequestQueueState);
+        });
 
-    // Attempt to retrieve the most recent pended request.
-    WDFREQUEST request = nullptr;
-    status = WdfIoQueueRetrieveNextRequest(m_wdfQueue, &request);
+        // If predicate returned false, wait() unblocked due to stop request.
+        if (!isNotificationRequestPending) {
+            assert(stopToken.stop_requested());
+            DbgPrint("%p exiting notification processing thread due to stop request", m_wdfQueue);
+            break;
+        }
 
-    // A request was pended, complete it with this notification data.
-    if (NT_SUCCESS(status)) {
+        // Wait for notification data to become available.
+        const auto isNotificationDataAvailable = m_notificationDataAvailable.wait(notificationLock, stopToken, [&] {
+            return !m_notificationQueue.empty();
+        });
+
+        if (!isNotificationDataAvailable) {
+            assert(stopToken.stop_requested());
+            DbgPrint("%p exiting notification processing thread due to stop request", m_wdfQueue);
+        }
+
+        // Obtain the pended request from the queue.
+        WDFREQUEST request = nullptr;
+        NTSTATUS status = WdfIoQueueRetrieveNextRequest(m_wdfQueue, &request);
+        if (!NT_SUCCESS(status)) {
+            DbgPrint("%p unable to retrieve pending i/o request from queue, status=0x%08x\n", m_wdfQueue, status);
+            continue;
+        }
+
+        // Remove the notification data from the top of the queue.
+        UwbNotificationData notification = std::move(m_notificationQueue.front());
+        m_notificationQueue.pop();
+
+        // Release the lock now that we've removed the queue item.
+        notificationLock.unlock();
+
+        // Convert the neutral type notification data to the DDI type.
+        auto notificationDdi = UwbCxDdi::From(notification);
+        auto notificationDdiBuffer = std::data(notificationDdi);
+        auto notificationDdiSize = std::size(notificationDdiBuffer);
+
+        // Attempt to copy the notification data to the output buffer.
         void *outputBuffer = nullptr;
-        status = WdfRequestRetrieveOutputBuffer(request, notificationDataDdiBufferSize, &outputBuffer, nullptr);
+        std::size_t outputBufferSize = 0;
+        status = WdfRequestRetrieveOutputBuffer(request, notificationDdiSize, &outputBuffer, &outputBufferSize);
         if (NT_SUCCESS(status)) {
-            std::memcpy(outputBuffer, std::data(notificationDataDdiBuffer), notificationDataDdiBufferSize);
+            DbgPrint("%p updating request %p with %llu byte payload %s\n", m_wdfQueue, request, notificationDdiSize, ToString(notification).c_str());
+            std::memcpy(outputBuffer, std::data(notificationDdiBuffer), notificationDdiSize);
         }
 
         // Complete the request.
-        WdfRequestCompleteWithInformation(request, status, notificationDataDdiBufferSize);
-    } else {
-        // No request is pended, so queue this notification data for future requests.
-        // If the queue is full, drop requests until there is space for this entry.
-        while (std::size(m_notificationQueue) >= m_maximumQueueSize) {
-            m_notificationQueue.pop();
-        }
-
-        // Add this notification data to the queue.
-        m_notificationQueue.push(std::move(notificationData));
-        status = STATUS_SUCCESS;
-    }
-
-    WdfWaitLockRelease(m_wdfQueueLock);
-
-    return status;
+        WdfRequestCompleteWithInformation(request, status, notificationDdiSize);
+    } // for (;;)
 }

--- a/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.hxx
@@ -81,11 +81,13 @@ private:
     WDFWAITLOCK m_wdfQueueLock{ nullptr };
     std::queue<::uwb::protocol::fira::UwbNotificationData> m_notificationQueue;
 
-    // Stuff for processing notifications.
+    // Notification processing. Note the jthread must come last to ensure it is
+    // joined first upon destruction, which will signal stop and release any waits
+    // on the condition variables.
     std::mutex m_notificationGate;
-    std::jthread m_notificationThread;
     std::condition_variable_any m_notificationRequestPending;
     std::condition_variable_any m_notificationDataAvailable;
+    std::jthread m_notificationThread;
 
     const std::size_t m_maximumQueueSize{ MaximumQueueSizeDefault };
 };

--- a/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorIoEventQueue.hxx
@@ -74,7 +74,7 @@ public:
 
 private:
     void
-    ProcessNotificationQueue(std::stop_token stopToken);  
+    ProcessNotificationQueue(std::stop_token stopToken);
 
 private:
     WDFQUEUE m_wdfQueue;

--- a/windows/drivers/uwb/simulator/UwbSimulatorIoQueue.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorIoQueue.cxx
@@ -83,7 +83,7 @@ UwbSimulatorIoQueue::OnIoDeviceControl(WDFREQUEST request, size_t outputBufferLe
     NTSTATUS status = STATUS_INVALID_DEVICE_STATE;
 
     // Get the file object this request came in on, and dispatch the request to it.
-    UwbSimulatorDeviceFile *uwbSimulatorDeviceFile = GetUwbSimulatorFile(WdfRequestGetFileObject(request));
+    UwbSimulatorDeviceFile *uwbSimulatorDeviceFile = GetUwbSimulatorDeviceFile(WdfRequestGetFileObject(request));
     if (uwbSimulatorDeviceFile != nullptr) {
         status = uwbSimulatorDeviceFile->OnRequest(request, ioControlCode, inputBufferLength, outputBufferLength);
     } else {

--- a/windows/drivers/uwb/simulator/UwbSimulatorIoQueue.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorIoQueue.cxx
@@ -83,7 +83,7 @@ UwbSimulatorIoQueue::OnIoDeviceControl(WDFREQUEST request, size_t outputBufferLe
     NTSTATUS status = STATUS_INVALID_DEVICE_STATE;
 
     // Get the file object this request came in on, and dispatch the request to it.
-    UwbSimulatorDeviceFile *uwbSimulatorDeviceFile = GetUwbSimulatorDeviceFile(WdfRequestGetFileObject(request));
+    auto uwbSimulatorDeviceFile = GetUwbSimulatorDeviceFileWdfContext(WdfRequestGetFileObject(request))->File;
     if (uwbSimulatorDeviceFile != nullptr) {
         status = uwbSimulatorDeviceFile->OnRequest(request, ioControlCode, inputBufferLength, outputBufferLength);
     } else {


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Ensure object lifetimes are handled correctly in the simulator driver.

### Technical Details

* Introduce wrapper context structures for each real driver object context that needs to provide `std::weak_ptr` and/or `std::shared_ptr` instances.
* Enable `shared_from_this()` for `UwbSimulatorDevice` and `UwbSimulatorDeviceFile`.
* Change all member `UwbSimulatorDevice` raw pointers to use `std::weak_ptr<UwbSimulatorDevice>`.
* Avoid holding the notification lock while distributing notification data to each open-file context (as described in #194).

### Test Results

Standard ad-hoc tests for full ranging are working.

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
