### PR TITLE
Invoke IOCTL_UWB_GET_SESSION_STATE and add nocli raw command

### DIFF
--- a/lib/uwb/UwbSession.cxx
+++ b/lib/uwb/UwbSession.cxx
@@ -134,6 +134,13 @@ UwbSession::GetApplicationConfigurationParameters()
     return GetApplicationConfigurationParametersImpl();
 }
 
+UwbSessionState
+UwbSession::GetSessionState()
+{
+    PLOG_VERBOSE << "get session state";
+    return GetSessionStateImpl();
+}
+
 void
 UwbSession::Destroy()
 {

--- a/lib/uwb/include/uwb/UwbSession.hxx
+++ b/lib/uwb/include/uwb/UwbSession.hxx
@@ -136,6 +136,14 @@ public:
     GetApplicationConfigurationParameters();
 
     /**
+     * @brief Get the current state for this session.
+     *
+     * @return ::uwb::protocol::fira::UwbSessionState
+     */
+    ::uwb::protocol::fira::UwbSessionState
+    GetSessionState();
+
+    /**
      * @brief Destroy the session, making it unusable.
      */
     void
@@ -195,6 +203,14 @@ private:
      */
     virtual std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter>
     GetApplicationConfigurationParametersImpl() = 0;
+
+    /**
+     * @brief Get the current state for this session.
+     *
+     * @return ::uwb::protocol::fira::UwbSessionState
+     */
+    virtual ::uwb::protocol::fira::UwbSessionState
+    GetSessionStateImpl() = 0;
 
     /**
      * @brief Destroy the session, making it unusable.

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -528,6 +528,7 @@ NearObjectCli::AddSubcommandUwbRaw(CLI::App* parent)
     AddSubcommandUwbRawGetDeviceInfo(rawApp);
     AddSubcommandUwbRawSessionDeinitialize(rawApp);
     AddSubcommandUwbRawGetSessionCount(rawApp);
+    AddSubcommandUwbRawGetSessionState(rawApp);
 
     return rawApp;
 }
@@ -675,6 +676,36 @@ NearObjectCli::AddSubcommandUwbRawGetSessionCount(CLI::App* parent)
     });
 
     return rawGetSessionCountApp;
+}
+
+CLI::App*
+NearObjectCli::AddSubcommandUwbRawGetSessionState(CLI::App* parent)
+{
+    // top-level command
+    auto rawGetSessionStateApp = parent->add_subcommand("getsessionstate", "Get the current state of a session")->fallthrough();
+    rawGetSessionStateApp->add_option("Session Id, --SessionId", m_cliData->SessionId)->required();
+
+    rawGetSessionStateApp->parse_complete_callback([this, rawGetSessionStateApp] {
+        RegisterCliAppWithOperation(rawGetSessionStateApp);
+        std::cout << "get session state of session " << m_cliData->SessionId << std::endl;
+    });
+
+    rawGetSessionStateApp->final_callback([this, rawGetSessionStateApp] {
+        auto uwbDevice = GetUwbDevice();
+        if (!uwbDevice) {
+            std::cerr << "no device found" << std::endl;
+            return;
+        }
+        if (!uwbDevice->Initialize()) {
+            std::cerr << "device not initialized" << std::endl;
+        }
+
+        m_cliHandler->HandleGetSessionState(uwbDevice, m_cliData->SessionId);
+
+        SignalCliAppOperationCompleted(rawGetSessionStateApp);
+    });
+
+    return rawGetSessionStateApp;
 }
 
 CLI::App*

--- a/tools/cli/NearObjectCliHandler.cxx
+++ b/tools/cli/NearObjectCliHandler.cxx
@@ -146,3 +146,19 @@ try {
 } catch (...) {
     PLOG_ERROR << "failed to get session count";
 }
+
+void
+NearObjectCliHandler::HandleGetSessionState(std::shared_ptr<::uwb::UwbDevice> uwbDevice, uint32_t sessionId) noexcept
+try {
+    auto session = uwbDevice->GetSession(sessionId);
+    if (session == nullptr) {
+        PLOG_WARNING << "no session found with id " << sessionId;
+        return;
+    }
+
+    auto sessionState = session->GetSessionState();
+    std::cout << "Session state: " << magic_enum::enum_name(sessionState) << std::endl;
+
+} catch (...) {
+    PLOG_ERROR << "failed to get session state";
+}

--- a/tools/cli/include/nearobject/cli/NearObjectCli.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCli.hxx
@@ -268,10 +268,10 @@ private:
     AddSubcommandUwbRawGetDeviceInfo(CLI::App* parent);
 
     /**
-     * @brief Add the 'uwb raw sessiondeinit' sub-command. 
-     * 
+     * @brief Add the 'uwb raw sessiondeinit' sub-command.
+     *
      * @param parent The parent app to add the command.
-     * @return CLI::App* 
+     * @return CLI::App*
      */
     CLI::App*
     AddSubcommandUwbRawSessionDeinitialize(CLI::App* parent);
@@ -284,6 +284,15 @@ private:
      */
     CLI::App*
     AddSubcommandUwbRawGetSessionCount(CLI::App* parent);
+
+    /**
+     * @brief Add the 'uwb raw getsessionstate' sub-command.
+     *
+     * @param parent The parent app to add the command.
+     * @return CLI::App*
+     */
+    CLI::App*
+    AddSubcommandUwbRawGetSessionState(CLI::App* parent);
 
     /**
      * @brief Add the 'uwb range start' sub-command.

--- a/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliHandler.hxx
@@ -115,6 +115,14 @@ struct NearObjectCliHandler
     virtual void
     HandleGetSessionCount(std::shared_ptr<::uwb::UwbDevice> uwbDevice) noexcept;
 
+    /**
+     * @brief Invoked by the command-line driver when the request is to get the current state of a session.
+     *
+     * @param uwbDevice
+     */
+    virtual void
+    HandleGetSessionState(std::shared_ptr<::uwb::UwbDevice> uwbDevice, uint32_t sessionId) noexcept;
+
 private:
     NearObjectCli* m_parent;
     std::shared_ptr<::uwb::UwbDevice> m_activeDevice;

--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -242,7 +242,7 @@ UwbSession::GetApplicationConfigurationParametersImpl()
     try {
         auto [uwbStatus, applicationConfigurationParameters] = resultFuture.get();
         if (!IsUwbStatusOk(uwbStatus)) {
-            // TODO: this value should be returned
+            throw UwbException(uwbStatus);
         }
         return applicationConfigurationParameters;
     } catch (UwbException &uwbException) {

--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -254,6 +254,32 @@ UwbSession::GetApplicationConfigurationParametersImpl()
     }
 }
 
+UwbSessionState
+UwbSession::GetSessionStateImpl()
+{
+    uint32_t sessionId = GetId();
+
+    auto resultFuture = m_uwbDeviceConnector->SessionGetState(sessionId);
+    if (!resultFuture.valid()) {
+        PLOG_ERROR << "failed to obtain session state for session id " << sessionId;
+        throw UwbException(UwbStatusGeneric::Failed);
+    }
+
+    try {
+        auto [uwbStatus, sessionState] = resultFuture.get();
+        if (!IsUwbStatusOk(uwbStatus)) {
+            // TODO: this value should be returned
+        }
+        return sessionState;
+    } catch (UwbException &uwbException) {
+        PLOG_ERROR << "caught exception attempting to obtain session state for session id " << sessionId << " (" << ToString(uwbException.Status) << ")";
+        throw uwbException;
+    } catch (std::exception &e) {
+        PLOG_ERROR << "caught unexpected exception attempting to obtain session state for session id " << sessionId << " (" << e.what() << ")";
+        throw e;
+    }
+}
+
 void
 UwbSession::DestroyImpl()
 {

--- a/windows/devices/uwb/include/windows/devices/uwb/IUwbSessionDdi.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/IUwbSessionDdi.hxx
@@ -30,7 +30,7 @@ struct IUwbSessionDdi
     SessionDeinitialize(uint32_t sessionId) = 0;
 
     // IOCTL_UWB_GET_SESSION_STATE
-    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::optional<::uwb::protocol::fira::UwbSessionState>>>
+    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, ::uwb::protocol::fira::UwbSessionState>>
     SessionGetState(uint32_t sessionId) = 0;
 
     // IOCTL_UWB_START_RANGING_SESSION

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDeviceConnector.hxx
@@ -114,7 +114,7 @@ public:
     virtual std::future<::uwb::protocol::fira::UwbStatus>
     SessionDeinitialize(uint32_t sessionId) override;
 
-    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, std::optional<::uwb::protocol::fira::UwbSessionState>>>
+    virtual std::future<std::tuple<::uwb::protocol::fira::UwbStatus, ::uwb::protocol::fira::UwbSessionState>>
     SessionGetState(uint32_t sessionId) override;
 
     virtual std::future<::uwb::protocol::fira::UwbStatus>

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
@@ -77,6 +77,14 @@ private:
     GetApplicationConfigurationParametersImpl() override;
 
     /**
+     * @brief Get the current state for this session.
+     *
+     * @return ::uwb::protocol::fira::UwbSessionState
+     */
+    virtual ::uwb::protocol::fira::UwbSessionState
+    GetSessionStateImpl() override;
+
+    /**
      * @brief Destroy the session, making it unusable.
      */
     void


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [x] Feature addition
- [x] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

This PR adds code to invoke IOCTL_UWB_GET_SESSION_STATE, as well as add a raw subcommand for it in nocli.

### Technical Details

- Added code to invoke the IOCTL in UwbConnector
- Added raw nocli subcommand called `getsessionstate`
- Changed the `std::optional<UwbSessionState>` return type to `UwbSessionState`

### Test Results

Tested new raw command in nocli with TestClient driver and verified expected output.

### Reviewer Focus

None.

### Future Work

None.

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
