### PR TITLE
Drop std::optional from GetSessionCount() return value type

### DIFF
--- a/lib/uwb/UwbDevice.cxx
+++ b/lib/uwb/UwbDevice.cxx
@@ -149,7 +149,7 @@ UwbDevice::GetDeviceInformation()
     return GetDeviceInformationImpl();
 }
 
-std::optional<uint32_t>
+uint32_t
 UwbDevice::GetSessionCount()
 {
     PLOG_INFO << "GetSessionCount";

--- a/lib/uwb/include/uwb/UwbDevice.hxx
+++ b/lib/uwb/include/uwb/UwbDevice.hxx
@@ -58,9 +58,9 @@ public:
     /**
      * @brief Get the number of sessions associated with the device.
      *
-     * @return std::optional<uint32_t>
+     * @return uint32_t
      */
-    std::optional<uint32_t>
+    uint32_t
     GetSessionCount();
 
     /**
@@ -134,9 +134,9 @@ private:
     /**
      * @brief Get the number of sessions associated with the device.
      *
-     * @return std::optional<uint32_t>
+     * @return uint32_t
      */
-    virtual std::optional<uint32_t>
+    virtual uint32_t
     GetSessionCountImpl() = 0;
 
     /**

--- a/tests/unit/uwb/TestUwbDevice.cxx
+++ b/tests/unit/uwb/TestUwbDevice.cxx
@@ -44,7 +44,7 @@ struct UwbDeviceTestBase : public uwb::UwbDevice
         return {};
     }
 
-    std::optional<uint32_t>
+    uint32_t
     GetSessionCountImpl() override
     {
         return {};

--- a/tools/cli/NearObjectCliHandler.cxx
+++ b/tools/cli/NearObjectCliHandler.cxx
@@ -141,12 +141,8 @@ try {
 void
 NearObjectCliHandler::HandleGetSessionCount(std::shared_ptr<::uwb::UwbDevice> uwbDevice) noexcept
 try {
-    auto sessionCount = uwbDevice->GetSessionCount();
-    if (sessionCount.has_value()) {
-        std::cout << "Session count: " << sessionCount.value() << std::endl;
-    } else {
-        std::cout << "No current sessions exist" << std::endl;
-    }
+    auto sessionCount = uwbDevice->GetSessionCount());
+    std::cout << "Session count: " << sessionCount << std::endl;
 } catch (...) {
     PLOG_ERROR << "failed to get session count";
 }

--- a/tools/cli/NearObjectCliHandler.cxx
+++ b/tools/cli/NearObjectCliHandler.cxx
@@ -141,7 +141,7 @@ try {
 void
 NearObjectCliHandler::HandleGetSessionCount(std::shared_ptr<::uwb::UwbDevice> uwbDevice) noexcept
 try {
-    auto sessionCount = uwbDevice->GetSessionCount());
+    auto sessionCount = uwbDevice->GetSessionCount();
     std::cout << "Session count: " << sessionCount << std::endl;
 } catch (...) {
     PLOG_ERROR << "failed to get session count";

--- a/windows/devices/uwb/UwbDevice.cxx
+++ b/windows/devices/uwb/UwbDevice.cxx
@@ -126,7 +126,7 @@ UwbDevice::GetDeviceInformationImpl()
     }
 }
 
-std::optional<uint32_t>
+uint32_t
 UwbDevice::GetSessionCountImpl()
 {
     auto resultFuture = m_uwbDeviceConnector->GetSessionCount();

--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -179,10 +179,10 @@ UwbConnector::GetCapabilities()
     return resultFuture;
 }
 
-std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::optional<uint32_t>>>
+std::future<std::tuple<::uwb::protocol::fira::UwbStatus, uint32_t>>
 UwbConnector::GetSessionCount()
 {
-    std::promise<std::tuple<::uwb::protocol::fira::UwbStatus, std::optional<uint32_t>>> resultPromise;
+    std::promise<std::tuple<::uwb::protocol::fira::UwbStatus, uint32_t>> resultPromise;
     auto resultFuture = resultPromise.get_future();
 
     wil::shared_hfile handleDriver;

--- a/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
@@ -5,7 +5,6 @@
 #include <cstdint>
 #include <future>
 #include <memory>
-#include <optional>
 #include <tuple>
 #include <vector>
 
@@ -34,7 +33,7 @@ struct IUwbDeviceDdi
     GetCapabilities() = 0;
 
     // IOCTL_UWB_GET_SESSION_COUNT
-    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::optional<uint32_t>>>
+    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, uint32_t>>
     GetSessionCount() = 0;
 
     // TODO: unspecified IOCTLs below

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
@@ -104,9 +104,9 @@ private:
     /**
      * @brief Get the number of sessions associated with the device.
      *
-     * @return std::optional<uint32_t>
+     * @return uint32_t
      */
-    virtual std::optional<uint32_t>
+    virtual uint32_t
     GetSessionCountImpl() override;
 
     /**

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
@@ -103,7 +103,7 @@ public:
     virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, ::uwb::protocol::fira::UwbCapability>>
     GetCapabilities() override;
 
-    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::optional<uint32_t>>>
+    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, uint32_t>>
     GetSessionCount() override;
 
 public:
@@ -171,7 +171,7 @@ private:
     /**
      * @brief Response for calling the relevant registered callbacks for the session ended event.
      * This function assumes the caller is holding the m_eventCallbacksGate
-     * 
+     *
      * @param sessionId The session identifier of the session that ended.
      * @param sessionEndReason The reason the session ended.
      */
@@ -189,14 +189,14 @@ private:
     /**
      * @brief Internal function that prepares the notification for processing by the m_sessionEventCallbacks
      * This function assumes the caller is holding the m_eventCallbacksGate
-     * 
+     *
      * @param rangingData
      */
     void
     OnSessionRangingData(::uwb::protocol::fira::UwbRangingData rangingData);
 
     /**
-     * @brief Internal function to check if there are callbacks present. 
+     * @brief Internal function to check if there are callbacks present.
      * This function assumes the caller is holding the m_eventCallbacksGate
      *
      * @return true


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Reduce ambiguity in `GetSessionCount()` return values (`!has_value()` and `.value() == 0` are ambiguous).

### Technical Details

* Use `uint32_t directly instead of `std::optional<uint32_t>` since the latter is unnecessary.

### Test Results

Compile-tested only.

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
