### PR TITLE
Update UwbConnector + simulator driver to handle in-band output buffer size indication

### DIFF
--- a/windows/devices/uwb/UwbDeviceConnector.cxx
+++ b/windows/devices/uwb/UwbDeviceConnector.cxx
@@ -97,7 +97,7 @@ UwbConnector::GetDeviceInformation()
     }
 
     std::vector<uint8_t> deviceInformationBuffer{};
-    DWORD bytesRequired = sizeof(UWB_DEVICE_INFO);
+    DWORD bytesRequired = offsetof(UWB_DEVICE_INFO, vendorSpecificInfo);
 
     // Attempt at most twice to obtain device information. On the first attempt,
     // we guess that no vendor-specific information will be supplied. If this is
@@ -118,6 +118,8 @@ UwbConnector::GetDeviceInformation()
                 break;
             }
             // Attempt to retry the ioctl with the appropriate buffer size, which is now held in bytesRequired.
+            const auto& deviceInformationPartial = *reinterpret_cast<UWB_DEVICE_INFO*>(std::data(deviceInformationBuffer));
+            bytesRequired = deviceInformationPartial.size;
             continue;
         } else {
             PLOG_DEBUG << "IOCTL_UWB_GET_DEVICE_INFO succeeded";
@@ -149,32 +151,39 @@ UwbConnector::GetCapabilities()
         return resultFuture;
     }
 
-    // Determine the amount of memory required for the UWB_DEVICE_CAPABILITIES from the driver.
-    DWORD bytesRequired = 0;
-    BOOL ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_GET_DEVICE_CAPABILITIES, nullptr, 0, nullptr, 0, &bytesRequired, nullptr);
-    if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
-        // TODO: need to do something different here
-        HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
-        PLOG_ERROR << "error when sending IOCTL_UWB_GET_DEVICE_CAPABILITIES, hr=" << std::showbase << std::hex << hr;
-        return resultFuture;
-    }
+    std::vector<uint8_t> uwbDeviceCapabilitiesBuffer{};
+    DWORD bytesRequired = offsetof(UWB_DEVICE_CAPABILITIES, capabilityParams);
 
-    // Allocate memory for the UWB_DEVICE_CAPABILITIES structure, and pass this to the driver request.
-    DWORD uwbCapabilitiesSize = bytesRequired;
-    auto uwbDeviceCapabilitiesBuffer = std::make_unique<uint8_t[]>(uwbCapabilitiesSize);
-    ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_GET_DEVICE_CAPABILITIES, nullptr, 0, uwbDeviceCapabilitiesBuffer.get(), uwbCapabilitiesSize, &bytesRequired, nullptr);
-    if (!ioResult) {
-        // TODO: need to do something different here
-        HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
-        PLOG_ERROR << "error when sending IOCTL_UWB_GET_DEVICE_CAPABILITIES, hr=" << std::showbase << std::hex << hr;
-        return resultFuture;
+    for (const auto i : std::ranges::iota_view{ 0, 2 }) {
+        uwbDeviceCapabilitiesBuffer.resize(bytesRequired);
+        PLOG_DEBUG << "IOCTL_UWB_GET_DEVICE_CAPABILITIES attempt #" << (i + 1) << " with " << std::size(uwbDeviceCapabilitiesBuffer) << "-byte buffer";
+        BOOL ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_GET_DEVICE_CAPABILITIES, nullptr, 0, std::data(uwbDeviceCapabilitiesBuffer), std::size(uwbDeviceCapabilitiesBuffer), &bytesRequired, nullptr);
+        if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
+            DWORD lastError = GetLastError();
+            // Treat all errors other than insufficient buffer size as fatal.
+            if (lastError != ERROR_MORE_DATA) {
+                HRESULT hr = HRESULT_FROM_WIN32(lastError);
+                PLOG_ERROR << "error when sending IOCTL_UWB_GET_DEVICE_CAPABILITIES, hr=" << std::showbase << std::hex << hr;
+                resultPromise.set_exception(std::make_exception_ptr(UwbException(UwbStatusGeneric::Failed)));
+                break;
+            }
+            // Attempt to retry the ioctl with the appropriate buffer size, which is now held in bytesRequired.
+            const auto& deviceCapabilitiesPartial = *reinterpret_cast<UWB_DEVICE_CAPABILITIES*>(std::data(uwbDeviceCapabilitiesBuffer));
+            bytesRequired = deviceCapabilitiesPartial.size;
+            continue;
+        } else {
+            PLOG_DEBUG << "IOCTL_UWB_GET_DEVICE_CAPABILITIES succeeded";
+            auto& deviceCapabilities = *reinterpret_cast<UWB_DEVICE_CAPABILITIES*>(std::data(uwbDeviceCapabilitiesBuffer));
+            auto uwbStatus = UwbCxDdi::To(deviceCapabilities.status);
+            if (!IsUwbStatusOk(uwbStatus)) {
+                resultPromise.set_exception(std::make_exception_ptr(UwbException(std::move(uwbStatus))));
+            } else {
+                auto uwbDeviceCapabilities = UwbCxDdi::To(deviceCapabilities);
+                resultPromise.set_value(std::make_tuple(uwbStatus, std::move(uwbDeviceCapabilities)));
+            }
+            break;
+        }
     }
-
-    const UWB_DEVICE_CAPABILITIES& uwbDeviceCapabilities = *reinterpret_cast<UWB_DEVICE_CAPABILITIES*>(uwbDeviceCapabilitiesBuffer.get());
-    auto deviceCapabilities = UwbCxDdi::To(uwbDeviceCapabilities);
-    auto uwbStatus = UwbCxDdi::To(uwbDeviceCapabilities.status);
-    auto result = std::make_tuple(uwbStatus, std::move(deviceCapabilities));
-    resultPromise.set_value(std::move(result));
 
     return resultFuture;
 }
@@ -423,7 +432,7 @@ UwbConnector::GetApplicationConfigurationParameters(uint32_t sessionId, std::vec
     auto getAppConfigParams = UwbCxDdi::From(uwbGetApplicationConfigurationParameters);
     auto getAppConfigParamsBuffer = std::data(getAppConfigParams);
 
-    DWORD bytesRequired = 0;
+    DWORD bytesRequired = offsetof(UWB_APP_CONFIG_PARAMS, appConfigParams);
     std::vector<uint8_t> getAppConfigParamsResultBuffer{};
 
     for (const auto i : std::ranges::iota_view{ 0, 2 }) {
@@ -440,6 +449,8 @@ UwbConnector::GetApplicationConfigurationParameters(uint32_t sessionId, std::vec
                 break;
             }
             // Attempt to retry the ioctl with the appropriate buffer size, which is now held in bytesRequired.
+            const auto& appConfigParamsPartial = *reinterpret_cast<UWB_APP_CONFIG_PARAMS*>(std::data(getAppConfigParamsResultBuffer));
+            bytesRequired = appConfigParamsPartial.size;
             continue;
         }
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDdiHandler.cxx
@@ -45,11 +45,11 @@ UwbSimulatorDispatchEntryLrp (*MakeLrpDispatchEntry)(ULONG, typename UwbSimulato
 const std::initializer_list<UwbSimulatorDispatchEntry<UwbSimulatorDdiHandler>> UwbSimulatorDdiHandler::Dispatch{
     // GUID_UWB_DEVICE_INTERFACE Handlers
     MakeLrpDispatchEntry<UWB_DEVICE_RESET, UWB_STATUS>(IOCTL_UWB_DEVICE_RESET, &UwbSimulatorDdiHandler::OnUwbDeviceReset),
-    MakeLrpDispatchEntry<Unrestricted, Unrestricted>(IOCTL_UWB_GET_DEVICE_INFO, &UwbSimulatorDdiHandler::OnUwbGetDeviceInformation),
-    MakeLrpDispatchEntry<Unrestricted, Unrestricted>(IOCTL_UWB_GET_DEVICE_CAPABILITIES, &UwbSimulatorDdiHandler::OnUwbGetDeviceCapabilities),
+    MakeLrpDispatchEntryWithSize(IOCTL_UWB_GET_DEVICE_INFO, &UwbSimulatorDdiHandler::OnUwbGetDeviceInformation, 0, offsetof(UWB_DEVICE_INFO, vendorSpecificInfo)),
+    MakeLrpDispatchEntryWithSize(IOCTL_UWB_GET_DEVICE_CAPABILITIES, &UwbSimulatorDdiHandler::OnUwbGetDeviceCapabilities, 0, offsetof(UWB_DEVICE_CAPABILITIES, capabilityParams)),
     MakeLrpDispatchEntry<UWB_SET_DEVICE_CONFIG_PARAMS, Unrestricted>(IOCTL_UWB_GET_DEVICE_CONFIG_PARAMS, &UwbSimulatorDdiHandler::OnUwbGetDeviceConfigurationParameters),
     MakeLrpDispatchEntry<UWB_GET_DEVICE_CONFIG_PARAMS, Unrestricted>(IOCTL_UWB_SET_DEVICE_CONFIG_PARAMS, &UwbSimulatorDdiHandler::OnUwbSetDeviceConfigurationParameters),
-    MakeLrpDispatchEntry<UWB_GET_APP_CONFIG_PARAMS, Unrestricted>(IOCTL_UWB_GET_APP_CONFIG_PARAMS, &UwbSimulatorDdiHandler::OnUwbGetApplicationConfigurationParameters),
+    MakeLrpDispatchEntryWithSize(IOCTL_UWB_GET_APP_CONFIG_PARAMS, &UwbSimulatorDdiHandler::OnUwbGetApplicationConfigurationParameters, offsetof(UWB_GET_APP_CONFIG_PARAMS, appConfigParams), offsetof(UWB_APP_CONFIG_PARAMS, appConfigParams)),
     MakeLrpDispatchEntryWithSize(IOCTL_UWB_SET_APP_CONFIG_PARAMS, &UwbSimulatorDdiHandler::OnUwbSetApplicationConfigurationParameters, offsetof(UWB_SET_APP_CONFIG_PARAMS, appConfigParams), offsetof(UWB_SET_APP_CONFIG_PARAMS_STATUS, appConfigParamsStatus)),
     MakeLrpDispatchEntry<Unrestricted, UWB_GET_SESSION_COUNT>(IOCTL_UWB_GET_SESSION_COUNT, &UwbSimulatorDdiHandler::OnUwbGetSessionCount),
     MakeLrpDispatchEntry<UWB_SESSION_INIT, UWB_STATUS>(IOCTL_UWB_SESSION_INIT, &UwbSimulatorDdiHandler::OnUwbSessionInitialize),


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [x] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

This PR updates the IOCTL invocation code to use the proper in-band indication for the required output buffer size. It also updates the simulator driver's dispatch table accordingly, matching the dispatch table in the CX driver.

### Technical Details

- Use `.size` field for resizing output buffers instead of what was previously returned in `bytesRequired`.
- Rewrite `GetCapabilities()` to match format and style of other similar functions.
- Update Simulator driver dispatch table.

### Test Results

Mostly compile tested for now. Can confirm that the new changes now allows GetApplicationConfigurationParameters to communicate with the TestClient driver (although #219 still causes failures)

### Reviewer Focus

Does the Simulator driver need additional changes besides the dispatch table updates?

### Future Work

Adding a raw command `GetDeviceCapabilities` could allow us to test that functionality. Also, additional testing could be done for the new resizing logic with variable size arrays (e.g. I tested GetDeviceInfo with the TestClient driver, but that currently doesn't set any vendor specific info, so the resizing logic wasn't actually tested).

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
