### PR TITLE
Add remaining UCI app config parameters to nocli uwb range start

### DIFF
--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -533,7 +533,7 @@ enum class UwbApplicationConfigurationParameterType : uint8_t {
 // clang-format off
 using UwbApplicationConfigurationParameterValue = std::variant<
     bool, // HOPPING_MODE, tag 0x2C, size 1
-    uint8_t, // NUMBER_OF_CONTROLLEES, tag 0x05, PREAMBLE_CODE_INDEX, tag 0x14, SFD_ID, tag 0x15, SLOTS_PER_RR, tag 0x1B, RESPONDER_SLOT_INDEX, tag 0x1E, KEY_ROTATION_RATE, tag 0x24, SESSION_PRIORITY, tag 0x25, NUMBER_OF_STS_SEGMENTS, tag 0x29, BLOCK_STRIDE_LENGTH, tag 0x2D, IN_BAND_TERMMINATION_ATTEMPT_COUNT, tag 0x2F, size 1
+    uint8_t, // NUMBER_OF_CONTROLLEES, tag 0x05, PREAMBLE_CODE_INDEX, tag 0x14, SFD_ID, tag 0x15, SLOTS_PER_RR, tag 0x1B, RESPONDER_SLOT_INDEX, tag 0x1E, KEY_ROTATION_RATE, tag 0x24, SESSION_PRIORITY, tag 0x25, NUMBER_OF_STS_SEGMENTS, tag 0x29, BLOCK_STRIDE_LENGTH, tag 0x2D, IN_BAND_TERMINATION_ATTEMPT_COUNT, tag 0x2F, size 1
     uint16_t, // SLOT_DURATION, tag 0x08, RANGE_DATA_NTF_PROXIMITY_NEAR, tag 0x0F, RANGE_DATA_NTF_PROXIMITY_FAR, tag 0x10, VENDOR_ID, tag 0x27, MAX_RR_RETRY, tag 0x2A, MAX_NUMBER_OF_MEASUREMENTS, tag 0x32, size 2
     uint32_t, // RANGING_INTERVAL, tag 0x09, STS_INDEX, tag 0x0A, UWB_INITIATION_TIME, tag 0x2B, SUB_SESSION_ID, tag 0x30, size 4
     AoAResult, // AOA_RESULT_REQ, tag 0x0D, size 1
@@ -550,7 +550,7 @@ using UwbApplicationConfigurationParameterValue = std::variant<
     RangingRoundUsage, // RANGING_ROUND_USAGE, tag0x01, size 1
     RangingMode, // RANGING_TIME_STRUCT, tag 0x1A, size 1
     RangingRoundControl, // RANGING_ROUND_CONTROL, tag 0x0C, size 1,
-    std::unordered_set<ResultReportConfiguration>, // RESULT_REPORT_CONFIG, tag 0x2E, size 1 // TODO this should really be a set
+    std::unordered_set<ResultReportConfiguration>, // RESULT_REPORT_CONFIG, tag 0x2E, size 1
     SchedulingMode, // SCHEDULED_MODE, tag 0x22, size 1
     StsConfiguration, // STS_CONFIG, tag 0x02, size 1
     StsLength, // STS_LENGTH, tag 0x035, length 1,

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -460,8 +460,57 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App* parent)
     }
     rangeStartApp->add_option("--DeviceMacAddress", m_cliData->deviceMacAddressString, deviceMacAddressDescription)->capture_default_str()->required();
     rangeStartApp->add_option("--DestinationMacAddress", m_cliData->destinationMacAddressString, dstMacAddressDescription)->capture_default_str()->required();
-
     detail::AddEnumOption(rangeStartApp, appConfigParamsData.deviceType, true);
+
+    // List remaining params
+    // uint8_t
+    rangeStartApp->add_option("--BlockStrideLength", appConfigParamsData.blockStrideLength, "0 = No block striding; 1-255 = Number of ranging blocks to be skipped")->capture_default_str();
+    rangeStartApp->add_option("--InBandTerminationAttemptCount", appConfigParamsData.inBandTerminationAttemptCount, "0 = Disable in-band termination attempt; 1-10 = In-band termination attempt count")->capture_default_str();
+    rangeStartApp->add_option("--KeyRotationRate", appConfigParamsData.keyRotationRate, "Exponent n where 2^n is the key rotation rate. Value range: 0-15")->capture_default_str();
+    rangeStartApp->add_option("--NumberOfStsSegments", appConfigParamsData.numberOfStsSegments, "Value range: 0-4. Note: 2-4 for HPRF Mode only")->capture_default_str();
+    rangeStartApp->add_option("--PreambleCodeIndex", appConfigParamsData.preambleCodeIndex, "Value range: 9-12 for BPRF Mode; 25-32 for HPRF Mode")->capture_default_str();
+    rangeStartApp->add_option("--ResponderSlotIndex", appConfigParamsData.responderSlotIndex, "Responder index in TWR. 1=Responder 1 ... N=Responder N. Not applicable to Initiator")->capture_default_str();
+    rangeStartApp->add_option("--SessionPriority", appConfigParamsData.sessionPriority, "Value range: 1-100")->capture_default_str();
+    rangeStartApp->add_option("--SfdId", appConfigParamsData.sfdId, "{0,2} for BPRF Mode; {1,2,3,4} for HPRF Mode")->capture_default_str();
+    rangeStartApp->add_option("--SlotsPerRangingRound", appConfigParamsData.slotsPerRangingRound, "Number of slots per ranging round")->capture_default_str();
+    
+    // uint16_t
+    rangeStartApp->add_option("--MaxNumberOfMeasurements", appConfigParamsData.maxNumberOfMeasurements, "0 = Unlimited; 1+ = Max number of ranging measurements in a session")->capture_default_str();
+    rangeStartApp->add_option("--MaxRangingRoundRetry", appConfigParamsData.maxRangingRoundRetry, "Number of failed RR attempts before stopping the session. Value range: 0-65535")->capture_default_str();
+    rangeStartApp->add_option("--RangeDataNotificationProximityFar", appConfigParamsData.rangeDataNotificationProximityFar, "Upper bound in cm for ranging proximity mode. N >= RangeDataNotificationProximityNear")->capture_default_str();
+    rangeStartApp->add_option("--RangeDataNotificationProximityNear", appConfigParamsData.rangeDataNotificationProximityNear, "Lower bound in cm for ranging proximity mode. N <= RangeDataNotificationProximityFar")->capture_default_str();
+    rangeStartApp->add_option("--SlotDuration", appConfigParamsData.slotDuration, "Duration of a ranging slot in the unit of RSTU")->capture_default_str();
+    rangeStartApp->add_option("--VendorId", appConfigParamsData.vendorId, "Unique ID for vendor. Used for static STS")->capture_default_str();
+
+    // uint32_t
+    rangeStartApp->add_option("--RangingInterval", appConfigParamsData.rangingInterval, "Ranging interval in the unit of 1200 RSTU (1ms) between ranging rounds. Minimum should be duration of one ranging round")->capture_default_str();
+    rangeStartApp->add_option("--StsIndex", appConfigParamsData.stsIndex, "Test Mode only. See FiRa Consortium PHY Conformance Test Specification")->capture_default_str();
+    rangeStartApp->add_option("--SubSessionId", appConfigParamsData.subSessionId, "Sub-session ID for the controlee device. Required for Dynamic STS with responder specific sub-session key")->capture_default_str();
+    rangeStartApp->add_option("--UwbInitiationTime", appConfigParamsData.uwbInitiationTime, "Value range: 0-10000")->capture_default_str();
+
+    // bool - TODO: Try add_flag instead
+    rangeStartApp->add_option("--HoppingMode", appConfigParamsData.hoppingMode, "true = FiRa hopping enabled; false = hopping disabled")->capture_default_str();
+
+    // enums
+    detail::AddEnumOption(rangeStartApp, appConfigParamsData.aoaResultRequest);
+    detail::AddEnumOption(rangeStartApp, appConfigParamsData.bprfPhrDataRate);
+    detail::AddEnumOption(rangeStartApp, appConfigParamsData.channelNumber);
+    detail::AddEnumOption(rangeStartApp, appConfigParamsData.keyRotation);
+    detail::AddEnumOption(rangeStartApp, appConfigParamsData.macAddressMode);
+    detail::AddEnumOption(rangeStartApp, appConfigParamsData.macFcsType);
+    detail::AddEnumOption(rangeStartApp, appConfigParamsData.preambleDuration);
+    detail::AddEnumOption(rangeStartApp, appConfigParamsData.prfMode);
+    detail::AddEnumOption(rangeStartApp, appConfigParamsData.rangeDataNotificationConfig);
+    detail::AddEnumOption(rangeStartApp, appConfigParamsData.rangingRoundControl);
+    detail::AddEnumOption(rangeStartApp, appConfigParamsData.rFrameConfiguration);
+    detail::AddEnumOption(rangeStartApp, appConfigParamsData.scheduledMode);
+    detail::AddEnumOption(rangeStartApp, appConfigParamsData.stsConfiguration);
+    detail::AddEnumOption(rangeStartApp, appConfigParamsData.stsLength);
+    detail::AddEnumOption(rangeStartApp, appConfigParamsData.txAdaptivePayloadPower);
+
+    // other
+    rangeStartApp->add_option("--ResultReportConfig", m_cliData->resultReportConfigurationString, "4-bit report config, e.g. 0101. b3=AOA FOM, b2=AOA Elevation, b1=AOA Azimuth, b0=TOF")->capture_default_str(); // TODO: Parse values into unordered_set
+    rangeStartApp->add_option("--StaticStsInitializationVector", appConfigParamsData.staticStsIv, "6-octet array for vendor-defined static STS configuration, e.g. 11:22:33:44:55:66")->delimiter(':'); // TODO: Test to make sure this works properly
 
     rangeStartApp->parse_complete_callback([this, rangeStartApp] {
         // TODO: Move validation logic into its own function

--- a/tools/cli/NearObjectCliData.cxx
+++ b/tools/cli/NearObjectCliData.cxx
@@ -4,6 +4,7 @@
 
 using namespace nearobject::cli;
 using uwb::protocol::fira::UwbApplicationConfigurationParameterType;
+using uwb::protocol::fira::UwbApplicationConfigurationParameterValue;
 using uwb::protocol::fira::UwbConfiguration;
 
 UwbConfigurationData::operator UwbConfiguration() const noexcept
@@ -116,10 +117,10 @@ UwbConfigurationData::operator UwbConfiguration() const noexcept
     return builder;
 }
 
-std::unordered_map<UwbApplicationConfigurationParameterType, UwbApplicationConfigurationParameterData::ParameterTypesVariant>
+std::unordered_map<UwbApplicationConfigurationParameterType, UwbApplicationConfigurationParameterValue>
 UwbApplicationConfigurationParameterData::GetValueMap() const
 {
-    std::unordered_map<UwbApplicationConfigurationParameterType, ParameterTypesVariant> valuesMap;
+    std::unordered_map<UwbApplicationConfigurationParameterType, UwbApplicationConfigurationParameterValue> valuesMap;
     if (deviceRole.has_value()) {
         valuesMap[UwbApplicationConfigurationParameterType::DeviceRole] = deviceRole.value();
     }

--- a/tools/cli/NearObjectCliData.cxx
+++ b/tools/cli/NearObjectCliData.cxx
@@ -121,23 +121,60 @@ std::unordered_map<UwbApplicationConfigurationParameterType, UwbApplicationConfi
 UwbApplicationConfigurationParameterData::GetValueMap() const
 {
     std::unordered_map<UwbApplicationConfigurationParameterType, UwbApplicationConfigurationParameterValue> valuesMap;
-    if (deviceRole.has_value()) {
-        valuesMap[UwbApplicationConfigurationParameterType::DeviceRole] = deviceRole.value();
+
+    std::initializer_list<std::pair<UwbApplicationConfigurationParameterType, std::optional<UwbApplicationConfigurationParameterValue>>> applicationConfigurationParameterList = {
+        { UwbApplicationConfigurationParameterType::DeviceRole, deviceRole },
+        { UwbApplicationConfigurationParameterType::MultiNodeMode, multiNodeMode },
+        { UwbApplicationConfigurationParameterType::NumberOfControlees, numberOfControlees },
+        { UwbApplicationConfigurationParameterType::DeviceMacAddress, deviceMacAddress },
+        { UwbApplicationConfigurationParameterType::DestinationMacAddresses, destinationMacAddresses },
+        { UwbApplicationConfigurationParameterType::DeviceType, deviceType },
+        { UwbApplicationConfigurationParameterType::RangingRoundUsage, rangingRoundUsage },
+        { UwbApplicationConfigurationParameterType::StsConfiguration, stsConfiguration },
+        { UwbApplicationConfigurationParameterType::ChannelNumber, channelNumber },
+        { UwbApplicationConfigurationParameterType::SlotDuration, slotDuration },
+        { UwbApplicationConfigurationParameterType::RangingInterval, rangingInterval },
+        { UwbApplicationConfigurationParameterType::StsIndex, stsIndex },
+        { UwbApplicationConfigurationParameterType::MacFcsType, macFcsType },
+        { UwbApplicationConfigurationParameterType::RangingRoundControl, rangingRoundControl },
+        { UwbApplicationConfigurationParameterType::AoAResultRequest, aoaResultRequest },
+        { UwbApplicationConfigurationParameterType::RangeDataNotificationConfig, rangeDataNotificationConfig },
+        { UwbApplicationConfigurationParameterType::RangeDataNotificationProximityNear, rangeDataNotificationProximityNear },
+        { UwbApplicationConfigurationParameterType::RangeDataNotificationProximityFar, rangeDataNotificationProximityFar },
+        { UwbApplicationConfigurationParameterType::RFrameConfiguration, rFrameConfiguration },
+        { UwbApplicationConfigurationParameterType::PreambleCodeIndex, preambleCodeIndex },
+        { UwbApplicationConfigurationParameterType::SfdId, sfdId },
+        { UwbApplicationConfigurationParameterType::PsduDataRate, psduDataRate },
+        { UwbApplicationConfigurationParameterType::PreambleDuration, preambleDuration },
+        { UwbApplicationConfigurationParameterType::RangingTimeStruct, rangingTimeStruct },
+        { UwbApplicationConfigurationParameterType::SlotsPerRangingRound, slotsPerRangingRound },
+        { UwbApplicationConfigurationParameterType::TxAdaptivePayloadPower, txAdaptivePayloadPower },
+        { UwbApplicationConfigurationParameterType::ResponderSlotIndex, responderSlotIndex },
+        { UwbApplicationConfigurationParameterType::PrfMode, prfMode },
+        { UwbApplicationConfigurationParameterType::ScheduledMode, scheduledMode },
+        { UwbApplicationConfigurationParameterType::KeyRotation, keyRotation },
+        { UwbApplicationConfigurationParameterType::KeyRotationRate, keyRotationRate },
+        { UwbApplicationConfigurationParameterType::SessionPriority, sessionPriority },
+        { UwbApplicationConfigurationParameterType::MacAddressMode, macAddressMode },
+        { UwbApplicationConfigurationParameterType::VendorId, vendorId },
+        { UwbApplicationConfigurationParameterType::StaticStsIv, staticStsIv },
+        { UwbApplicationConfigurationParameterType::NumberOfStsSegments, numberOfStsSegments },
+        { UwbApplicationConfigurationParameterType::MaxRangingRoundRetry, maxRangingRoundRetry },
+        { UwbApplicationConfigurationParameterType::UwbInitiationTime, uwbInitiationTime },
+        { UwbApplicationConfigurationParameterType::HoppingMode, hoppingMode },
+        { UwbApplicationConfigurationParameterType::BlockStrideLength, blockStrideLength },
+        { UwbApplicationConfigurationParameterType::ResultReportConfig, resultReportConfig },
+        { UwbApplicationConfigurationParameterType::InBandTerminationAttemptCount, inBandTerminationAttemptCount },
+        { UwbApplicationConfigurationParameterType::SubSessionId, subSessionId },
+        { UwbApplicationConfigurationParameterType::BprfPhrDataRate, bprfPhrDataRate },
+        { UwbApplicationConfigurationParameterType::MaxNumberOfMeasurements, maxNumberOfMeasurements },
+        { UwbApplicationConfigurationParameterType::StsLength, stsLength }
+    };
+    for (const auto& [parameterType, parameterValue] : applicationConfigurationParameterList) {
+        if (parameterValue.has_value()) {
+            valuesMap[parameterType] = parameterValue.value();
+        }
     }
-    if (multiNodeMode.has_value()) {
-        valuesMap[UwbApplicationConfigurationParameterType::MultiNodeMode] = multiNodeMode.value();
-    }
-    if (numberOfControlees.has_value()) {
-        valuesMap[UwbApplicationConfigurationParameterType::NumberOfControlees] = numberOfControlees.value();
-    }
-    if (deviceMacAddress.has_value()) {
-        valuesMap[UwbApplicationConfigurationParameterType::DeviceMacAddress] = deviceMacAddress.value();
-    }
-    if (destinationMacAddresses.has_value()) {
-        valuesMap[UwbApplicationConfigurationParameterType::DestinationMacAddresses] = destinationMacAddresses.value();
-    }
-    if (deviceType.has_value()) {
-        valuesMap[UwbApplicationConfigurationParameterType::DeviceType] = deviceType.value();
-    }
+
     return valuesMap;
 }

--- a/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
@@ -150,6 +150,7 @@ struct NearObjectCliData
     bool HostIsController{ false };
     std::string deviceMacAddressString;
     std::string destinationMacAddressString; // TODO: List of strings (or large string of mac address substrings) to support multiple controlees
+    std::string resultReportConfigurationString;
     UwbConfigurationData uwbConfiguration{};
     UwbApplicationConfigurationParameterData appConfigParamsData{};
     uwb::protocol::fira::StaticRangingInfo StaticRanging{};

--- a/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
@@ -95,21 +95,9 @@ struct UwbApplicationConfigurationParameterData
     std::optional<uwb::UwbMacAddressType> macAddressMode;
 
     /**
-     * @brief Variant for all possible property types.
-     */
-    using ParameterTypesVariant = std::variant<
-        uint8_t,
-        ::uwb::protocol::fira::DeviceRole,
-        ::uwb::protocol::fira::DeviceType,
-        ::uwb::protocol::fira::MultiNodeMode,
-        ::uwb::UwbMacAddress,
-        ::uwb::UwbMacAddressType,
-        std::unordered_set<::uwb::UwbMacAddress>>;
-
-    /**
      * @brief Map of application configuration parameter type to the parameter's value.
      */
-    std::unordered_map<uwb::protocol::fira::UwbApplicationConfigurationParameterType, ParameterTypesVariant>
+    std::unordered_map<uwb::protocol::fira::UwbApplicationConfigurationParameterType, uwb::protocol::fira::UwbApplicationConfigurationParameterValue>
     GetValueMap() const;
 };
 

--- a/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
@@ -86,13 +86,52 @@ struct UwbApplicationConfigurationParameterData
     // Mirrored properties from UwbApplicationConfigurationParameter data. Any newly added fields
     // that should be supported from the command-line must also be added here,
     // along with parsing support in a NearObjectCli instance.
-    std::optional<uwb::protocol::fira::DeviceRole> deviceRole;
+    std::optional<uwb::protocol::fira::DeviceType> deviceType;
+    std::optional<uwb::protocol::fira::RangingRoundUsage> rangingRoundUsage;
+    std::optional<uwb::protocol::fira::StsConfiguration> stsConfiguration;
     std::optional<uwb::protocol::fira::MultiNodeMode> multiNodeMode;
+    std::optional<uwb::protocol::fira::Channel> channelNumber;
     std::optional<uint8_t> numberOfControlees;
     std::optional<uwb::UwbMacAddress> deviceMacAddress;
     std::optional<std::unordered_set<uwb::UwbMacAddress>> destinationMacAddresses;
-    std::optional<uwb::protocol::fira::DeviceType> deviceType;
+    std::optional<uint16_t> slotDuration;
+    std::optional<uint32_t> rangingInterval;
+    std::optional<uint32_t> stsIndex;
+    std::optional<uwb::UwbMacAddressFcsType> macFcsType;
+    std::optional<uwb::protocol::fira::RangingRoundControl> rangingRoundControl;
+    std::optional<uwb::protocol::fira::AoAResult> aoaResultRequest;
+    std::optional<uwb::protocol::fira::RangeDataNotificationConfiguration> rangeDataNotificationConfig;
+    std::optional<uint16_t> rangeDataNotificationProximityNear;
+    std::optional<uint16_t> rangeDataNotificationProximityFar;
+    std::optional<uwb::protocol::fira::DeviceRole> deviceRole;
+    std::optional<uwb::protocol::fira::StsPacketConfiguration> rFrameConfiguration;
+    std::optional<uint8_t> preambleCodeIndex;
+    std::optional<uint8_t> sfdId;
+    std::optional<uwb::protocol::fira::PsduDataRate> psduDataRate;
+    std::optional<uwb::protocol::fira::PreambleDuration> preambleDuration;
+    std::optional<uwb::protocol::fira::RangingMode> rangingTimeStruct;
+    std::optional<uint8_t> slotsPerRangingRound;
+    std::optional<uwb::protocol::fira::TxAdaptivePayloadPower> txAdaptivePayloadPower;
+    std::optional<uint8_t> responderSlotIndex;
+    std::optional<uwb::protocol::fira::PrfMode> prfMode;
+    std::optional<uwb::protocol::fira::SchedulingMode> scheduledMode;
+    std::optional<uwb::protocol::fira::KeyRotation> keyRotation;
+    std::optional<uint8_t> keyRotationRate;
+    std::optional<uint8_t> sessionPriority;
     std::optional<uwb::UwbMacAddressType> macAddressMode;
+    std::optional<uint16_t> vendorId;
+    std::optional<std::array<uint8_t, uwb::protocol::fira::StaticStsInitializationVectorLength>> staticStsIv;
+    std::optional<uint8_t> numberOfStsSegments;
+    std::optional<uint16_t> maxRangingRoundRetry;
+    std::optional<uint32_t> uwbInitiationTime;
+    std::optional<bool> hoppingMode;
+    std::optional<uint8_t> blockStrideLength;
+    std::optional<std::unordered_set<uwb::protocol::fira::ResultReportConfiguration>> resultReportConfig;
+    std::optional<uint8_t> inBandTerminationAttemptCount;
+    std::optional<uint32_t> subSessionId;
+    std::optional<uwb::protocol::fira::BprfPhrDataRate> bprfPhrDataRate;
+    std::optional<uint16_t> maxNumberOfMeasurements;
+    std::optional<uwb::protocol::fira::StsLength> stsLength;
 
     /**
      * @brief Map of application configuration parameter type to the parameter's value.


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [x] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

This PR adds the remaining UCI app config params to nocli. This includes CLI options, some additional validation (not all), and additional code to print out parameters.

### Technical Details

- Add new CLI options
- Add to and improve parameter display code in ProcessApplicationConfigurationParameters
- Add validation for ResultReportConfig
- Improve GetValueMap()
- Remove redundant ParameterTypesVariant
- Update some comments in FiraDevice.hxx

### Test Results

nocli output looks correct

### Reviewer Focus

Apologies for the long PR, but there are so many UCI app config parameters!

Also, in this line: `oss << "0x" << std::setw(2) << std::internal << std::setfill('0') << std::hex << +value << " ";`, I had to add `"0x"` instead of `std::showbase` because it interferes with `std::setw(2)` and `std::setfill('0')`, since the added base is considered part of the width, thus truncating the added 0.

### Future Work

Additional validation for the newly added parameters.

I also really don't like how CLI11 adds "UINT" or "ENUM" when displaying the options. Perhaps this can be changed.

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
