### PR TITLE
Minor improvements to nocli

### DIFF
--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -546,7 +546,7 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App* parent)
         }
 
         // Parse and validate ResultReportConfig
-        constexpr int resultReportConfigurationSize = 4; // TODO: Find a way to calculate this number
+        constexpr int resultReportConfigurationSize = magic_enum::enum_count<ResultReportConfiguration>();
         auto IsValidResultReportConfigurationString = [resultReportConfigurationSize](const std::string& resultReportConfigurationString) {
             if (resultReportConfigurationString.length() != resultReportConfigurationSize) {
                 std::cerr << "Invalid ResultReportConfiguration length" << std::endl;
@@ -564,17 +564,17 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App* parent)
         if (IsValidResultReportConfigurationString(m_cliData->resultReportConfigurationString)) {
             m_cliData->appConfigParamsData.resultReportConfig.emplace();
 
-            const std::bitset<4> resultReportConfigurationBits(m_cliData->resultReportConfigurationString);
-            if (resultReportConfigurationBits[0]) {
+            const std::bitset<resultReportConfigurationSize> resultReportConfigurationBits(m_cliData->resultReportConfigurationString);
+            if (resultReportConfigurationBits.test(0)) {
                 m_cliData->appConfigParamsData.resultReportConfig.value().insert(ResultReportConfiguration::TofReport);
             }
-            if (resultReportConfigurationBits[1]) {
+            if (resultReportConfigurationBits.test(1)) {
                 m_cliData->appConfigParamsData.resultReportConfig.value().insert(ResultReportConfiguration::AoAAzimuthReport);
             }
-            if (resultReportConfigurationBits[2]) {
+            if (resultReportConfigurationBits.test(2)) {
                 m_cliData->appConfigParamsData.resultReportConfig.value().insert(ResultReportConfiguration::AoAElevationReport);
             }
-            if (resultReportConfigurationBits[3]) {
+            if (resultReportConfigurationBits.test(3)) {
                 m_cliData->appConfigParamsData.resultReportConfig.value().insert(ResultReportConfiguration::AoAFoMReport);
             }
         }

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -565,17 +565,11 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App* parent)
             m_cliData->appConfigParamsData.resultReportConfig.emplace();
 
             const std::bitset<resultReportConfigurationSize> resultReportConfigurationBits(m_cliData->resultReportConfigurationString);
-            if (resultReportConfigurationBits.test(0)) {
-                m_cliData->appConfigParamsData.resultReportConfig.value().insert(ResultReportConfiguration::TofReport);
-            }
-            if (resultReportConfigurationBits.test(1)) {
-                m_cliData->appConfigParamsData.resultReportConfig.value().insert(ResultReportConfiguration::AoAAzimuthReport);
-            }
-            if (resultReportConfigurationBits.test(2)) {
-                m_cliData->appConfigParamsData.resultReportConfig.value().insert(ResultReportConfiguration::AoAElevationReport);
-            }
-            if (resultReportConfigurationBits.test(3)) {
-                m_cliData->appConfigParamsData.resultReportConfig.value().insert(ResultReportConfiguration::AoAFoMReport);
+
+            for (auto i = 0; i < resultReportConfigurationSize; i++) {
+                if (resultReportConfigurationBits.test(i)) {
+                    m_cliData->appConfigParamsData.resultReportConfig.value().insert(magic_enum::enum_value<ResultReportConfiguration>(i));
+                }
             }
         }
 

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -565,7 +565,6 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App* parent)
             m_cliData->appConfigParamsData.resultReportConfig.emplace();
 
             const std::bitset<resultReportConfigurationSize> resultReportConfigurationBits(m_cliData->resultReportConfigurationString);
-
             for (auto i = 0; i < resultReportConfigurationSize; i++) {
                 if (resultReportConfigurationBits.test(i)) {
                     m_cliData->appConfigParamsData.resultReportConfig.value().insert(magic_enum::enum_value<ResultReportConfiguration>(i));


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [x] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

This PR makes a few minor improvements to the nocli tool based on review feedback from my last PR that I didn't get to before the last release.

### Technical Details

- Use magic_enum to calculate number of fields of the ResultReportConfiguration enum.
- Use .test() method of std::bitset instead of subscript operator.

### Test Results

Verified nocli output is the same as before.

### Reviewer Focus

None.

### Future Work

None.

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
