### PR TITLE
Add support for multiple controlees in nocli

### DIFF
--- a/lib/uwb/UwbMacAddress.cxx
+++ b/lib/uwb/UwbMacAddress.cxx
@@ -86,6 +86,35 @@ UwbMacAddress::Random(UwbMacAddressType type)
 }
 
 /* static */
+std::optional<std::unordered_set<UwbMacAddress>>
+UwbMacAddress::MacAddressesFromString(const std::string& addressesString, UwbMacAddressType addressType)
+{
+    const std::regex singleShortRegex(R"(([0-9A-Fa-f]{2}:){1}([0-9A-Fa-f]{2}))");
+    const std::regex singleExtendedRegex(R"((([0-9A-Fa-f]{2}:){7}[0-9A-Fa-f]{2}))");
+
+    const std::regex shortRegex("^([0-9A-Fa-f]{2}:){1}([0-9A-Fa-f]{2})(,([0-9A-Fa-f]{2}:){1}([0-9A-Fa-f]{2}))*$");
+    const std::regex extendedRegex("^([0-9A-Fa-f]{2}:){7}([0-9A-Fa-f]{2})(,([0-9A-Fa-f]{2}:){7}([0-9A-Fa-f]{2}))*$");
+
+    if ((addressType == UwbMacAddressType::Short && !std::regex_match(addressesString, shortRegex)) ||
+        (addressType == UwbMacAddressType::Extended && !std::regex_match(addressesString, extendedRegex))) {
+        return std::nullopt;
+    }
+
+    std::unordered_set<UwbMacAddress> macAddresses{};
+    std::stringstream ss(addressesString);
+
+    std::string macAddressString;
+    while (std::getline(ss, macAddressString, ',')) {
+        auto macAddress = UwbMacAddress::FromString(macAddressString, addressType);
+        if (macAddress.has_value()) {
+            macAddresses.insert(macAddress.value());
+        }
+    }
+
+    return macAddresses;
+}
+
+/* static */
 std::optional<UwbMacAddress>
 UwbMacAddress::FromString(const std::string& addressString, UwbMacAddressType addressType)
 {

--- a/lib/uwb/UwbMacAddress.cxx
+++ b/lib/uwb/UwbMacAddress.cxx
@@ -86,32 +86,6 @@ UwbMacAddress::Random(UwbMacAddressType type)
 }
 
 /* static */
-std::optional<std::unordered_set<UwbMacAddress>>
-UwbMacAddress::MacAddressesFromString(const std::string& addressesString, UwbMacAddressType addressType)
-{
-    const std::regex shortRegex("^([0-9A-Fa-f]{2}:){1}([0-9A-Fa-f]{2})(,([0-9A-Fa-f]{2}:){1}([0-9A-Fa-f]{2}))*$");
-    const std::regex extendedRegex("^([0-9A-Fa-f]{2}:){7}([0-9A-Fa-f]{2})(,([0-9A-Fa-f]{2}:){7}([0-9A-Fa-f]{2}))*$");
-
-    if ((addressType == UwbMacAddressType::Short && !std::regex_match(addressesString, shortRegex)) ||
-        (addressType == UwbMacAddressType::Extended && !std::regex_match(addressesString, extendedRegex))) {
-        return std::nullopt;
-    }
-
-    std::unordered_set<UwbMacAddress> macAddresses{};
-    std::stringstream ss(addressesString);
-
-    std::string macAddressString;
-    while (std::getline(ss, macAddressString, ',')) {
-        auto macAddress = UwbMacAddress::FromString(macAddressString, addressType);
-        if (macAddress.has_value()) {
-            macAddresses.insert(macAddress.value());
-        }
-    }
-
-    return macAddresses;
-}
-
-/* static */
 std::optional<UwbMacAddress>
 UwbMacAddress::FromString(const std::string& addressString, UwbMacAddressType addressType)
 {

--- a/lib/uwb/UwbMacAddress.cxx
+++ b/lib/uwb/UwbMacAddress.cxx
@@ -89,9 +89,6 @@ UwbMacAddress::Random(UwbMacAddressType type)
 std::optional<std::unordered_set<UwbMacAddress>>
 UwbMacAddress::MacAddressesFromString(const std::string& addressesString, UwbMacAddressType addressType)
 {
-    const std::regex singleShortRegex(R"(([0-9A-Fa-f]{2}:){1}([0-9A-Fa-f]{2}))");
-    const std::regex singleExtendedRegex(R"((([0-9A-Fa-f]{2}:){7}[0-9A-Fa-f]{2}))");
-
     const std::regex shortRegex("^([0-9A-Fa-f]{2}:){1}([0-9A-Fa-f]{2})(,([0-9A-Fa-f]{2}:){1}([0-9A-Fa-f]{2}))*$");
     const std::regex extendedRegex("^([0-9A-Fa-f]{2}:){7}([0-9A-Fa-f]{2})(,([0-9A-Fa-f]{2}:){7}([0-9A-Fa-f]{2}))*$");
 

--- a/lib/uwb/include/uwb/UwbMacAddress.hxx
+++ b/lib/uwb/include/uwb/UwbMacAddress.hxx
@@ -350,16 +350,6 @@ public:
     Random(UwbMacAddressType type);
 
     /**
-     * @brief Creates a set of UwbMacAddress from a comma-delimited string of multiple mac addresses.
-     *
-     * @param addressesString The comma-delimited string of mac addresses.
-     * @param addressType The type of each mac address.
-     * @return std::optional<std::unordered_set<UwbMacAddress>> The constructed optional set of UwbMacAddress.
-     */
-    static std::optional<std::unordered_set<UwbMacAddress>>
-    MacAddressesFromString(const std::string& addressesString, UwbMacAddressType addressType);
-
-    /**
      * @brief Creates a UwbMacAddress from a string representation of a mac address.
      *
      * @param addressString The mac address string.

--- a/lib/uwb/include/uwb/UwbMacAddress.hxx
+++ b/lib/uwb/include/uwb/UwbMacAddress.hxx
@@ -13,6 +13,7 @@
 #include <span>
 #include <string>
 #include <type_traits>
+#include <unordered_set>
 #include <variant>
 
 #include <notstd/hash.hxx>
@@ -349,8 +350,18 @@ public:
     Random(UwbMacAddressType type);
 
     /**
+     * @brief Creates a set of UwbMacAddress from a comma-delimited string of multiple mac addresses.
+     *
+     * @param addressesString The comma-delimited string of mac addresses.
+     * @param addressType The type of each mac address.
+     * @return std::optional<std::unordered_set<UwbMacAddress>> The constructed optional set of UwbMacAddress.
+     */
+    static std::optional<std::unordered_set<UwbMacAddress>>
+    MacAddressesFromString(const std::string& addressesString, UwbMacAddressType addressType);
+
+    /**
      * @brief Creates a UwbMacAddress from a string representation of a mac address.
-     * 
+     *
      * @param addressString The mac address string.
      * @param addressType The type of mac address.
      * @return std::optional<UwbMacAddress> The constructed optional UwbMacAddress.

--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -79,6 +79,7 @@ constexpr uint16_t DefaultRangeDataNotificationProximityNear = 0;
 constexpr uint16_t DefaultRangeDataNotificationProximityFar = 20000;
 constexpr uint32_t MinimumUwbInitiationTime = 0;
 constexpr uint32_t MaximumUwbInitiationTime = 10000;
+constexpr size_t DestinationMacAddressesCountWhenControlee = 1;
 
 /**
  * @brief See FiRa Consortium UWB MAC Technical Requirements v1.3.0, Section

--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -561,6 +561,16 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
         .Value = std::move(uwbMacAddressSetSingleAddress),
     };
 
+    // UWB_APP_CONFIG_PARAM_TYPE_DST_MAC_ADDRESS (multiple addresses)
+    const std::unordered_set<::uwb::UwbMacAddress> uwbMacAddressSetMultipleAddresses{
+        std::array<uint8_t, ::uwb::UwbMacAddressLength::Short>{ 0xAA, 0xBB },
+        std::array<uint8_t, ::uwb::UwbMacAddressLength::Short>{ 0x12, 0x34 },
+    };
+    const UwbApplicationConfigurationParameter parameterUwbMacAddressSetMultipleAddresses = {
+        .Type = UwbApplicationConfigurationParameterType::DestinationMacAddresses,
+        .Value = std::move(uwbMacAddressSetMultipleAddresses),
+    };
+
     constexpr UwbSetApplicationConfigurationParameterStatus uwbSetApplicationConfigurationParameterStatusAoaResulReq{
         .Status = UwbStatusOk,
         .ParameterType = UwbApplicationConfigurationParameterType::AoAResultRequest,
@@ -626,6 +636,11 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
     SECTION("UwbApplicationConfigurationParameter std::unordered_set<::uwb::UwbMacAddress> (single address) is stable")
     {
         test::ValidateRoundtrip(parameterUwbMacAddressSetSingleAddress);
+    }
+
+    SECTION("UwbApplicationConfigurationParameter std::unordered_set<::uwb::UwbMacAddress> (multiple addresses) is stable")
+    {
+        test::ValidateRoundtrip(parameterUwbMacAddressSetMultipleAddresses);
     }
 
     SECTION("std::vector<UwbApplicationConfigurationParameter> is stable")

--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -49,6 +49,23 @@ ValidateRoundtrip(const NeutralT& instance)
 }
 
 /**
+ * @brief Validate a neutral type round-trip conversion works.
+ * 
+ * This overload is used specifically for DestinationMacAddresses.
+ * 
+ * @tparam NeutralT
+ * @param instance An instance of the neutral type to validate.
+ * @param macAddressMode
+ */
+template <typename NeutralT>
+void
+ValidateRoundtrip(const NeutralT& instance, const ::uwb::UwbMacAddressType macAddressMode)
+{
+    auto instanceCopy = UwbCxDdi::To(UwbCxDdi::From(instance), macAddressMode);
+    REQUIRE(instanceCopy == instance);
+}
+
+/**
  * @brief Generate a random integral value.
  *
  * @tparam ReturnT
@@ -635,12 +652,12 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
 
     SECTION("UwbApplicationConfigurationParameter std::unordered_set<::uwb::UwbMacAddress> (single address) is stable")
     {
-        test::ValidateRoundtrip(parameterUwbMacAddressSetSingleAddress);
+        test::ValidateRoundtrip(parameterUwbMacAddressSetSingleAddress, ::uwb::UwbMacAddressType::Short);
     }
 
     SECTION("UwbApplicationConfigurationParameter std::unordered_set<::uwb::UwbMacAddress> (multiple addresses) is stable")
     {
-        test::ValidateRoundtrip(parameterUwbMacAddressSetMultipleAddresses);
+        test::ValidateRoundtrip(parameterUwbMacAddressSetMultipleAddresses, ::uwb::UwbMacAddressType::Short);
     }
 
     SECTION("std::vector<UwbApplicationConfigurationParameter> is stable")

--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -50,9 +50,9 @@ ValidateRoundtrip(const NeutralT& instance)
 
 /**
  * @brief Validate a neutral type round-trip conversion works.
- * 
+ *
  * This overload is used specifically for DestinationMacAddresses.
- * 
+ *
  * @tparam NeutralT
  * @param instance An instance of the neutral type to validate.
  * @param macAddressMode

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -257,14 +257,24 @@ ValidateNonEnumParameterValues(NearObjectCliData& cliData)
         }
     }
 
-    // DestinationMacAddresses (mandatory)
-    if (parametersData.deviceType == DeviceType::Controller) {
-        if (parametersData.destinationMacAddresses.value().size() != parametersData.numberOfControlees) {
-            std::cerr << "Invalid number of DestinationMacAddresses. Should be equal to NumberOfControlees when device is a Controller." << std::endl;
-        }
+    // DeviceMacAddress (mandatory) and DestinationMacAddresses (mandatory)
+    const auto macAddressType = parametersData.macAddressMode == uwb::UwbMacAddressType::Extended ? uwb::UwbMacAddressType::Extended : uwb::UwbMacAddressType::Short;
+
+    if (!parametersData.deviceMacAddress.has_value()) {
+        std::cerr << "Invalid DeviceMacAddress. Does not match format of MacAddressMode: " << ToString(macAddressType) << std::endl;
+    }
+
+    if (!parametersData.destinationMacAddresses.has_value()) {
+        std::cerr << "Invalid DestinationMacAddresses. Does not match format of MacAddressMode: " << ToString(macAddressType) << std::endl;
     } else {
-        if (parametersData.destinationMacAddresses.value().size() != DestinationMacAddressesCountWhenControlee) {
-            std::cerr << "Invalid number of DestinationMacAddresses. Should only contain " << DestinationMacAddressesCountWhenControlee << " mac address for the Controller when device is a Controlee." << std::endl;
+        if (parametersData.deviceType == DeviceType::Controller) {
+            if (parametersData.destinationMacAddresses.value().size() != parametersData.numberOfControlees) {
+                std::cerr << "Invalid number of DestinationMacAddresses. Should be equal to NumberOfControlees when device is a Controller." << std::endl;
+            }
+        } else {
+            if (parametersData.destinationMacAddresses.value().size() != DestinationMacAddressesCountWhenControlee) {
+                std::cerr << "Invalid number of DestinationMacAddresses. Should only contain " << DestinationMacAddressesCountWhenControlee << " mac address for the Controller when device is a Controlee." << std::endl;
+            }
         }
     }
 

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -744,7 +744,7 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App* parent)
         dstMacAddressDescription = "Comma-delimited array with 8-byte hexadecimal values, colon-delimited. Extended MAC address(es) of other device(s). If device is Controller, list NumberOfControlees mac addresses. If device is Controlee, list Controller mac address";
     }
     rangeStartApp->add_option("--DeviceMacAddress", m_cliData->deviceMacAddressString, deviceMacAddressDescription)->capture_default_str()->required();
-    rangeStartApp->add_option("--DestinationMacAddress", m_cliData->destinationMacAddressString, dstMacAddressDescription)->capture_default_str()->required();
+    rangeStartApp->add_option("--DestinationMacAddresses", m_cliData->destinationMacAddressesString, dstMacAddressDescription)->capture_default_str()->required();
     detail::AddEnumOption(rangeStartApp, applicationConfigurationParametersData.deviceType, true);
 
     // List remaining params
@@ -803,7 +803,7 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App* parent)
         // Set DeviceMacAddress and DestinationMacAddresses
         const auto macAddressType = applicationConfigurationParametersData.macAddressMode == uwb::UwbMacAddressType::Extended ? uwb::UwbMacAddressType::Extended : uwb::UwbMacAddressType::Short;
         applicationConfigurationParametersData.deviceMacAddress = uwb::UwbMacAddress::FromString(m_cliData->deviceMacAddressString, macAddressType);
-        applicationConfigurationParametersData.destinationMacAddresses = uwb::UwbMacAddress::MacAddressesFromString(m_cliData->destinationMacAddressString, macAddressType);
+        applicationConfigurationParametersData.destinationMacAddresses = uwb::UwbMacAddress::MacAddressesFromString(m_cliData->destinationMacAddressesString, macAddressType);
 
         m_cliData->RangingParameters.ApplicationConfigurationParameters = detail::ProcessApplicationConfigurationParameters(*m_cliData);
         RegisterCliAppWithOperation(rangeStartApp);

--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -249,21 +249,23 @@ ValidateNonEnumParameterValues(NearObjectCliData& cliData)
     // NumberOfControlees (mandatory)
     if (parametersData.multiNodeMode == MultiNodeMode::Unicast) {
         if (parametersData.numberOfControlees != MinimumNumberOfControlees) {
-            std::cerr << "Invalid NumberOfControlees. Only " << +MinimumNumberOfControlees << " controlee expected in Unicast mode " << std::endl;
+            std::cerr << "Invalid NumberOfControlees. Only " << +MinimumNumberOfControlees << " controlee expected in Unicast mode." << std::endl;
         }
     } else {
         if (parametersData.numberOfControlees < MinimumNumberOfControlees) {
-            std::cerr << "Invalid NumberOfControlees. At least " << +MinimumNumberOfControlees << " controlees expected" << std::endl;
+            std::cerr << "Invalid NumberOfControlees. At least " << +MinimumNumberOfControlees << " controlees expected." << std::endl;
         }
     }
 
-    // DeviceMacAddress (mandatory) and DestinationMacAddresses (mandatory)
-    const auto macAddressType = parametersData.macAddressMode == uwb::UwbMacAddressType::Extended ? uwb::UwbMacAddressType::Extended : uwb::UwbMacAddressType::Short;
-    parametersData.deviceMacAddress = uwb::UwbMacAddress::FromString(cliData.deviceMacAddressString, macAddressType);
-    parametersData.destinationMacAddresses.emplace();
-    // TODO: Insert the correct Controlee mac address rather than simply inserting the entire destinationMacAddressString
-    for (auto i = 0; i < parametersData.numberOfControlees; i++) {
-        parametersData.destinationMacAddresses.value().insert(uwb::UwbMacAddress::FromString(cliData.destinationMacAddressString, macAddressType).value());
+    // DestinationMacAddresses (mandatory)
+    if (parametersData.deviceType == DeviceType::Controller) {
+        if (parametersData.destinationMacAddresses.value().size() != parametersData.numberOfControlees) {
+            std::cerr << "Invalid number of DestinationMacAddresses. Should be equal to NumberOfControlees when device is a Controller." << std::endl;
+        }
+    } else {
+        if (parametersData.destinationMacAddresses.value().size() != DestinationMacAddressesCountWhenControlee) {
+            std::cerr << "Invalid number of DestinationMacAddresses. Should only contain " << DestinationMacAddressesCountWhenControlee << " mac address for the Controller when device is a Controlee." << std::endl;
+        }
     }
 
     // RangeDataNotificationProximityNear
@@ -359,7 +361,9 @@ ValidateNonEnumParameterValues(NearObjectCliData& cliData)
     // ResultReportConfig
     constexpr int resultReportConfigurationSize = magic_enum::enum_count<ResultReportConfiguration>();
     auto IsValidResultReportConfigurationString = [resultReportConfigurationSize](const std::string& resultReportConfigurationString) {
-        if (resultReportConfigurationString.length() != resultReportConfigurationSize) {
+        if (resultReportConfigurationString.empty()) {
+            return false;
+        } else if (!resultReportConfigurationString.empty() && resultReportConfigurationString.length() != resultReportConfigurationSize) {
             std::cerr << "Invalid ResultReportConfiguration length" << std::endl;
             return false;
         }
@@ -454,9 +458,7 @@ ProcessApplicationConfigurationParameters(NearObjectCliData& cliData)
             } else if constexpr (std::is_same_v<ParameterValueT, ::uwb::UwbMacAddress>) {
                 oss << ToString(arg);
             } else if constexpr (std::is_same_v<ParameterValueT, std::unordered_set<::uwb::UwbMacAddress>>) {
-                for (const auto& address : arg) {
-                    oss << ToString(arg);
-                }
+                oss << ToString(arg);
             } else if constexpr (std::is_same_v<ParameterValueT, std::unordered_set<ResultReportConfiguration>>) {
                 oss << ToString(arg);
             } else if constexpr (std::is_same_v<ParameterValueT, std::array<uint8_t, StaticStsInitializationVectorLength>>) {
@@ -786,6 +788,13 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App* parent)
     rangeStartApp->add_option("--StaticStsInitializationVector", applicationConfigurationParametersData.staticStsIv, "6-byte hexadecimal value, colon-delimited. Vendor-defined static STS initialization vector, e.g. 11:22:33:44:55:66")->delimiter(':');
 
     rangeStartApp->parse_complete_callback([this, rangeStartApp] {
+        auto& applicationConfigurationParametersData = m_cliData->applicationConfigurationParametersData;
+
+        // Set DeviceMacAddress and DestinationMacAddresses
+        const auto macAddressType = applicationConfigurationParametersData.macAddressMode == uwb::UwbMacAddressType::Extended ? uwb::UwbMacAddressType::Extended : uwb::UwbMacAddressType::Short;
+        applicationConfigurationParametersData.deviceMacAddress = uwb::UwbMacAddress::FromString(m_cliData->deviceMacAddressString, macAddressType);
+        applicationConfigurationParametersData.destinationMacAddresses = uwb::UwbMacAddress::MacAddressesFromString(m_cliData->destinationMacAddressString, macAddressType);
+
         m_cliData->RangingParameters.ApplicationConfigurationParameters = detail::ProcessApplicationConfigurationParameters(*m_cliData);
         RegisterCliAppWithOperation(rangeStartApp);
     });

--- a/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliData.hxx
@@ -149,7 +149,7 @@ struct NearObjectCliData
 
     bool HostIsController{ false };
     std::string deviceMacAddressString;
-    std::string destinationMacAddressString; // TODO: List of strings (or large string of mac address substrings) to support multiple controlees
+    std::string destinationMacAddressesString;
     std::string resultReportConfigurationString;
     UwbConfigurationData uwbConfiguration{};
     UwbApplicationConfigurationParameterData applicationConfigurationParametersData{};

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -674,14 +674,16 @@ windows::devices::uwb::ddi::lrp::From(const UwbApplicationConfigurationParameter
             UWB_APP_CONFIG_PARAM &applicationConfigurationParameter = applicationConfigurationParameterWrapper->value();
             applicationConfigurationParameter.paramValue[0] = value;
         } else if constexpr (std::is_same_v<T, std::unordered_set<::uwb::UwbMacAddress>>) {
-            // TODO: Get all values from set, not just first one
-            const auto val = *std::begin(arg);
-            const auto value = val.GetValue();
-            parameterLength = std::size(value);
+            std::vector<std::span<const uint8_t>> values{};
+            for (const auto &uwbMacAddress : arg) {
+                const auto value = uwbMacAddress.GetValue();
+                parameterLength += std::size(value);
+                values.push_back(value);
+            }
             totalSize += parameterLength;
             applicationConfigurationParameterWrapper = std::make_unique<UwbApplicationConfigurationParameterWrapper>(totalSize);
             UWB_APP_CONFIG_PARAM &applicationConfigurationParameter = applicationConfigurationParameterWrapper->value();
-            std::memcpy(&applicationConfigurationParameter.paramValue[0], std::data(value), parameterLength);
+            std::memcpy(&applicationConfigurationParameter.paramValue[0], std::data(values), parameterLength);
         } else {
             throw std::runtime_error("unknown UwbApplicationConfigurationParameter variant value encountered");
         }

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -1669,7 +1669,7 @@ windows::devices::uwb::ddi::lrp::To(const UWB_APP_CONFIG_PARAMS &applicationConf
         if (To(applicationConfigurationParameter.paramType) == UwbApplicationConfigurationParameterType::MacAddressMode) {
             macAddressMode = std::get<::uwb::UwbMacAddressType>(To(applicationConfigurationParameter).Value);
         }
-        
+
         // If parameter is DestinationMacAddresses, store until other parameters have been converted.
         if (To(applicationConfigurationParameter.paramType) == UwbApplicationConfigurationParameterType::DestinationMacAddresses) {
             destinationMacAddresses = applicationConfigurationParameter;

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -674,16 +674,16 @@ windows::devices::uwb::ddi::lrp::From(const UwbApplicationConfigurationParameter
             UWB_APP_CONFIG_PARAM &applicationConfigurationParameter = applicationConfigurationParameterWrapper->value();
             applicationConfigurationParameter.paramValue[0] = value;
         } else if constexpr (std::is_same_v<T, std::unordered_set<::uwb::UwbMacAddress>>) {
-            std::vector<std::span<const uint8_t>> values{};
+            std::vector<uint8_t> valueBuffer{};
             for (const auto &uwbMacAddress : arg) {
                 const auto value = uwbMacAddress.GetValue();
                 parameterLength += std::size(value);
-                values.push_back(value);
+                valueBuffer.insert(valueBuffer.end(), std::cbegin(value), std::cend(value));
             }
             totalSize += parameterLength;
             applicationConfigurationParameterWrapper = std::make_unique<UwbApplicationConfigurationParameterWrapper>(totalSize);
             UWB_APP_CONFIG_PARAM &applicationConfigurationParameter = applicationConfigurationParameterWrapper->value();
-            std::memcpy(&applicationConfigurationParameter.paramValue[0], std::data(values), parameterLength);
+            std::memcpy(&applicationConfigurationParameter.paramValue[0], std::data(valueBuffer), parameterLength);
         } else {
             throw std::runtime_error("unknown UwbApplicationConfigurationParameter variant value encountered");
         }
@@ -1612,21 +1612,7 @@ windows::devices::uwb::ddi::lrp::To(const UWB_APP_CONFIG_PARAM &applicationConfi
         break;
     }
     case UWB_APP_CONFIG_PARAM_TYPE_DST_MAC_ADDRESS: {
-        // TODO: we can't infer the length as is done with
-        // UWB_APP_CONFIG_PARAM_TYPE_DEVICE_MAC_ADDRESS since the number of
-        // bytes is ambiguous (eg. paramLength == 8 could mean 4 short addresses
-        // or 1 extended address). The mac address type needs to be provided in
-        // in some way, but it's unclear how that information would be injected
-        // here. Re-visit.
-        std::unordered_set<::uwb::UwbMacAddress> value{};
-
-        // TODO: Currently assuming that DST_MAC_ADDRESS is a single, short address.
-        // However, the addresses could be extended and there could be multiple.
-        // Re-visit.
-        ::uwb::UwbMacAddress::ShortType data{};
-        std::memcpy(std::data(data), &applicationConfigurationParameter.paramValue[0], std::size(data));
-        value.insert(::uwb::UwbMacAddress(std::move(data)));
-        uwbApplicationConfigurationParameter.Value = std::move(value);
+        PLOG_ERROR << "unexpected uwb application configuration parameter type encountered for this conversion function, type=" << std::showbase << std::hex << notstd::to_underlying(applicationConfigurationParameter.paramType);
         break;
     }
     default:
@@ -1637,15 +1623,70 @@ windows::devices::uwb::ddi::lrp::To(const UWB_APP_CONFIG_PARAM &applicationConfi
     return uwbApplicationConfigurationParameter;
 }
 
+UwbApplicationConfigurationParameter
+windows::devices::uwb::ddi::lrp::To(const UWB_APP_CONFIG_PARAM &applicationConfigurationParameter, const ::uwb::UwbMacAddressType macAddressMode)
+{
+    UwbApplicationConfigurationParameter uwbApplicationConfigurationParameter{
+        .Type = To(applicationConfigurationParameter.paramType)
+    };
+
+    if (applicationConfigurationParameter.paramType == UWB_APP_CONFIG_PARAM_TYPE_DST_MAC_ADDRESS) {
+        std::unordered_set<::uwb::UwbMacAddress> value{};
+
+        if (macAddressMode == ::uwb::UwbMacAddressType::Short) {
+            for (auto i = 0; i < (applicationConfigurationParameter.paramLength / ::uwb::UwbMacAddress::ShortLength); i++) {
+                ::uwb::UwbMacAddress::ShortType data{};
+                auto offset = i * ::uwb::UwbMacAddress::ShortLength;
+                std::memcpy(std::data(data), &applicationConfigurationParameter.paramValue[0] + offset, std::size(data));
+                value.insert(::uwb::UwbMacAddress(std::move(data)));
+            }
+        } else { // ::uwb::UwbMacAddressType::Extended
+            for (auto i = 0; i < (applicationConfigurationParameter.paramLength / ::uwb::UwbMacAddress::ExtendedLength); i++) {
+                ::uwb::UwbMacAddress::ExtendedType data{};
+                auto offset = i * ::uwb::UwbMacAddress::ExtendedLength;
+                std::memcpy(std::data(data), &applicationConfigurationParameter.paramValue[0] + offset, std::size(data));
+                value.insert(::uwb::UwbMacAddress(std::move(data)));
+            }
+        }
+
+        uwbApplicationConfigurationParameter.Value = std::move(value);
+    } else {
+        PLOG_ERROR << "unexpected uwb application configuration parameter type encountered, type=" << std::showbase << std::hex << notstd::to_underlying(applicationConfigurationParameter.paramType);
+    }
+
+    return uwbApplicationConfigurationParameter;
+}
+
 std::vector<UwbApplicationConfigurationParameter>
 windows::devices::uwb::ddi::lrp::To(const UWB_APP_CONFIG_PARAMS &applicationConfigurationParameters)
 {
     std::vector<UwbApplicationConfigurationParameter> uwbApplicationConfigurationParameters{};
 
-    detail::ForEachApplicationConfigurationParameter(applicationConfigurationParameters, [&uwbApplicationConfigurationParameters](const auto &applicationConfigurationParameter) {
-        auto uwbApplicationConfigurationParameter = To(applicationConfigurationParameter);
-        uwbApplicationConfigurationParameters.push_back(std::move(uwbApplicationConfigurationParameter));
+    std::optional<::uwb::UwbMacAddressType> macAddressMode;
+    std::optional<UWB_APP_CONFIG_PARAM> destinationMacAddresses;
+    detail::ForEachApplicationConfigurationParameter(applicationConfigurationParameters, [&uwbApplicationConfigurationParameters, &macAddressMode, &destinationMacAddresses](const auto &applicationConfigurationParameter) {
+        // If parameter is MacAddressMode, store value
+        if (To(applicationConfigurationParameter.paramType) == UwbApplicationConfigurationParameterType::MacAddressMode) {
+            macAddressMode = std::get<::uwb::UwbMacAddressType>(To(applicationConfigurationParameter).Value);
+        }
+        
+        // If parameter is DestinationMacAddresses, store until other parameters have been converted.
+        if (To(applicationConfigurationParameter.paramType) == UwbApplicationConfigurationParameterType::DestinationMacAddresses) {
+            destinationMacAddresses = applicationConfigurationParameter;
+        } else {
+            auto uwbApplicationConfigurationParameter = To(applicationConfigurationParameter);
+            uwbApplicationConfigurationParameters.push_back(std::move(uwbApplicationConfigurationParameter));
+        }
     });
+
+    // Now that the other parameters have been converted, convert DestinationMacAddresses with special conversion function
+    if (destinationMacAddresses.has_value()) {
+        if (macAddressMode.has_value()) {
+            uwbApplicationConfigurationParameters.push_back(std::move(To(destinationMacAddresses.value(), macAddressMode.value())));
+        } else {
+            uwbApplicationConfigurationParameters.push_back(std::move(To(destinationMacAddresses.value(), ::uwb::UwbMacAddressType::Short)));
+        }
+    }
 
     return std::move(uwbApplicationConfigurationParameters);
 }

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -678,7 +678,7 @@ windows::devices::uwb::ddi::lrp::From(const UwbApplicationConfigurationParameter
             for (const auto &uwbMacAddress : arg) {
                 const auto value = uwbMacAddress.GetValue();
                 parameterLength += std::size(value);
-                valueBuffer.insert(valueBuffer.end(), std::cbegin(value), std::cend(value));
+                valueBuffer.insert(std::end(valueBuffer), std::cbegin(value), std::cend(value));
             }
             totalSize += parameterLength;
             applicationConfigurationParameterWrapper = std::make_unique<UwbApplicationConfigurationParameterWrapper>(totalSize);
@@ -1652,6 +1652,7 @@ windows::devices::uwb::ddi::lrp::To(const UWB_APP_CONFIG_PARAM &applicationConfi
         uwbApplicationConfigurationParameter.Value = std::move(value);
     } else {
         PLOG_ERROR << "unexpected uwb application configuration parameter type encountered, type=" << std::showbase << std::hex << notstd::to_underlying(applicationConfigurationParameter.paramType);
+        throw std::runtime_error("incorrect conversion function used for the given parameter type. Expected UWB_APP_CONFIG_PARAM_TYPE_DST_MAC_ADDRESS");
     }
 
     return uwbApplicationConfigurationParameter;
@@ -1686,6 +1687,8 @@ windows::devices::uwb::ddi::lrp::To(const UWB_APP_CONFIG_PARAMS &applicationConf
         } else {
             uwbApplicationConfigurationParameters.push_back(std::move(To(destinationMacAddresses.value(), ::uwb::UwbMacAddressType::Short)));
         }
+    } else {
+        PLOG_ERROR << "missing DestinationMacAddresses value";
     }
 
     return std::move(uwbApplicationConfigurationParameters);

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -612,6 +612,19 @@ To(const UWB_SET_APP_CONFIG_PARAMS_STATUS &applicationConfigurationParameterStat
 To(const UWB_APP_CONFIG_PARAM &applicationConfigurationParameter);
 
 /**
+ * @brief Converts UWB_APP_CONFIG_PARAM to UwbApplicationConfigurationParameter.
+ * 
+ * This special conversion function is only used for UWB_APP_CONFIG_PARAM_TYPE_DST_MAC_ADDRESS.
+ * This is because an additional parameter is needed to do the conversion.
+ *
+ * @param applicationConfigurationParameter
+ * @param macAddressMode
+ * @return ::uwb::protocol::fira::UwbApplicationConfigurationParameter
+ */
+::uwb::protocol::fira::UwbApplicationConfigurationParameter
+To(const UWB_APP_CONFIG_PARAM &applicationConfigurationParameter, const ::uwb::UwbMacAddressType macAddressMode);
+
+/**
  * @brief Converts UWB_APP_CONFIG_PARAMS to a vector of UwbApplicationConfigurationParameter.
  *
  * @param applicationConfigurationParameters

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -613,7 +613,7 @@ To(const UWB_APP_CONFIG_PARAM &applicationConfigurationParameter);
 
 /**
  * @brief Converts UWB_APP_CONFIG_PARAM to UwbApplicationConfigurationParameter.
- * 
+ *
  * This special conversion function is only used for UWB_APP_CONFIG_PARAM_TYPE_DST_MAC_ADDRESS.
  * This is because an additional parameter is needed to do the conversion.
  *


### PR DESCRIPTION
### Type

- [x] Bug fix
- [x] Feature addition
- [x] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

This PR adds support for multiple controlees in nocli. Specifically, this allows DestinationMacAddresses to hold multiple mac addresses, which corresponds to having multiple controlees, assuming the host device is a Controller.

### Technical Details

- Added parsing function `MacAddressesFromString` which takes a comma-delimited string of mac addresses and creates a `std::unordered_set`.
- Updated nocli to allow a user to supply multiple mac addresses in the `DestinationMacAddresses` field.
- Added/updated nocli input validation accordingly.
- Added a test in `TestUwbCxAdapterDdiLrpConversion.cxx` for multiple mac addresses in `DestinationMacAddresses`.
- Added a special `To()` conversion function for `DestinationMacAddresses` which takes the `MacAddressType` as an additional parameter.
- Fixed a bug with the input validation code, where supplying an extended mac address without specifying the correct mac address mode was causing ungraceful crashes.
- Fixed a bug with printing a `std::unordered_set<UwbMacAddress>`.
- Other minor syntax improvements.

### Test Results

Verified correct output in nocli, including correctly parsing and printing multiple mac addresses in `DestinationMacAddresses` and correctly validating nocli input. 

All CTests pass.

### Reviewer Focus

I'm not sure if the special `To()` conversion function is the best approach, but I'm unsure of another way. We need the mac address type in order to properly handle `DestinationMacAddresses` since 8-bytes could be 1 extended address or 4 short addresses, and I couldn't find a prettier way of injecting that into the existing `To()` conversion functions.

### Future Work

None.

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
