### PR TITLE
Consolidate UwbConnector usage

### DIFF
--- a/lib/uwb/UwbSession.cxx
+++ b/lib/uwb/UwbSession.cxx
@@ -11,15 +11,16 @@
 using namespace uwb;
 using namespace uwb::protocol::fira;
 
-UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<UwbSessionEventCallbacks> callbacks, DeviceType deviceType) :
+UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<UwbDevice> device, std::weak_ptr<UwbSessionEventCallbacks> callbacks, DeviceType deviceType) :
     m_uwbMacAddressSelf(UwbMacAddress::Random<UwbMacAddressType::Extended>()),
     m_callbacks(std::move(callbacks)),
     m_deviceType{ deviceType },
-    m_sessionId(sessionId)
+    m_sessionId(sessionId),
+    m_device(std::move(device))
 {}
 
-UwbSession::UwbSession(uint32_t sessionId, DeviceType deviceType) :
-    UwbSession(sessionId, std::weak_ptr<UwbSessionEventCallbacks>{}, deviceType)
+UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<UwbDevice> device, DeviceType deviceType) :
+    UwbSession(sessionId, std::move(device), std::weak_ptr<UwbSessionEventCallbacks>{}, deviceType)
 {}
 
 std::weak_ptr<UwbSessionEventCallbacks>

--- a/lib/uwb/include/uwb/UwbDevice.hxx
+++ b/lib/uwb/include/uwb/UwbDevice.hxx
@@ -20,6 +20,13 @@ class UwbSession;
  */
 class UwbDevice
 {
+protected:
+    /**
+     * @brief Only allow derived classes to instantiate an instance.
+     *
+     */
+    UwbDevice() = default;
+
 public:
     /**
      * @brief Creates a new UWB session with no configuration nor peers.

--- a/lib/uwb/include/uwb/UwbDevice.hxx
+++ b/lib/uwb/include/uwb/UwbDevice.hxx
@@ -23,7 +23,6 @@ class UwbDevice
 protected:
     /**
      * @brief Only allow derived classes to instantiate an instance.
-     *
      */
     UwbDevice() = default;
 

--- a/lib/uwb/include/uwb/UwbSession.hxx
+++ b/lib/uwb/include/uwb/UwbSession.hxx
@@ -184,7 +184,7 @@ protected:
         if constexpr (std::is_same_v<TDerived, UwbDevice>) {
             return m_device.lock();
         } else {
-            return dynamic_pointer_cast<TDerived>(m_device.lock());
+            return std::dynamic_pointer_cast<TDerived>(m_device.lock());
         }
     }
 

--- a/windows/devices/uwb/UwbConnector.cxx
+++ b/windows/devices/uwb/UwbConnector.cxx
@@ -623,6 +623,7 @@ UwbConnector::GetResolvedDeviceEventCallbacks()
         auto deviceEventCallback = deviceEventCallbackWeak.lock();
         if (deviceEventCallback != nullptr) {
             deviceEventCallbacks.push_back(std::move(deviceEventCallback));
+            it = std::next(it);
         } else {
             it = m_deviceEventCallbacks.erase(it);
         }
@@ -654,6 +655,7 @@ UwbConnector::GetResolvedSessionEventCallbacks(uint32_t sessionId)
         auto sessionEventCallback = sessionEventCallbackWeak.lock();
         if (sessionEventCallback != nullptr) {
             sessionEventCallbacks.push_back(std::move(sessionEventCallback));
+            it = std::next(it);
         } else {
             it = sessionEventCallbacksWeak.erase(it);
         }
@@ -808,6 +810,8 @@ UwbConnector::DispatchCallbacks(::uwb::protocol::fira::UwbNotificationData uwbNo
     constexpr auto getSessionStatusChangedCallback = [](auto&& callbacks) {
         return callbacks->OnSessionStatusChanged;
     };
+
+    LOG_DEBUG << "received notification: " << ToString(uwbNotificationData);
 
     std::visit([this](auto&& arg) {
         using ValueType = std::decay_t<decltype(arg)>;

--- a/windows/devices/uwb/UwbConnector.cxx
+++ b/windows/devices/uwb/UwbConnector.cxx
@@ -537,6 +537,8 @@ UwbConnector::SetApplicationConfigurationParameters(uint32_t sessionId, std::vec
 void
 UwbConnector::HandleNotifications(std::stop_token stopToken)
 {
+    LOG_INFO << "uwb notification listener started for device " << DeviceName();
+
     auto handleDriver = m_notificationHandleDriver;
 
     while (!stopToken.stop_requested()) {
@@ -608,6 +610,8 @@ UwbConnector::HandleNotifications(std::stop_token stopToken)
             });
         }
     }
+
+    LOG_INFO << "uwb notification listener stopped for device " << DeviceName();
 }
 
 std::vector<std::shared_ptr<::uwb::UwbRegisteredDeviceEventCallbacks>>

--- a/windows/devices/uwb/UwbConnector.cxx
+++ b/windows/devices/uwb/UwbConnector.cxx
@@ -613,6 +613,8 @@ UwbConnector::HandleNotifications(std::stop_token stopToken)
 std::vector<std::shared_ptr<::uwb::UwbRegisteredDeviceEventCallbacks>>
 UwbConnector::GetResolvedDeviceEventCallbacks()
 {
+    std::lock_guard eventCallbacksLockExclusive{ m_eventCallbacksGate };
+
     std::vector<std::shared_ptr<::uwb::UwbRegisteredDeviceEventCallbacks>> deviceEventCallbacks;
     deviceEventCallbacks.reserve(std::size(m_deviceEventCallbacks));
 

--- a/windows/devices/uwb/UwbDevice.cxx
+++ b/windows/devices/uwb/UwbDevice.cxx
@@ -191,3 +191,15 @@ UwbDevice::IsEqual(const ::uwb::UwbDevice& other) const noexcept
     const auto& rhs = static_cast<const windows::devices::uwb::UwbDevice&>(other);
     return (this->DeviceName() == rhs.DeviceName());
 }
+
+std::shared_ptr<IUwbDeviceDdiConnector>
+UwbDevice::GetDeviceDdiConnector() noexcept
+{
+    return m_uwbDeviceConnector;
+}
+
+std::shared_ptr<IUwbSessionDdiConnector> 
+UwbDevice::GetSessionDdiConnector() noexcept
+{
+    return m_uwbSessionConnector;
+}

--- a/windows/devices/uwb/UwbDevice.cxx
+++ b/windows/devices/uwb/UwbDevice.cxx
@@ -50,7 +50,7 @@ UwbDevice::DeviceName() const noexcept
 std::shared_ptr<::uwb::UwbSession>
 UwbDevice::CreateSessionImpl(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks)
 {
-    return std::make_shared<UwbSession>(sessionId, std::move(callbacks), this);
+    return std::make_shared<UwbSession>(sessionId, m_uwbSessionConnector, std::move(callbacks));
 }
 
 std::shared_ptr<::uwb::UwbSession>
@@ -88,7 +88,7 @@ UwbDevice::ResolveSessionImpl(uint32_t sessionId)
 
     // Create an instance of the session.
     auto deviceType = std::get<DeviceType>(applicationConfigurationParameters.front().Value);
-    auto session = std::make_shared<UwbSession>(sessionId, this, deviceType);
+    auto session = std::make_shared<UwbSession>(sessionId, m_uwbSessionConnector, deviceType);
 
     return session;
 }

--- a/windows/devices/uwb/UwbDevice.cxx
+++ b/windows/devices/uwb/UwbDevice.cxx
@@ -50,7 +50,7 @@ UwbDevice::DeviceName() const noexcept
 std::shared_ptr<::uwb::UwbSession>
 UwbDevice::CreateSessionImpl(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks)
 {
-    return std::make_shared<UwbSession>(sessionId, m_uwbSessionConnector, std::move(callbacks));
+    return std::make_shared<UwbSession>(sessionId, shared_from_this(), m_uwbSessionConnector, std::move(callbacks));
 }
 
 std::shared_ptr<::uwb::UwbSession>
@@ -88,7 +88,7 @@ UwbDevice::ResolveSessionImpl(uint32_t sessionId)
 
     // Create an instance of the session.
     auto deviceType = std::get<DeviceType>(applicationConfigurationParameters.front().Value);
-    auto session = std::make_shared<UwbSession>(sessionId, m_uwbSessionConnector, deviceType);
+    auto session = std::make_shared<UwbSession>(sessionId, shared_from_this(), m_uwbSessionConnector, deviceType);
 
     return session;
 }
@@ -198,7 +198,7 @@ UwbDevice::GetDeviceDdiConnector() noexcept
     return m_uwbDeviceConnector;
 }
 
-std::shared_ptr<IUwbSessionDdiConnector> 
+std::shared_ptr<IUwbSessionDdiConnector>
 UwbDevice::GetSessionDdiConnector() noexcept
 {
     return m_uwbSessionConnector;

--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -9,16 +9,16 @@
 #include <wil/result.h>
 
 #include <uwb/protocols/fira/UwbException.hxx>
+#include <windows/devices/uwb/UwbConnector.hxx>
 #include <windows/devices/uwb/UwbCxDdiLrp.hxx>
 #include <windows/devices/uwb/UwbDevice.hxx>
-#include <windows/devices/uwb/UwbConnector.hxx>
 #include <windows/devices/uwb/UwbSession.hxx>
 
 using namespace windows::devices::uwb;
 using namespace ::uwb::protocol::fira;
 
-UwbSession::UwbSession(uint32_t sessionId, std::shared_ptr<IUwbSessionDdiConnector> uwbSessionConnector, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, ::uwb::protocol::fira::DeviceType deviceType) :
-    ::uwb::UwbSession(sessionId, std::move(callbacks), deviceType),
+UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<::uwb::UwbDevice> device, std::shared_ptr<IUwbSessionDdiConnector> uwbSessionConnector, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, ::uwb::protocol::fira::DeviceType deviceType) :
+    ::uwb::UwbSession(sessionId, std::move(device), std::move(callbacks), deviceType),
     m_uwbSessionConnector(std::move(uwbSessionConnector))
 {
     m_registeredCallbacks = std::make_shared<::uwb::UwbRegisteredSessionEventCallbacks>(
@@ -66,8 +66,8 @@ UwbSession::UwbSession(uint32_t sessionId, std::shared_ptr<IUwbSessionDdiConnect
     m_registeredCallbacksToken = m_uwbSessionConnector->RegisterSessionEventCallbacks(m_sessionId, m_registeredCallbacks);
 }
 
-UwbSession::UwbSession(uint32_t sessionId,  std::shared_ptr<IUwbSessionDdiConnector> uwbSessionConnector, ::uwb::protocol::fira::DeviceType deviceType) :
-    UwbSession(sessionId, std::move(uwbSessionConnector), std::weak_ptr<::uwb::UwbSessionEventCallbacks>{}, deviceType)
+UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<::uwb::UwbDevice> device, std::shared_ptr<IUwbSessionDdiConnector> uwbSessionConnector, ::uwb::protocol::fira::DeviceType deviceType) :
+    UwbSession(sessionId, std::move(device), std::move(uwbSessionConnector), std::weak_ptr<::uwb::UwbSessionEventCallbacks>{}, deviceType)
 {}
 
 std::shared_ptr<IUwbSessionDdiConnector>

--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -17,8 +17,9 @@
 using namespace windows::devices::uwb;
 using namespace ::uwb::protocol::fira;
 
-UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, UwbDevice *uwbDevice, ::uwb::protocol::fira::DeviceType deviceType) :
-    ::uwb::UwbSession(sessionId, std::move(callbacks), deviceType)
+UwbSession::UwbSession(uint32_t sessionId, std::shared_ptr<IUwbSessionDdiConnector> uwbSessionConnector, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, ::uwb::protocol::fira::DeviceType deviceType) :
+    ::uwb::UwbSession(sessionId, std::move(callbacks), deviceType),
+    m_uwbSessionConnector(std::move(uwbSessionConnector))
 {
     m_registeredCallbacks = std::make_shared<::uwb::UwbRegisteredSessionEventCallbacks>(
         [this](::uwb::UwbSessionEndReason reason) {
@@ -62,19 +63,17 @@ UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventC
             return callbacks->OnSessionMembershipChanged(this, peersAdded, peersRemoved);
         });
 
-    auto uwbConnector = std::make_shared<UwbConnector>(uwbDevice->DeviceName());
-    m_uwbSessionconnector = uwbConnector;
-    m_registeredCallbacksToken = m_uwbSessionconnector->RegisterSessionEventCallbacks(m_sessionId, m_registeredCallbacks);
+    m_registeredCallbacksToken = m_uwbSessionConnector->RegisterSessionEventCallbacks(m_sessionId, m_registeredCallbacks);
 }
 
-UwbSession::UwbSession(uint32_t sessionId, UwbDevice *uwbDevice, ::uwb::protocol::fira::DeviceType deviceType) :
-    UwbSession(sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks>{}, uwbDevice, deviceType)
+UwbSession::UwbSession(uint32_t sessionId,  std::shared_ptr<IUwbSessionDdiConnector> uwbSessionConnector, ::uwb::protocol::fira::DeviceType deviceType) :
+    UwbSession(sessionId, std::move(uwbSessionConnector), std::weak_ptr<::uwb::UwbSessionEventCallbacks>{}, deviceType)
 {}
 
 std::shared_ptr<IUwbSessionDdiConnector>
 UwbSession::GetUwbSessionConnector() noexcept
 {
-    return m_uwbSessionconnector;
+    return m_uwbSessionConnector;
 }
 
 void
@@ -85,7 +84,7 @@ UwbSession::ConfigureImpl(const std::vector<::uwb::protocol::fira::UwbApplicatio
     UwbSessionType sessionType = UwbSessionType::RangingSession;
 
     // Request a new session from the driver.
-    auto sessionInitResultFuture = m_uwbSessionconnector->SessionInitialize(m_sessionId, sessionType);
+    auto sessionInitResultFuture = m_uwbSessionConnector->SessionInitialize(m_sessionId, sessionType);
     if (!sessionInitResultFuture.valid()) {
         PLOG_ERROR << "failed to initialize session";
         throw UwbException(UwbStatusGeneric::Rejected);
@@ -98,7 +97,7 @@ UwbSession::ConfigureImpl(const std::vector<::uwb::protocol::fira::UwbApplicatio
     }
 
     // Set the application configuration parameters for the session.
-    auto setAppConfigParamsFuture = m_uwbSessionconnector->SetApplicationConfigurationParameters(m_sessionId, configParams);
+    auto setAppConfigParamsFuture = m_uwbSessionConnector->SetApplicationConfigurationParameters(m_sessionId, configParams);
     if (!setAppConfigParamsFuture.valid()) {
         PLOG_ERROR << "failed to set the application configuration parameters";
         throw UwbException(UwbStatusGeneric::Rejected);
@@ -127,7 +126,7 @@ UwbSession::StartRangingImpl()
     // TODO: interface function should be modified to return a UwbStatus, and this value will be returned.
     UwbStatus status;
     uint32_t sessionId = GetId();
-    auto resultFuture = m_uwbSessionconnector->SessionRangingStart(sessionId);
+    auto resultFuture = m_uwbSessionConnector->SessionRangingStart(sessionId);
     if (!resultFuture.valid()) {
         PLOG_ERROR << "failed to start ranging for session id " << sessionId;
         status = UwbStatusGeneric::Failed;
@@ -150,7 +149,7 @@ UwbSession::StopRangingImpl()
     // TODO: interface function should be modified to return a UwbStatus, and this value will be returned.
     UwbStatus status;
     uint32_t sessionId = GetId();
-    auto resultFuture = m_uwbSessionconnector->SessionRangingStop(sessionId);
+    auto resultFuture = m_uwbSessionConnector->SessionRangingStop(sessionId);
     if (!resultFuture.valid()) {
         PLOG_ERROR << "failed to stop ranging for session id " << sessionId;
         status = UwbStatusGeneric::Failed;
@@ -233,7 +232,7 @@ UwbSession::GetApplicationConfigurationParametersImpl()
     constexpr auto allParameterTypesArray = magic_enum::enum_values<UwbApplicationConfigurationParameterType>();
     std::vector<UwbApplicationConfigurationParameterType> applicationConfigurationParameterTypes(std::cbegin(allParameterTypesArray), std::cend(allParameterTypesArray));
 
-    auto resultFuture = m_uwbSessionconnector->GetApplicationConfigurationParameters(sessionId, applicationConfigurationParameterTypes);
+    auto resultFuture = m_uwbSessionConnector->GetApplicationConfigurationParameters(sessionId, applicationConfigurationParameterTypes);
     if (!resultFuture.valid()) {
         PLOG_ERROR << "failed to obtain application configuration parameters for session id " << sessionId;
         throw UwbException(UwbStatusGeneric::Failed);
@@ -259,7 +258,7 @@ UwbSession::GetSessionStateImpl()
 {
     uint32_t sessionId = GetId();
 
-    auto resultFuture = m_uwbSessionconnector->SessionGetState(sessionId);
+    auto resultFuture = m_uwbSessionConnector->SessionGetState(sessionId);
     if (!resultFuture.valid()) {
         PLOG_ERROR << "failed to obtain session state for session id " << sessionId;
         throw UwbException(UwbStatusGeneric::Failed);
@@ -284,7 +283,7 @@ void
 UwbSession::DestroyImpl()
 {
     uint32_t sessionId = GetId();
-    auto resultFuture = m_uwbSessionconnector->SessionDeinitialize(sessionId);
+    auto resultFuture = m_uwbSessionConnector->SessionDeinitialize(sessionId);
     if (!resultFuture.valid()) {
         PLOG_ERROR << "failed to issue device deinitialization request for session id " << sessionId;
         throw UwbException(UwbStatusGeneric::Rejected);

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
@@ -134,6 +134,23 @@ private:
     virtual bool
     InitializeImpl() override;
 
+protected:
+    /**
+     * @brief Get the device DDI connector object (derived classes only).
+     *
+     * @return std::shared_ptr<IUwbDeviceDdiConnector>
+     */
+    std::shared_ptr<IUwbDeviceDdiConnector>
+    GetDeviceDdiConnector() noexcept;
+
+    /**
+     * @brief Get the session DDI connector object (derived classes only).
+     *
+     * @return std::shared_ptr<IUwbSessionDdiConnector>
+     */
+    std::shared_ptr<IUwbSessionDdiConnector>
+    GetSessionDdiConnector() noexcept;
+
 private:
     const std::string m_deviceName;
     std::shared_ptr<IUwbDeviceDdiConnector> m_uwbDeviceConnector;

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
@@ -27,21 +27,23 @@ public:
      * @brief Construct a new UwbSession object without callbacks.
      *
      * @param sessionId The session identifier.
+     * @param device Reference to the parent device.
      * @param uwbSessionConnector The connector used to communicate with the device.
      * @param deviceType The device type of the host in this session.
      */
-    UwbSession(uint32_t sessionId, std::shared_ptr<IUwbSessionDdiConnector> uwbSessionConnector, ::uwb::protocol::fira::DeviceType deviceType = ::uwb::protocol::fira::DeviceType::Controller);
+    UwbSession(uint32_t sessionId, std::weak_ptr<::uwb::UwbDevice> device, std::shared_ptr<IUwbSessionDdiConnector> uwbSessionConnector, ::uwb::protocol::fira::DeviceType deviceType = ::uwb::protocol::fira::DeviceType::Controller);
 
     /**
      * @brief Construct a new UwbSession object.
      * This also registers the callbacks with the UwbConnector
-     * 
+     *
      * @param sessionId The session identifier.
+     * @param device Reference to the parent device.
      * @param uwbSessionConnector The connector used to communicate with the device.
      * @param callbacks The event callback instance.
      * @param deviceType The device type of the host in this session.
      */
-    UwbSession(uint32_t sessionId, std::shared_ptr<IUwbSessionDdiConnector> uwbSessionConnector, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, ::uwb::protocol::fira::DeviceType deviceType = ::uwb::protocol::fira::DeviceType::Controller);
+    UwbSession(uint32_t sessionId, std::weak_ptr<::uwb::UwbDevice> device, std::shared_ptr<IUwbSessionDdiConnector> uwbSessionConnector, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, ::uwb::protocol::fira::DeviceType deviceType = ::uwb::protocol::fira::DeviceType::Controller);
 
 private:
     /**

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
@@ -27,19 +27,21 @@ public:
      * @brief Construct a new UwbSession object without callbacks.
      *
      * @param sessionId The session identifier.
-     * @param uwbDevice The uwb device tied to the session.
+     * @param uwbSessionConnector The connector used to communicate with the device.
+     * @param deviceType The device type of the host in this session.
      */
-    UwbSession(uint32_t sessionId, UwbDevice* uwbDevice, ::uwb::protocol::fira::DeviceType deviceType = ::uwb::protocol::fira::DeviceType::Controller);
+    UwbSession(uint32_t sessionId, std::shared_ptr<IUwbSessionDdiConnector> uwbSessionConnector, ::uwb::protocol::fira::DeviceType deviceType = ::uwb::protocol::fira::DeviceType::Controller);
 
     /**
      * @brief Construct a new UwbSession object.
      * This also registers the callbacks with the UwbConnector
-     *
+     * 
      * @param sessionId The session identifier.
+     * @param uwbSessionConnector The connector used to communicate with the device.
      * @param callbacks The event callback instance.
-     * @param uwbDevice The uwb device tied to the session.
+     * @param deviceType The device type of the host in this session.
      */
-    UwbSession(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, UwbDevice* uwbDevice, ::uwb::protocol::fira::DeviceType deviceType = ::uwb::protocol::fira::DeviceType::Controller);
+    UwbSession(uint32_t sessionId, std::shared_ptr<IUwbSessionDdiConnector> uwbSessionConnector, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, ::uwb::protocol::fira::DeviceType deviceType = ::uwb::protocol::fira::DeviceType::Controller);
 
 private:
     /**
@@ -100,7 +102,7 @@ protected:
     GetUwbSessionConnector() noexcept;
 
 private:
-    std::shared_ptr<IUwbSessionDdiConnector> m_uwbSessionconnector;
+    std::shared_ptr<IUwbSessionDdiConnector> m_uwbSessionConnector;
     std::shared_ptr<::uwb::UwbRegisteredSessionEventCallbacks> m_registeredCallbacks;
     ::uwb::RegisteredCallbackToken* m_registeredCallbacksToken;
 };

--- a/windows/devices/uwbsimulator/UwbDeviceSimulator.cxx
+++ b/windows/devices/uwbsimulator/UwbDeviceSimulator.cxx
@@ -39,7 +39,7 @@ UwbDeviceSimulator::Initialize()
 std::shared_ptr<::uwb::UwbSession>
 UwbDeviceSimulator::CreateSessionImpl(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks)
 {
-    return std::make_shared<UwbSessionSimulator>(sessionId, GetSessionDdiConnector(), std::move(callbacks), m_uwbDeviceSimulatorConnector);
+    return std::make_shared<UwbSessionSimulator>(sessionId, shared_from_this(), GetSessionDdiConnector(), std::move(callbacks), m_uwbDeviceSimulatorConnector);
 }
 
 UwbSimulatorCapabilities

--- a/windows/devices/uwbsimulator/UwbDeviceSimulator.cxx
+++ b/windows/devices/uwbsimulator/UwbDeviceSimulator.cxx
@@ -39,7 +39,7 @@ UwbDeviceSimulator::Initialize()
 std::shared_ptr<::uwb::UwbSession>
 UwbDeviceSimulator::CreateSessionImpl(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks)
 {
-    return std::make_shared<UwbSessionSimulator>(sessionId, std::move(callbacks), this, m_uwbDeviceSimulatorConnector);
+    return std::make_shared<UwbSessionSimulator>(sessionId, GetSessionDdiConnector(), std::move(callbacks), m_uwbDeviceSimulatorConnector);
 }
 
 UwbSimulatorCapabilities

--- a/windows/devices/uwbsimulator/UwbSessionSimulator.cxx
+++ b/windows/devices/uwbsimulator/UwbSessionSimulator.cxx
@@ -3,7 +3,7 @@
 
 using namespace windows::devices::uwb::simulator;
 
-UwbSessionSimulator::UwbSessionSimulator(uint32_t sessionId, std::shared_ptr<IUwbSessionDdiConnector> uwbSessionConnector, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, std::shared_ptr<UwbDeviceSimulatorConnector> uwbDeviceSimulatorConnector) :
-    UwbSession(sessionId, std::move(uwbSessionConnector), std::move(callbacks)),
+UwbSessionSimulator::UwbSessionSimulator(uint32_t sessionId, std::weak_ptr<::uwb::UwbDevice> device, std::shared_ptr<IUwbSessionDdiConnector> uwbSessionConnector, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, std::shared_ptr<UwbDeviceSimulatorConnector> uwbDeviceSimulatorConnector) :
+    UwbSession(sessionId, std::move(device), std::move(uwbSessionConnector), std::move(callbacks)),
     m_uwbDeviceSimulatorConnector(std::move(uwbDeviceSimulatorConnector))
 {}

--- a/windows/devices/uwbsimulator/UwbSessionSimulator.cxx
+++ b/windows/devices/uwbsimulator/UwbSessionSimulator.cxx
@@ -3,7 +3,7 @@
 
 using namespace windows::devices::uwb::simulator;
 
-UwbSessionSimulator::UwbSessionSimulator(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, UwbDevice* uwbDevice, std::shared_ptr<UwbDeviceSimulatorConnector> uwbDeviceSimulatorConnector) :
-    UwbSession(sessionId, std::move(callbacks), uwbDevice),
+UwbSessionSimulator::UwbSessionSimulator(uint32_t sessionId, std::shared_ptr<IUwbSessionDdiConnector> uwbSessionConnector, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, std::shared_ptr<UwbDeviceSimulatorConnector> uwbDeviceSimulatorConnector) :
+    UwbSession(sessionId, std::move(uwbSessionConnector), std::move(callbacks)),
     m_uwbDeviceSimulatorConnector(std::move(uwbDeviceSimulatorConnector))
 {}

--- a/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbSessionSimulator.hxx
+++ b/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbSessionSimulator.hxx
@@ -14,11 +14,25 @@
 
 namespace windows::devices::uwb::simulator
 {
+/**
+ * @brief Simulator driver session.
+ *
+ * This class is used to represent simulator driver specific session context.
+ */
 class UwbSessionSimulator :
     public windows::devices::uwb::UwbSession
 {
 public:
-    UwbSessionSimulator(uint32_t sessionId, std::shared_ptr<IUwbSessionDdiConnector> uwbSessionConnector, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, std::shared_ptr<UwbDeviceSimulatorConnector> uwbDeviceSimulatorConnector);
+    /**
+     * @brief Construct a new UwbSessionSimulator object.
+     *
+     * @param sessionId The session identifier.
+     * @param device Reference to the parent device.
+     * @param uwbSessionConnector The connector used to communicate with the uwb device.
+     * @param callbacks The event callback instance.
+     * @param uwbDeviceSimulatorConnector The connector used to communicate with the simulator device.
+     */
+    UwbSessionSimulator(uint32_t sessionId, std::weak_ptr<::uwb::UwbDevice> device, std::shared_ptr<IUwbSessionDdiConnector> uwbSessionConnector, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, std::shared_ptr<UwbDeviceSimulatorConnector> uwbDeviceSimulatorConnector);
 
     virtual ~UwbSessionSimulator() = default;
 

--- a/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbSessionSimulator.hxx
+++ b/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbSessionSimulator.hxx
@@ -18,7 +18,7 @@ class UwbSessionSimulator :
     public windows::devices::uwb::UwbSession
 {
 public:
-    UwbSessionSimulator(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, UwbDevice* uwbDevice, std::shared_ptr<UwbDeviceSimulatorConnector> uwbDeviceSimulatorConnector);
+    UwbSessionSimulator(uint32_t sessionId, std::shared_ptr<IUwbSessionDdiConnector> uwbSessionConnector, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, std::shared_ptr<UwbDeviceSimulatorConnector> uwbDeviceSimulatorConnector);
 
     virtual ~UwbSessionSimulator() = default;
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Ensure a single `UwbConnector` instance is used for processing notifications from the driver.

### Technical Details

* Modify Windows `UwbSession` implementation to accept a `std::shared_ptr<IUwbSessionDdiConnector>` instead of creating another distinct instance using the device name. The instance passed is expected to come from the `UwbDevice`.
* Modify top-level `UwbSession` to accept a `std::weak_ptr<UwbDevice>` so that it can reference its parent.
* Expose accessor method for resolving the parent `UwbDevice` from a `UwbSession`, with optional support to resolve it as the derived type. 
* Prevent top-level `UwbDevice` objects from being created outside of a derived instance. This is to allow safe usage of `std::enable_shared_from_this<>`.

### Test Results

* Ran end-to-end ranging scenario, verified all events were delivered.

### Reviewer Focus

The Windows `UwbSession` constructor was modified to take a `std::shared_ptr<IUwbSessionDdiConnector>` instead of creating a new instance. While this works perfectly fine, the source of the instance could be anything, yet we really want the instance to come from the `UwbDevice`. The parent `UwbDevice` is passed into `UwbSession` now anyway, so the session could easily obtain the connector instance directly from it instead. The only requirement would be to change the connector accessor methods in `UwbDevice` from `protected` to `public`. This feels wrong since the connector is a detail of `UwbDevice` and so should not be exposed from the public interface. Need to consider this a little further.

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
