### PR TITLE
Move to shared creation of UwbDevice

### DIFF
--- a/lib/nearobject/include/nearobject/service/NearObjectDeviceControllerUwb.hxx
+++ b/lib/nearobject/include/nearobject/service/NearObjectDeviceControllerUwb.hxx
@@ -22,14 +22,19 @@ class NearObjectDeviceControllerUwb :
     public NearObjectDeviceController
 {
 public:
-    NearObjectDeviceControllerUwb(std::unique_ptr<uwb::UwbDevice> uwbDevice);
+    /**
+     * @brief Construct a new NearObjectDeviceControllerUwb object.
+     *
+     * @param uwbDevice The underlying UWB device.
+     */
+    NearObjectDeviceControllerUwb(std::shared_ptr<uwb::UwbDevice> uwbDevice);
 
     /**
-     * @brief 
-     * 
-     * @param other 
-     * @return true 
-     * @return false 
+     * @brief
+     *
+     * @param other
+     * @return true
+     * @return false
      */
     bool
     IsEqual(const NearObjectDeviceController& other) const noexcept override;
@@ -39,7 +44,7 @@ private:
     StartSessionImpl(const NearObjectProfile& profile, std::weak_ptr<NearObjectSessionEventCallbacks> eventCallbacks) override;
 
 private:
-    std::unique_ptr<uwb::UwbDevice> m_uwbDevice{};
+    std::shared_ptr<::uwb::UwbDevice> m_uwbDevice{};
 };
 
 } // namespace service

--- a/lib/nearobject/service/NearObjectDeviceControllerUwb.cxx
+++ b/lib/nearobject/service/NearObjectDeviceControllerUwb.cxx
@@ -5,7 +5,7 @@
 
 using namespace nearobject::service;
 
-NearObjectDeviceControllerUwb::NearObjectDeviceControllerUwb(std::unique_ptr<uwb::UwbDevice> uwbDevice) :
+NearObjectDeviceControllerUwb::NearObjectDeviceControllerUwb(std::shared_ptr<uwb::UwbDevice> uwbDevice) :
     m_uwbDevice(std::move(uwbDevice))
 {
 }

--- a/windows/devices/uwb/UwbDevice.cxx
+++ b/windows/devices/uwb/UwbDevice.cxx
@@ -4,12 +4,13 @@
 #include <stdexcept>
 #include <tuple>
 
+#include <notstd/memory.hxx>
 #include <uwb/protocols/fira/FiraDevice.hxx>
 #include <uwb/protocols/fira/UwbException.hxx>
+#include <windows/devices/uwb/UwbConnector.hxx>
 #include <windows/devices/uwb/UwbCxAdapterDdiLrp.hxx>
 #include <windows/devices/uwb/UwbCxDdiLrp.hxx>
 #include <windows/devices/uwb/UwbDevice.hxx>
-#include <windows/devices/uwb/UwbConnector.hxx>
 #include <windows/devices/uwb/UwbSession.hxx>
 
 #include <plog/Log.h>
@@ -31,6 +32,13 @@ UwbDevice::UwbDevice(std::string deviceName) :
         [this](::uwb::protocol::fira::UwbSessionStatus status) {
             return OnSessionStatusChanged(status);
         });
+}
+
+/* static */
+std::shared_ptr<UwbDevice>
+UwbDevice::Create(std::string deviceName)
+{
+    return std::make_shared<notstd::enable_make_protected<UwbDevice>>(std::move(deviceName));
 }
 
 const std::string&

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
@@ -34,15 +34,26 @@ namespace windows::devices::uwb
  * UWB DDI.
  */
 class UwbDevice :
-    public ::uwb::UwbDevice
+    public ::uwb::UwbDevice,
+    public std::enable_shared_from_this<UwbDevice>
 {
-public:
+protected:
     /**
      * @brief Construct a new Uwb Device object.
      *
      * @param deviceName The interface path name.
      */
     explicit UwbDevice(std::string deviceName);
+
+public:
+    /**
+     * @brief Create a new UwbDevice object instance.
+     *
+     * @param deviceName The interface path name.
+     * @return std::shared_ptr<UwbDevice>
+     */
+    static std::shared_ptr<UwbDevice>
+    Create(std::string deviceName);
 
     /**
      * @brief Get the name of this device.

--- a/windows/nearobject/service/NearObjectDeviceDiscoveryAgentUwb.cxx
+++ b/windows/nearobject/service/NearObjectDeviceDiscoveryAgentUwb.cxx
@@ -18,7 +18,7 @@ namespace detail
 std::shared_ptr<NearObjectDeviceControllerUwb>
 CreateNearObjectUwbDevice(std::string deviceName)
 {
-    auto uwbDevice = std::make_unique<windows::devices::uwb::UwbDevice>(std::move(deviceName));
+    auto uwbDevice = windows::devices::uwb::UwbDevice::Create(std::move(deviceName));
     return std::make_shared<NearObjectDeviceControllerUwb>(std::move(uwbDevice));
 }
 } // namespace detail

--- a/windows/tools/nocli/NearObjectCliHandlerWindows.cxx
+++ b/windows/tools/nocli/NearObjectCliHandlerWindows.cxx
@@ -88,7 +88,7 @@ ResolveUwbDevice(const nearobject::cli::NearObjectCliDataWindows& cliData)
         return nullptr;
     }
 
-    return std::make_shared<windows::devices::uwb::UwbDevice>(deviceName);
+    return windows::devices::uwb::UwbDevice::Create(deviceName);
 }
 } // namespace detail
 
@@ -106,7 +106,7 @@ NearObjectCliHandlerWindows::ResolveUwbDevice(const nearobject::cli::NearObjectC
 void
 NearObjectCliHandlerWindows::OnDeviceArrived(const std::string& deviceName)
 {
-    auto uwbDevice = std::make_unique<windows::devices::uwb::UwbDevice>(deviceName);
+    auto uwbDevice = windows::devices::uwb::UwbDevice::Create(deviceName);
     if (!uwbDevice) {
         PLOG_ERROR << "Failed to instantiate UWB device with name " << deviceName;
         return;

--- a/windows/tools/nocli/NearObjectCliHandlerWindows.hxx
+++ b/windows/tools/nocli/NearObjectCliHandlerWindows.hxx
@@ -34,7 +34,7 @@ private:
     OnDeviceDeparted(const std::string& deviceName);
 
 private:
-    std::vector<std::unique_ptr<windows::devices::uwb::UwbDevice>> m_uwbDevices;
+    std::vector<std::shared_ptr<windows::devices::uwb::UwbDevice>> m_uwbDevices;
 };
 } // namespace nearobject::cli
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Ensure that shared instances of `UwbDevice` are passed around, enabling other components that need `std::weak_ptr` references to obtain them.

### Technical Details

* Change visibility of `UwbDevice` `public` constructors to `protected` to prevent leaking instances that don't have a `std::shared_ptr` control block.
* Add `static` factory method `UwbDevice::Create` that guarantees the existence of a `std::shared_ptr` control block for ever live instance of `UwbDevice`.
* Update existing instances using `std::unique_ptr<UwbDevice>` to `std::shared_ptr<UwbDevice>`.

### Test Results

Compile tested only. Additional testing will be done with other non-trivial changes coming in subsequent PRs.

### Reviewer Focus

None

### Future Work

* Convert instances using raw `UwbDevice` pointers to use `std::weak_ptr<UwbDevice>`.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
