### PR TITLE
Add input validation to remaining UCI app configuration parameters

### DIFF
--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -97,12 +97,14 @@ enum class StsConfiguration : uint8_t {
  * @brief See FiRa Consortium UWB MAC Technical Requirements v1.3.0, Section
  * 5.3.
  */
-enum class StsPacketConfiguration : uint8_t {
+enum class RFrameConfiguration : uint8_t {
     SP0 = 0,
     SP1 = 1,
     SP2 = 2,
     SP3 = 3,
 };
+
+using StsPacketConfiguration = RFrameConfiguration;
 
 /**
  * @brief See FiRa Consortium UWB MAC Technical Requirements v1.3.0, Section
@@ -190,13 +192,11 @@ enum class Channel {
 
 /**
  * @brief See FiRa Consortium UWB MAC Technical Requirements v1.3.0, Section
- * 7.5.3.3, Table 53; and FiRa Consortium UWB Command Interface Generic Technical
- * Specification v1.1.0, Section 8.3, Table 29
+ * 7.5.3.3, Table 53.
  */
 enum class PrfMode {
     Bprf = 0,
     Hprf = 1,
-    HprfSpecialDataRate = 2,
 };
 
 /**
@@ -547,7 +547,7 @@ using UwbApplicationConfigurationParameterValue = std::variant<
     KeyRotation, // KEY_ROTATION, tag 0x23, size 1
     MultiNodeMode, // MULTI_NODE_MODE, tag 0x03, size 1
     PreambleDuration, // PREAMBLE_DURATION, tag 0x17, size 1
-    PrfMode, // PRF_MODE, tag 0x1F, size 1
+    PrfModeDetailed, // PRF_MODE, tag 0x1F, size 1
     PsduDataRate, // PSDU_DATA_RATE, tag 0x16, size 1
     RangeDataNotificationConfiguration, // RANGE_DATA_NTF_CONFIG, tag 0x0E, size 1
     RangingRoundUsage, // RANGING_ROUND_USAGE, tag0x01, size 1
@@ -557,7 +557,7 @@ using UwbApplicationConfigurationParameterValue = std::variant<
     SchedulingMode, // SCHEDULED_MODE, tag 0x22, size 1
     StsConfiguration, // STS_CONFIG, tag 0x02, size 1
     StsLength, // STS_LENGTH, tag 0x035, length 1,
-    StsPacketConfiguration, // RFRAME_CONFIG, tag 0x12, size 1
+    RFrameConfiguration, // RFRAME_CONFIG, tag 0x12, size 1
     TxAdaptivePayloadPower, // TX_ADAPTIVE_PAYLOAD_POWER, tag 0x1C, size 1
     ::uwb::UwbMacAddress, // DEVICE_MAC_ADDRESS, tag 0x06, size 2/8
     ::uwb::UwbMacAddressFcsType, // MAC_FCS_TYPE, tag 0x0B, size 1

--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -435,6 +435,7 @@ enum class AoAResult : uint8_t {
 enum class RangeDataNotificationConfiguration : uint8_t {
     Disable = 0U,
     Enable = 1U,
+    EnableInProximityRange = 2U,
 };
 
 enum class PreambleDuration : uint8_t {

--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -190,11 +190,13 @@ enum class Channel {
 
 /**
  * @brief See FiRa Consortium UWB MAC Technical Requirements v1.3.0, Section
- * 7.5.3.3, Table 53.
+ * 7.5.3.3, Table 53; and FiRa Consortium UWB Command Interface Generic Technical
+ * Specification v1.1.0, Section 8.3, Table 29
  */
 enum class PrfMode {
     Bprf = 0,
     Hprf = 1,
+    HprfSpecialDataRate = 2,
 };
 
 /**

--- a/lib/uwb/protocols/fira/UwbOobConversions.cxx
+++ b/lib/uwb/protocols/fira/UwbOobConversions.cxx
@@ -44,9 +44,6 @@ const std::unordered_map<UwbApplicationConfigurationParameterType, std::function
     { UwbApplicationConfigurationParameterType::SlotsPerRangingRound, [](const UwbConfiguration& config, DeviceType deviceType) -> std::optional<UwbApplicationConfigurationParameterValue> {
          return config.GetSlotsPerRangingRound();
      } },
-    { UwbApplicationConfigurationParameterType::PrfMode, [](const UwbConfiguration& config, DeviceType deviceType) -> std::optional<UwbApplicationConfigurationParameterValue> {
-         return config.GetPrfMode();
-     } },
     { UwbApplicationConfigurationParameterType::ScheduledMode, [](const UwbConfiguration& config, DeviceType deviceType) -> std::optional<UwbApplicationConfigurationParameterValue> {
          return config.GetSchedulingMode();
      } },
@@ -118,6 +115,14 @@ const std::unordered_map<UwbApplicationConfigurationParameterType, std::function
              }
          } else {
              return config.GetControllerMacAddress();
+         }
+     } },
+    { UwbApplicationConfigurationParameterType::PrfMode, [](const UwbConfiguration& config, DeviceType deviceType) -> std::optional<UwbApplicationConfigurationParameterValue> {
+         auto prfMode = config.GetPrfMode();
+         if (prfMode == PrfMode::Bprf) {
+             return PrfModeDetailed::Bprf62MHz;
+         } else {                                // HPRF
+             return PrfModeDetailed::Hprf124MHz; // TODO: Is there a way to determine OOB which Hprf frequency is used?
          }
      } },
     // TODO figure out the rest of the uci params

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -211,7 +211,12 @@ CLI::Option*
 AddEnumOption(CLI::App* app, std::optional<EnumType>& assignTo, bool isMandatory = false)
 // clang-format on
 {
-    std::string optionName{ std::string("--").append(magic_enum::enum_type_name<EnumType>()) };
+    std::string optionName{ std::string("--") };
+    if (magic_enum::enum_type_name<EnumType>() == "StsPacketConfiguration") {
+        optionName.append("RFrameConfiguration");
+    } else {
+        optionName.append(magic_enum::enum_type_name<EnumType>());
+    }
 
     const auto map = CreateEnumerationStringMap<EnumType>();
     std::ostringstream enumUsage;

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -233,43 +233,18 @@ AddEnumOption(CLI::App* app, std::optional<EnumType>& assignTo, bool isMandatory
 }
 
 /**
- * @brief Validates input for nocli uwb range start.
+ * @brief Validates non-enum application configuration parameter inputs from nocli.
  *
  * @param cliData The nocli input data containing the application configuration parameters
  */
 void
-ValidateUwbRangeStartInput(std::shared_ptr<NearObjectCliData> cliData)
+ValidateNonEnumParameterValues(std::shared_ptr<NearObjectCliData> cliData)
 {
     // Note: No restrictions other than type bounds checking given in FiRa UCI Generic Technical Specification v1.1.0 for the following parameters:
     // SlotDuration, SlotsPerRangingRound, VendorId, MaxRangingRoundRetry, BlockStrideLength, MaxNumberOfMeasurements, RangingInterval, StsIndex,
     // HoppingMode, StaticStsIv
 
     auto& parametersData = cliData->applicationConfigurationParametersData;
-
-    // DeviceType (mandatory)
-    if (!magic_enum::enum_contains<DeviceType>(parametersData.deviceType.value())) {
-        std::cerr << "Invalid DeviceType" << std::endl;
-    }
-
-    // RangingRoundUsage
-    if (parametersData.rangingRoundUsage.has_value() && !magic_enum::enum_contains<RangingRoundUsage>(parametersData.rangingRoundUsage.value())) {
-        std::cerr << "Invalid RangingRoundUsage" << std::endl;
-    }
-
-    // StsConfiguration
-    if (parametersData.stsConfiguration.has_value() && !magic_enum::enum_contains<StsConfiguration>(parametersData.stsConfiguration.value())) {
-        std::cerr << "Invalid StsConfiguration" << std::endl;
-    }
-
-    // MultiNodeMode (mandatory)
-    if (!magic_enum::enum_contains<MultiNodeMode>(parametersData.multiNodeMode.value())) {
-        std::cerr << "Invalid MultiNodeMode" << std::endl;
-    }
-
-    // Channel
-    if (parametersData.channelNumber.has_value() && !magic_enum::enum_contains<Channel>(parametersData.channelNumber.value())) {
-        std::cerr << "Invalid Channel" << std::endl;
-    }
 
     // NumberOfControlees (mandatory)
     if (parametersData.multiNodeMode == MultiNodeMode::Unicast) {
@@ -285,26 +260,6 @@ ValidateUwbRangeStartInput(std::shared_ptr<NearObjectCliData> cliData)
     // TODO: Insert the correct Controlee mac address rather than simply inserting the entire destinationMacAddressString
     for (auto i = 0; i < parametersData.numberOfControlees; i++) {
         parametersData.destinationMacAddresses.value().insert(uwb::UwbMacAddress::FromString(cliData->destinationMacAddressString, macAddressType).value());
-    }
-
-    // MacFcsType
-    if (parametersData.macFcsType.has_value() && !magic_enum::enum_contains<uwb::UwbMacAddressFcsType>(parametersData.macFcsType.value())) {
-        std::cerr << "Invalid MacFcsType" << std::endl;
-    }
-
-    // RangingRoundControl
-    if (parametersData.rangingRoundControl.has_value() && !magic_enum::enum_contains<RangingRoundControl>(parametersData.rangingRoundControl.value())) {
-        std::cerr << "Invalid RangingRoundControl" << std::endl;
-    }
-
-    // AoaResultRequest
-    if (parametersData.aoaResultRequest.has_value() && !magic_enum::enum_contains<AoAResult>(parametersData.aoaResultRequest.value())) {
-        std::cerr << "Invalid AoAResultRequest" << std::endl;
-    }
-
-    // RangeDataNotificationConfig
-    if (parametersData.rangeDataNotificationConfig.has_value() && !magic_enum::enum_contains<RangeDataNotificationConfiguration>(parametersData.rangeDataNotificationConfig.value())) {
-        std::cerr << "Invalid RangeDataNotificationConfig" << std::endl;
     }
 
     // RangeDataNotificationProximityNear
@@ -324,16 +279,6 @@ ValidateUwbRangeStartInput(std::shared_ptr<NearObjectCliData> cliData)
                 std::cerr << "Invalid RangeDataNotificationProximityFar" << std::endl;
             }
         }
-    }
-
-    // DeviceRole (mandatory)
-    if (!magic_enum::enum_contains<DeviceRole>(parametersData.deviceRole.value())) {
-        std::cerr << "Invalid DeviceRole" << std::endl;
-    }
-
-    // RFrameConfiguration
-    if (parametersData.rFrameConfiguration.has_value() && !magic_enum::enum_contains<StsPacketConfiguration>(parametersData.rFrameConfiguration.value())) {
-        std::cerr << "Invalid RFrameConfiguration" << std::endl;
     }
 
     // PreambleCodeIndex
@@ -362,44 +307,9 @@ ValidateUwbRangeStartInput(std::shared_ptr<NearObjectCliData> cliData)
         }
     }
 
-    // PsduDataRate
-    if (parametersData.psduDataRate.has_value() && !magic_enum::enum_contains<PsduDataRate>(parametersData.psduDataRate.value())) {
-        std::cerr << "Invalid PsduDataRate" << std::endl;
-    }
-
-    // PreambleDuration
-    if (parametersData.preambleDuration.has_value() && !magic_enum::enum_contains<PreambleDuration>(parametersData.preambleDuration.value())) {
-        std::cerr << "Invalid PreambleDuration" << std::endl;
-    }
-
-    // RangingTimeStruct
-    if (parametersData.rangingTimeStruct.has_value() && !magic_enum::enum_contains<RangingMode>(parametersData.rangingTimeStruct.value())) {
-        std::cerr << "Invalid RangingTimeStruct" << std::endl;
-    }
-
-    // TxAdaptivePayloadPower
-    if (parametersData.txAdaptivePayloadPower.has_value() && !magic_enum::enum_contains<TxAdaptivePayloadPower>(parametersData.txAdaptivePayloadPower.value())) {
-        std::cerr << "Invalid TxAdaptivePayloadPower" << std::endl;
-    }
-
     // ResponderSlotIndex
     if (parametersData.responderSlotIndex.has_value() && parametersData.responderSlotIndex.value() < 1) { // TODO: > N, where N is number of Responders
         std::cerr << "Invalid ResponderSlotIndex. Out of range." << std::endl;
-    }
-
-    // PrfMode
-    if (parametersData.prfMode.has_value() && !magic_enum::enum_contains<PrfMode>(parametersData.prfMode.value())) {
-        std::cerr << "Invalid PrfMode" << std::endl;
-    }
-
-    // ScheduledMode
-    if (parametersData.scheduledMode.has_value() && !magic_enum::enum_contains<SchedulingMode>(parametersData.scheduledMode.value())) {
-        std::cerr << "Invalid ScheduledMode" << std::endl;
-    }
-
-    // KeyRotation
-    if (parametersData.keyRotation.has_value() && !magic_enum::enum_contains<KeyRotation>(parametersData.keyRotation.value())) {
-        std::cerr << "Invalid KeyRotation" << std::endl;
     }
 
     // KeyRotationRate
@@ -410,11 +320,6 @@ ValidateUwbRangeStartInput(std::shared_ptr<NearObjectCliData> cliData)
     // SessionPriority
     if (parametersData.sessionPriority.has_value() && (parametersData.sessionPriority.value() < 1 || parametersData.sessionPriority.value() > 100)) {
         std::cerr << "Invalid SessionPriority. Out of range." << std::endl;
-    }
-
-    // MacAddressMode
-    if (parametersData.macAddressMode.has_value() && !magic_enum::enum_contains<uwb::UwbMacAddressType>(parametersData.macAddressMode.value())) {
-        std::cerr << "Invalid MacAddressMode" << std::endl;
     }
 
     // NumberOfStsSegments
@@ -485,10 +390,28 @@ ValidateUwbRangeStartInput(std::shared_ptr<NearObjectCliData> cliData)
             std::cerr << "Invalid BprfPhrDataRate" << std::endl;
         }
     }
+}
 
-    // StsLength
-    if (parametersData.stsLength.has_value() && !magic_enum::enum_contains<StsLength>(parametersData.stsLength.value())) {
-        std::cerr << "Invalid StsLength" << std::endl;
+/**
+ * @brief Validates the enum application configuration parameter inputs from nocli.
+ * 
+ * @tparam EnumType The type of the enumeration.
+ * @param applicationConfigurationParameter The application configuration parameter of type EnumType.
+ */
+template <typename EnumType>
+// clang-format off
+requires std::is_enum_v<EnumType>
+void
+ValidateEnumParameterValue(const EnumType& applicationConfigurationParameter)
+// clang-format on
+{
+    auto parameterType = magic_enum::enum_type_name<EnumType>();
+    if (!magic_enum::enum_contains<EnumType>(applicationConfigurationParameter)) {
+        if (parameterType == "StsPacketConfiguration") { // Special case
+            std::cerr << "Invalid RFrameConfiguration" << std::endl;
+        } else {
+            std::cerr << "Invalid " << parameterType << std::endl;
+        }
     }
 }
 
@@ -501,7 +424,7 @@ ValidateUwbRangeStartInput(std::shared_ptr<NearObjectCliData> cliData)
 std::vector<uwb::protocol::fira::UwbApplicationConfigurationParameter>
 ProcessApplicationConfigurationParameters(std::shared_ptr<NearObjectCliData> cliData)
 {
-    detail::ValidateUwbRangeStartInput(cliData);
+    detail::ValidateNonEnumParameterValues(cliData);
     auto& applicationConfigurationParameterData = cliData->applicationConfigurationParametersData;
 
     std::vector<uwb::protocol::fira::UwbApplicationConfigurationParameter> applicationConfigurationParameters;
@@ -516,12 +439,9 @@ ProcessApplicationConfigurationParameters(std::shared_ptr<NearObjectCliData> cli
             std::ostringstream oss;
             oss << magic_enum::enum_name(applicationConfigurationParameter) << "::";
             if constexpr (std::is_enum_v<ParameterValueT>) {
+                ValidateEnumParameterValue(arg);
                 oss << magic_enum::enum_name(arg);
-            } else if constexpr (std::is_same_v<ParameterValueT, uint8_t>) {
-                oss << +arg;
-            } else if constexpr (std::is_same_v<ParameterValueT, uint16_t>) {
-                oss << +arg;
-            } else if constexpr (std::is_same_v<ParameterValueT, uint32_t>) {
+            } else if constexpr (std::is_unsigned_v<ParameterValueT>) {
                 oss << +arg;
             } else if constexpr (std::is_same_v<ParameterValueT, ::uwb::UwbMacAddress>) {
                 oss << ToString(arg);

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -399,7 +399,7 @@ ValidateNonEnumParameterValues(std::shared_ptr<NearObjectCliData> cliData)
 
 /**
  * @brief Validates the enum application configuration parameter inputs from nocli.
- * 
+ *
  * @tparam EnumType The type of the enumeration.
  * @param applicationConfigurationParameter The application configuration parameter of type EnumType.
  */

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -347,7 +347,7 @@ ValidateUwbRangeStartInput(std::shared_ptr<NearObjectCliData> cliData)
     // KeyRotation
     
     // KeyRotationRate
-    if (parametersData.keyRotationRate.has_value() && (parametersData.keyRotationRate.value() < 0 || parametersData.keyRotationRate.value() > 15)) {
+    if (parametersData.keyRotationRate.has_value() && parametersData.keyRotationRate.value() > 15) {
         std::cerr << "Invalid KeyRotationRate. Out of range." << std::endl;
     }
     
@@ -364,7 +364,7 @@ ValidateUwbRangeStartInput(std::shared_ptr<NearObjectCliData> cliData)
     
     // NumberOfStsSegments
     if (parametersData.numberOfStsSegments.has_value()) {
-        if (parametersData.numberOfStsSegments.value() < 0 || parametersData.numberOfStsSegments.value() > 4) {
+        if (parametersData.numberOfStsSegments.value() > 4) {
             std::cerr << "Invalid NumberOfStsSegments. Out of range." << std::endl;
         }
         if (!parametersData.prfMode.has_value() || (parametersData.prfMode.has_value() && parametersData.prfMode.value() == PrfMode::Bprf)) { // Either BPRF is set or PRF_MODE is left at default (BPRF)
@@ -383,10 +383,7 @@ ValidateUwbRangeStartInput(std::shared_ptr<NearObjectCliData> cliData)
     
     // HoppingMode
     
-    // BlockStrideLength
-    if (parametersData.blockStrideLength.has_value() && (parametersData.blockStrideLength.value() < 0 || parametersData.blockStrideLength.value() > 255)) {
-        std::cerr << "Invalid BlockStrideLength. Out of range." << std::endl;
-    }
+    // BlockStrideLength (No restrictions given in FiRa UCI Generic Technical Specification v1.1.0)
     
     // ResultReportConfig
     constexpr int resultReportConfigurationSize = magic_enum::enum_count<ResultReportConfiguration>();
@@ -415,7 +412,7 @@ ValidateUwbRangeStartInput(std::shared_ptr<NearObjectCliData> cliData)
     }
     
     // InBandTerminationAttemptCount
-    if (parametersData.inBandTerminationAttemptCount.has_value() && (parametersData.inBandTerminationAttemptCount.value() < 0 || parametersData.inBandTerminationAttemptCount.value() > 10)) {
+    if (parametersData.inBandTerminationAttemptCount.has_value() && parametersData.inBandTerminationAttemptCount.value() > 10) {
         std::cerr << "Invalid InBandTerminationAttemptCount. Out of range." << std::endl;
     }
     
@@ -423,7 +420,7 @@ ValidateUwbRangeStartInput(std::shared_ptr<NearObjectCliData> cliData)
     
     // BprfPhrDataRate
     
-    // MaxNumberOfMeasurements
+    // MaxNumberOfMeasurements (No restrictions given in FiRa UCI Generic Technical Specification v1.1.0)
     
     // StsLength
 

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -241,7 +241,8 @@ void
 ValidateUwbRangeStartInput(std::shared_ptr<NearObjectCliData> cliData)
 {
     // Note: No restrictions other than type bounds checking given in FiRa UCI Generic Technical Specification v1.1.0 for the following parameters:
-    // SlotDuration, SlotsPerRangingRound, VendorId, MaxRangingRoundRetry, BlockStrideLength, MaxNumberOfMeasurements, RangingInterval, StsIndex, HoppingMode
+    // SlotDuration, SlotsPerRangingRound, VendorId, MaxRangingRoundRetry, BlockStrideLength, MaxNumberOfMeasurements, RangingInterval, StsIndex,
+    // HoppingMode, StaticStsIv
 
     auto& parametersData = cliData->applicationConfigurationParametersData;
 
@@ -251,8 +252,14 @@ ValidateUwbRangeStartInput(std::shared_ptr<NearObjectCliData> cliData)
     }
 
     // RangingRoundUsage
+    if (parametersData.rangingRoundUsage.has_value() && !magic_enum::enum_contains<RangingRoundUsage>(parametersData.rangingRoundUsage.value())) {
+        std::cerr << "Invalid RangingRoundUsage" << std::endl;
+    }
 
     // StsConfiguration
+    if (parametersData.stsConfiguration.has_value() && !magic_enum::enum_contains<StsConfiguration>(parametersData.stsConfiguration.value())) {
+        std::cerr << "Invalid StsConfiguration" << std::endl;
+    }
 
     // MultiNodeMode (mandatory)
     if (!magic_enum::enum_contains<MultiNodeMode>(parametersData.multiNodeMode.value())) {
@@ -260,6 +267,9 @@ ValidateUwbRangeStartInput(std::shared_ptr<NearObjectCliData> cliData)
     }
 
     // Channel
+    if (parametersData.channelNumber.has_value() && !magic_enum::enum_contains<Channel>(parametersData.channelNumber.value())) {
+        std::cerr << "Invalid Channel" << std::endl;
+    }
 
     // NumberOfControlees (mandatory)
     if (parametersData.multiNodeMode == MultiNodeMode::Unicast) {
@@ -278,12 +288,24 @@ ValidateUwbRangeStartInput(std::shared_ptr<NearObjectCliData> cliData)
     }
 
     // MacFcsType
+    if (parametersData.macFcsType.has_value() && !magic_enum::enum_contains<uwb::UwbMacAddressFcsType>(parametersData.macFcsType.value())) {
+        std::cerr << "Invalid MacFcsType" << std::endl;
+    }
 
     // RangingRoundControl
+    if (parametersData.rangingRoundControl.has_value() && !magic_enum::enum_contains<RangingRoundControl>(parametersData.rangingRoundControl.value())) {
+        std::cerr << "Invalid RangingRoundControl" << std::endl;
+    }
 
     // AoaResultRequest
+    if (parametersData.aoaResultRequest.has_value() && !magic_enum::enum_contains<AoAResult>(parametersData.aoaResultRequest.value())) {
+        std::cerr << "Invalid AoAResultRequest" << std::endl;
+    }
 
     // RangeDataNotificationConfig
+    if (parametersData.rangeDataNotificationConfig.has_value() && !magic_enum::enum_contains<RangeDataNotificationConfiguration>(parametersData.rangeDataNotificationConfig.value())) {
+        std::cerr << "Invalid RangeDataNotificationConfig" << std::endl;
+    }
 
     // RangeDataNotificationProximityNear
     if (parametersData.rangeDataNotificationProximityNear.has_value()) {
@@ -310,6 +332,9 @@ ValidateUwbRangeStartInput(std::shared_ptr<NearObjectCliData> cliData)
     }
 
     // RFrameConfiguration
+    if (parametersData.rFrameConfiguration.has_value() && !magic_enum::enum_contains<StsPacketConfiguration>(parametersData.rFrameConfiguration.value())) {
+        std::cerr << "Invalid RFrameConfiguration" << std::endl;
+    }
 
     // PreambleCodeIndex
     if (parametersData.preambleCodeIndex.has_value()) {
@@ -338,12 +363,24 @@ ValidateUwbRangeStartInput(std::shared_ptr<NearObjectCliData> cliData)
     }
 
     // PsduDataRate
+    if (parametersData.psduDataRate.has_value() && !magic_enum::enum_contains<PsduDataRate>(parametersData.psduDataRate.value())) {
+        std::cerr << "Invalid PsduDataRate" << std::endl;
+    }
 
     // PreambleDuration
+    if (parametersData.preambleDuration.has_value() && !magic_enum::enum_contains<PreambleDuration>(parametersData.preambleDuration.value())) {
+        std::cerr << "Invalid PreambleDuration" << std::endl;
+    }
 
     // RangingTimeStruct
+    if (parametersData.rangingTimeStruct.has_value() && !magic_enum::enum_contains<RangingMode>(parametersData.rangingTimeStruct.value())) {
+        std::cerr << "Invalid RangingTimeStruct" << std::endl;
+    }
 
     // TxAdaptivePayloadPower
+    if (parametersData.txAdaptivePayloadPower.has_value() && !magic_enum::enum_contains<TxAdaptivePayloadPower>(parametersData.txAdaptivePayloadPower.value())) {
+        std::cerr << "Invalid TxAdaptivePayloadPower" << std::endl;
+    }
 
     // ResponderSlotIndex
     if (parametersData.responderSlotIndex.has_value() && parametersData.responderSlotIndex.value() < 1) { // TODO: > N, where N is number of Responders
@@ -351,10 +388,19 @@ ValidateUwbRangeStartInput(std::shared_ptr<NearObjectCliData> cliData)
     }
 
     // PrfMode
+    if (parametersData.prfMode.has_value() && !magic_enum::enum_contains<PrfMode>(parametersData.prfMode.value())) {
+        std::cerr << "Invalid PrfMode" << std::endl;
+    }
 
     // ScheduledMode
+    if (parametersData.scheduledMode.has_value() && !magic_enum::enum_contains<SchedulingMode>(parametersData.scheduledMode.value())) {
+        std::cerr << "Invalid ScheduledMode" << std::endl;
+    }
 
     // KeyRotation
+    if (parametersData.keyRotation.has_value() && !magic_enum::enum_contains<KeyRotation>(parametersData.keyRotation.value())) {
+        std::cerr << "Invalid KeyRotation" << std::endl;
+    }
 
     // KeyRotationRate
     if (parametersData.keyRotationRate.has_value() && parametersData.keyRotationRate.value() > 15) {
@@ -367,8 +413,9 @@ ValidateUwbRangeStartInput(std::shared_ptr<NearObjectCliData> cliData)
     }
 
     // MacAddressMode
-
-    // StaticStsIv
+    if (parametersData.macAddressMode.has_value() && !magic_enum::enum_contains<uwb::UwbMacAddressType>(parametersData.macAddressMode.value())) {
+        std::cerr << "Invalid MacAddressMode" << std::endl;
+    }
 
     // NumberOfStsSegments
     if (parametersData.numberOfStsSegments.has_value()) {
@@ -429,8 +476,20 @@ ValidateUwbRangeStartInput(std::shared_ptr<NearObjectCliData> cliData)
     }
 
     // BprfPhrDataRate
+    if (parametersData.prfMode.has_value() && parametersData.prfMode.value() != PrfMode::Bprf) {
+        if (parametersData.bprfPhrDataRate.has_value()) {
+            std::cerr << "Invalid BprfPhrDataRate. Value expected only in BPRF mode" << std::endl;
+        }
+    } else {
+        if (parametersData.bprfPhrDataRate.has_value() && !magic_enum::enum_contains<BprfPhrDataRate>(parametersData.bprfPhrDataRate.value())) {
+            std::cerr << "Invalid BprfPhrDataRate" << std::endl;
+        }
+    }
 
     // StsLength
+    if (parametersData.stsLength.has_value() && !magic_enum::enum_contains<StsLength>(parametersData.stsLength.value())) {
+        std::cerr << "Invalid StsLength" << std::endl;
+    }
 }
 
 /**

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -300,8 +300,30 @@ ValidateUwbRangeStartInput(std::shared_ptr<NearObjectCliData> cliData)
     // RFrameConfiguration
     
     // PreambleCodeIndex
+    if (parametersData.preambleCodeIndex.has_value()) {
+        if (!parametersData.prfMode.has_value() || (parametersData.prfMode.has_value() && parametersData.prfMode.value() == PrfMode::Bprf)) { // Either BPRF is set or PRF_MODE is left at default (BPRF)
+            if (parametersData.preambleCodeIndex.value() < 9 || parametersData.preambleCodeIndex.value() > 12) {
+                std::cerr << "Invalid PreambleCodeIndex. Expected value range of 9-12 in BPRF mode" << std::endl;
+            }
+        } else { // HPRF mode
+            if (parametersData.preambleCodeIndex.value() < 25 || parametersData.preambleCodeIndex.value() > 32) {
+                std::cerr << "Invalid PreambleCodeIndex. Expected value range of 25-32 in HPRF mode" << std::endl;
+            }
+        }
+    }
     
     // SfdId
+    if (parametersData.sfdId.has_value()) {
+        if (!parametersData.prfMode.has_value() || (parametersData.prfMode.has_value() && parametersData.prfMode.value() == PrfMode::Bprf)) { // Either BPRF is set or PRF_MODE is left at default (BPRF)
+            if (parametersData.sfdId.value() != 0 && parametersData.sfdId.value() != 2) {
+                std::cerr << "Invalid SfdId. Expected values of 0 or 2 in BPRF mode" << std::endl;
+            }
+        } else { // HPRF mode
+            if (parametersData.sfdId.value() < 1 || parametersData.sfdId.value() > 4) {
+                std::cerr << "Invalid SfdId. Expected value range of 1-4 in HPRF mode" << std::endl;
+            }
+        }
+    }
     
     // PsduDataRate
     
@@ -309,11 +331,14 @@ ValidateUwbRangeStartInput(std::shared_ptr<NearObjectCliData> cliData)
     
     // RangingTimeStruct
     
-    // SlotsPerRangingRound
+    // SlotsPerRangingRound (No restrictions given in FiRa UCI Generic Technical Specification v1.1.0)
     
     // TxAdaptivePayloadPower
     
     // ResponderSlotIndex
+    if (parametersData.responderSlotIndex.has_value() && parametersData.responderSlotIndex.value() < 1) { // TODO: > N, where N is number of Responders
+        std::cerr << "Invalid ResponderSlotIndex. Out of range." << std::endl;
+    }
     
     // PrfMode
     
@@ -322,8 +347,14 @@ ValidateUwbRangeStartInput(std::shared_ptr<NearObjectCliData> cliData)
     // KeyRotation
     
     // KeyRotationRate
+    if (parametersData.keyRotationRate.has_value() && (parametersData.keyRotationRate.value() < 0 || parametersData.keyRotationRate.value() > 15)) {
+        std::cerr << "Invalid KeyRotationRate. Out of range." << std::endl;
+    }
     
     // SessionPriority
+    if (parametersData.sessionPriority.has_value() && (parametersData.sessionPriority.value() < 1 || parametersData.sessionPriority.value() > 100)) {
+        std::cerr << "Invalid SessionPriority. Out of range." << std::endl;
+    }
     
     // MacAddressMode
     
@@ -332,6 +363,19 @@ ValidateUwbRangeStartInput(std::shared_ptr<NearObjectCliData> cliData)
     // StaticStsIv
     
     // NumberOfStsSegments
+    if (parametersData.numberOfStsSegments.has_value()) {
+        if (parametersData.numberOfStsSegments.value() < 0 || parametersData.numberOfStsSegments.value() > 4) {
+            std::cerr << "Invalid NumberOfStsSegments. Out of range." << std::endl;
+        }
+        if (!parametersData.prfMode.has_value() || (parametersData.prfMode.has_value() && parametersData.prfMode.value() == PrfMode::Bprf)) { // Either BPRF is set or PRF_MODE is left at default (BPRF)
+            if (parametersData.numberOfStsSegments.value() >= 2) {
+                std::cerr << "Invalid NumberOfStsSegments. Only 0 or 1 STS segments expected in BPRF mode" << std::endl;
+            }
+        }
+        if (parametersData.rFrameConfiguration.value() == StsPacketConfiguration::SP0 && parametersData.numberOfStsSegments != 0) {
+            std::cerr << "Invalid NumberOfStsSegments. No STS segments expected with non-STS frames" << std::endl;
+        }
+    }
     
     // MaxRangingRoundRetry
     
@@ -340,6 +384,9 @@ ValidateUwbRangeStartInput(std::shared_ptr<NearObjectCliData> cliData)
     // HoppingMode
     
     // BlockStrideLength
+    if (parametersData.blockStrideLength.has_value() && (parametersData.blockStrideLength.value() < 0 || parametersData.blockStrideLength.value() > 255)) {
+        std::cerr << "Invalid BlockStrideLength. Out of range." << std::endl;
+    }
     
     // ResultReportConfig
     constexpr int resultReportConfigurationSize = magic_enum::enum_count<ResultReportConfiguration>();
@@ -368,6 +415,9 @@ ValidateUwbRangeStartInput(std::shared_ptr<NearObjectCliData> cliData)
     }
     
     // InBandTerminationAttemptCount
+    if (parametersData.inBandTerminationAttemptCount.has_value() && (parametersData.inBandTerminationAttemptCount.value() < 0 || parametersData.inBandTerminationAttemptCount.value() > 10)) {
+        std::cerr << "Invalid InBandTerminationAttemptCount. Out of range." << std::endl;
+    }
     
     // SubSessionId
     
@@ -405,6 +455,10 @@ ProcessApplicationConfigurationParameters(std::shared_ptr<NearObjectCliData> cli
             if constexpr (std::is_enum_v<ParameterValueT>) {
                 oss << magic_enum::enum_name(arg);
             } else if constexpr (std::is_same_v<ParameterValueT, uint8_t>) {
+                oss << +arg;
+            } else if constexpr (std::is_same_v<ParameterValueT, uint16_t>) {
+                oss << +arg;
+            } else if constexpr (std::is_same_v<ParameterValueT, uint32_t>) {
                 oss << +arg;
             } else if constexpr (std::is_same_v<ParameterValueT, ::uwb::UwbMacAddress>) {
                 oss << ToString(arg);

--- a/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
@@ -104,7 +104,7 @@ struct UwbApplicationConfigurationParameterData
     std::optional<uint16_t> rangeDataNotificationProximityNear;
     std::optional<uint16_t> rangeDataNotificationProximityFar;
     std::optional<uwb::protocol::fira::DeviceRole> deviceRole;
-    std::optional<uwb::protocol::fira::StsPacketConfiguration> rFrameConfiguration;
+    std::optional<uwb::protocol::fira::RFrameConfiguration> rFrameConfiguration;
     std::optional<uint8_t> preambleCodeIndex;
     std::optional<uint8_t> sfdId;
     std::optional<uwb::protocol::fira::PsduDataRate> psduDataRate;
@@ -113,7 +113,7 @@ struct UwbApplicationConfigurationParameterData
     std::optional<uint8_t> slotsPerRangingRound;
     std::optional<uwb::protocol::fira::TxAdaptivePayloadPower> txAdaptivePayloadPower;
     std::optional<uint8_t> responderSlotIndex;
-    std::optional<uwb::protocol::fira::PrfMode> prfMode;
+    std::optional<uwb::protocol::fira::PrfModeDetailed> prfMode;
     std::optional<uwb::protocol::fira::SchedulingMode> scheduledMode;
     std::optional<uwb::protocol::fira::KeyRotation> keyRotation;
     std::optional<uint8_t> keyRotationRate;

--- a/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
@@ -152,7 +152,7 @@ struct NearObjectCliData
     std::string destinationMacAddressString; // TODO: List of strings (or large string of mac address substrings) to support multiple controlees
     std::string resultReportConfigurationString;
     UwbConfigurationData uwbConfiguration{};
-    UwbApplicationConfigurationParameterData appConfigParamsData{};
+    UwbApplicationConfigurationParameterData applicationConfigurationParametersData{};
     uwb::protocol::fira::StaticRangingInfo StaticRanging{};
     uwb::protocol::fira::UwbSessionData SessionData{};
     UwbRangingParameters RangingParameters{};

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -1530,7 +1530,7 @@ windows::devices::uwb::ddi::lrp::To(const UWB_APP_CONFIG_PARAM &applicationConfi
         detail::ConvertUwbApplicationConfigurationParameterTo<PreambleDuration>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
         break;
     case UWB_APP_CONFIG_PARAM_TYPE_PRF_MODE:
-        detail::ConvertUwbApplicationConfigurationParameterTo<PrfMode>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
+        detail::ConvertUwbApplicationConfigurationParameterTo<PrfModeDetailed>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);
         break;
     case UWB_APP_CONFIG_PARAM_TYPE_PSDU_DATA_RATE:
         detail::ConvertUwbApplicationConfigurationParameterTo<PsduDataRate>(applicationConfigurationParameter, uwbApplicationConfigurationParameter);


### PR DESCRIPTION
### Type

- [x] Bug fix
- [x] Feature addition
- [x] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

This PR adds input validation to the remaining UCI app config parameters in nocli. Some bug fixes and minor improvements are also included.

### Technical Details

- Added missing fields to `PrfMode` and `RangeDataNotificationConfiguration` in `FiraDevice.hxx`.
- Updated `AddEnumOption` to display "RFrameConfiguration" instead of "StsPacketConfiguration".
- Added a function to do simple validation of all enum parameters.
- Added a function to do validation of all non-enum parameters and moved existing validation logic into it.
- Updated `ProcessApplicationConfigurationParameters` to handle all unsigned integers, not just uint8_t.
- Changed `appConfigParamsData` variable to `applicationConfigurationParametersData`.

### Test Results

Tested a few parameters of various types with invalid values - verified `std::cerr` output in nocli. Did not test every parameter.

### Reviewer Focus

There is a lot, partially due to the variable name change occurring in many places. The main focus should be on the two new validation functions.

Also, I don't like the name I gave to the new PrfMode parameter (`HprfSpecialDataRate`), but not sure what else to call it. It seems best to be more specific, but `HprfWithDataRate27_2And31_2Mbps` just doesn't seem right...

### Future Work

There are a lot of magic numbers that need to be changed. These are based on the UCI spec, so putting these in FiraDevice.hxx makes sense to me.

Right now, if a parameter is invalid, I just output a message to `std::cerr`. This is fine, but it might make more sense to either not send the invalid parameter and send all of the valid ones, or not send any parameters at all if one or more are invalid.

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
