### PR TITLE
Callback Deregistration

### DIFF
--- a/lib/uwb/include/uwb/UwbRegisteredCallbacks.hxx
+++ b/lib/uwb/include/uwb/UwbRegisteredCallbacks.hxx
@@ -17,6 +17,10 @@ namespace uwb
  */
 class RegisteredCallbackToken;
 
+class RegisteredSessionCallbackToken;
+
+class RegisteredDeviceCallbackToken;
+
 /**
  * @brief Interface for receiving events from a UwbSession. This is the primary
  * method to receive information from near peers.

--- a/lib/uwb/include/uwb/UwbRegisteredCallbacks.hxx
+++ b/lib/uwb/include/uwb/UwbRegisteredCallbacks.hxx
@@ -17,10 +17,6 @@ namespace uwb
  */
 class RegisteredCallbackToken;
 
-class RegisteredSessionCallbackToken;
-
-class RegisteredDeviceCallbackToken;
-
 /**
  * @brief Interface for receiving events from a UwbSession. This is the primary
  * method to receive information from near peers.

--- a/windows/devices/uwb/UwbConnector.cxx
+++ b/windows/devices/uwb/UwbConnector.cxx
@@ -23,21 +23,21 @@ namespace uwb
 {
 struct RegisteredCallbackToken
 {
-    virtual ~RegisteredCallbackToken(){};
+    virtual ~RegisteredCallbackToken() = default;
 };
 
 struct RegisteredSessionCallbackToken : public RegisteredCallbackToken
 {
-    RegisteredSessionCallbackToken(uint32_t sessionId, std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbacks> Callbacks) :
-        sessionId(sessionId),
-        Callbacks(Callbacks){};
-    uint32_t sessionId;
+    RegisteredSessionCallbackToken(uint32_t sessionId, std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbacks> callbacks) :
+        SessionId(sessionId),
+        Callbacks(std::move(callbacks)){};
+    uint32_t SessionId;
     std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbacks> Callbacks;
 };
 
 struct RegisteredDeviceCallbackToken : public RegisteredCallbackToken
 {
-    RegisteredDeviceCallbackToken(std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbacks> Callbacks) :
+    RegisteredDeviceCallbackToken(std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbacks> callbacks) :
         Callbacks(Callbacks){};
     std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbacks> Callbacks;
 };
@@ -946,7 +946,7 @@ UwbConnector::DeregisterEventCallback(std::weak_ptr<::uwb::RegisteredCallbackTok
         m_deviceEventCallbacks.erase(tokenIt);
     } else {
         auto sessionCallback = dynamic_pointer_cast<::uwb::RegisteredSessionCallbackToken>(tokenShared);
-        auto sessionId = sessionCallback->sessionId;
+        auto sessionId = sessionCallback->SessionId;
 
         auto node = m_sessionEventCallbacks.extract(sessionId);
         if (node.empty()) {

--- a/windows/devices/uwb/UwbConnector.cxx
+++ b/windows/devices/uwb/UwbConnector.cxx
@@ -23,16 +23,22 @@ namespace uwb
 {
 struct RegisteredCallbackToken
 {
+    virtual ~RegisteredCallbackToken(){};
 };
 
 struct RegisteredSessionCallbackToken : public RegisteredCallbackToken
 {
+    RegisteredSessionCallbackToken(uint32_t sessionId, std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbacks> Callbacks) :
+        sessionId(sessionId),
+        Callbacks(Callbacks){};
     uint32_t sessionId;
     std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbacks> Callbacks;
 };
 
 struct RegisteredDeviceCallbackToken : public RegisteredCallbackToken
 {
+    RegisteredDeviceCallbackToken(std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbacks> Callbacks) :
+        Callbacks(Callbacks){};
     std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbacks> Callbacks;
 };
 } // namespace uwb

--- a/windows/devices/uwb/UwbConnector.cxx
+++ b/windows/devices/uwb/UwbConnector.cxx
@@ -19,14 +19,14 @@ using namespace windows::devices;
 using namespace windows::devices::uwb;
 using namespace ::uwb::protocol::fira;
 
-namespace windows::devices::uwb
+namespace uwb
 {
-struct RegisteredCallbackToken
+struct ::uwb::RegisteredCallbackToken
 {
     uint32_t callbackId;
     bool isDeviceEventCallback;
 };
-} // namespace windows::devices::uwb
+} // namespace uwb
 
 UwbConnector::UwbConnector(std::string deviceName) :
     m_deviceName(std::move(deviceName))
@@ -653,7 +653,7 @@ UwbConnector::GetResolvedDeviceEventCallbacks()
     }
 
     for (auto id : staleCallbacks) {
-        DeregisterEventCallback(RegisteredCallbackToken{ id, true });
+        DeregisterEventCallback(::uwb::RegisteredCallbackToken{ id, true });
     }
 
     return deviceEventCallbacks;
@@ -698,7 +698,7 @@ UwbConnector::GetResolvedSessionEventCallbacks(uint32_t sessionId)
     m_sessionEventCallbacks.insert(std::move(node));
 
     for (auto id : staleCallbacks) {
-        DeregisterEventCallback(RegisteredCallbackToken{ id, false });
+        DeregisterEventCallback(::uwb::RegisteredCallbackToken{ id, false });
     }
 
     return sessionEventCallbacks;
@@ -898,7 +898,7 @@ UwbConnector::NotificationListenerStop()
     m_notificationThread.request_stop();
 }
 
-std::weak_ptr<RegisteredCallbackToken>
+std::weak_ptr<::uwb::RegisteredCallbackToken>
 UwbConnector::RegisterDeviceEventCallbacks(std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbacks> callbacks)
 {
     std::lock_guard eventCallbacksLockExclusive{ m_eventCallbacksGate };
@@ -910,7 +910,7 @@ UwbConnector::RegisterDeviceEventCallbacks(std::weak_ptr<::uwb::UwbRegisteredDev
     return token;
 }
 
-std::weak_ptr<RegisteredCallbackToken>
+std::weak_ptr<::uwb::RegisteredCallbackToken>
 UwbConnector::RegisterSessionEventCallbacks(uint32_t sessionId, std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbacks> callbacks)
 {
     std::lock_guard eventCallbacksLockExclusive{ m_eventCallbacksGate };
@@ -939,7 +939,7 @@ UwbConnector::CallbacksPresent()
 }
 
 void
-UwbConnector::DeregisterEventCallback(std::weak_ptr<RegisteredCallbackToken> token)
+UwbConnector::DeregisterEventCallback(std::weak_ptr<::uwb::RegisteredCallbackToken> token)
 {
     auto tok = token.lock();
     if (not tok) {
@@ -951,7 +951,7 @@ UwbConnector::DeregisterEventCallback(std::weak_ptr<RegisteredCallbackToken> tok
 }
 
 void
-UwbConnector::DeregisterEventCallback(RegisteredCallbackToken token)
+UwbConnector::DeregisterEventCallback(::uwb::RegisteredCallbackToken token)
 {
     auto callbackId = token.callbackId;
     auto isDeviceEventCallback = token.isDeviceEventCallback;
@@ -1010,20 +1010,20 @@ UwbConnector::DeregisterEventCallback(RegisteredCallbackToken token)
     }
 }
 
-std::shared_ptr<RegisteredCallbackToken>
+std::shared_ptr<::uwb::RegisteredCallbackToken>
 UwbConnector::InsertDeviceEventCallback(std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbacks> callback)
 {
     m_tokenUniqueState++;
     m_deviceEventCallbacksIdMap.insert({ m_tokenUniqueState, std::move(callback) });
-    m_tokens.push_back(std::make_shared<RegisteredCallbackToken>(m_tokenUniqueState, true));
+    m_tokens.push_back(std::make_shared<::uwb::RegisteredCallbackToken>(m_tokenUniqueState, true));
     return m_tokens.back();
 }
 
-std::shared_ptr<RegisteredCallbackToken>
+std::shared_ptr<::uwb::RegisteredCallbackToken>
 UwbConnector::InsertSessionEventCallback(std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbacks> callback)
 {
     m_tokenUniqueState++;
     m_sessionEventCallbacksIdMap.insert({ m_tokenUniqueState, std::move(callback) });
-    m_tokens.push_back(std::make_shared<RegisteredCallbackToken>(m_tokenUniqueState, false));
+    m_tokens.push_back(std::make_shared<::uwb::RegisteredCallbackToken>(m_tokenUniqueState, false));
     return m_tokens.back();
 }

--- a/windows/devices/uwb/UwbConnector.cxx
+++ b/windows/devices/uwb/UwbConnector.cxx
@@ -908,7 +908,6 @@ UwbConnector::RegisterSessionEventCallbacks(uint32_t sessionId, std::weak_ptr<::
         NotificationListenerStart();
     }
     return token;
-    // TODO move the below to InsertSessionEventCallback
 }
 
 bool

--- a/windows/devices/uwb/UwbConnector.cxx
+++ b/windows/devices/uwb/UwbConnector.cxx
@@ -21,7 +21,7 @@ using namespace ::uwb::protocol::fira;
 
 namespace uwb
 {
-struct ::uwb::RegisteredCallbackToken
+struct RegisteredCallbackToken
 {
     uint32_t callbackId;
     bool isDeviceEventCallback;
@@ -957,11 +957,10 @@ UwbConnector::DeregisterEventCallback(::uwb::RegisteredCallbackToken token)
     auto isDeviceEventCallback = token.isDeviceEventCallback;
 
     // first remove the token from the list of tokens
-    for (auto it = std::cbegin(m_tokens); it != std::cend(m_tokens);) {
+    for (auto it = std::cbegin(m_tokens); it != std::cend(m_tokens); it++) {
         if ((*it)->callbackId == callbackId) {
-            it = m_tokens.erase(it);
-        } else {
-            it++;
+            m_tokens.erase(it);
+            break;
         }
     }
 

--- a/windows/devices/uwb/UwbConnector.cxx
+++ b/windows/devices/uwb/UwbConnector.cxx
@@ -23,8 +23,17 @@ namespace uwb
 {
 struct RegisteredCallbackToken
 {
-    uint32_t callbackId;
-    bool isDeviceEventCallback;
+};
+
+struct RegisteredSessionCallbackToken : public RegisteredCallbackToken
+{
+    uint32_t sessionId;
+    std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbacks> Callbacks;
+};
+
+struct RegisteredDeviceCallbackToken : public RegisteredCallbackToken
+{
+    std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbacks> Callbacks;
 };
 } // namespace uwb
 

--- a/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
@@ -49,7 +49,7 @@ struct IUwbDeviceDdiConnector : public IUwbDeviceDdi
      * @param callbacks
      * @return RegisteredCallbackToken* You can pass this pointer into DeregisterEventCallback to deregister this event callback
      */
-    virtual std::weak_ptr<RegisteredCallbackToken> RegisterDeviceEventCallbacks(std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbacks>) = 0;
+    virtual std::weak_ptr<::uwb::RegisteredCallbackToken> RegisterDeviceEventCallbacks(std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbacks>) = 0;
 };
 
 } // namespace windows::devices::uwb

--- a/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
@@ -49,7 +49,7 @@ struct IUwbDeviceDdiConnector : public IUwbDeviceDdi
      * @param callbacks
      * @return RegisteredCallbackToken* You can pass this pointer into DeregisterEventCallback to deregister this event callback
      */
-    virtual ::uwb::RegisteredCallbackToken* RegisterDeviceEventCallbacks(std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbacks>) = 0;
+    virtual std::weak_ptr<RegisteredCallbackToken> RegisterDeviceEventCallbacks(std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbacks>) = 0;
 };
 
 } // namespace windows::devices::uwb

--- a/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
@@ -47,7 +47,7 @@ struct IUwbDeviceDdiConnector : public IUwbDeviceDdi
      * @brief Sets the callbacks for the UwbDevice that owns this UwbConnector
      *
      * @param callbacks
-     * @return RegisteredCallbackToken* You can pass this pointer into DeregisterEventCallback to deregister this event callback
+     * @return std::weak_ptr<::uwb::RegisteredCallbackToken> You can pass this pointer into DeregisterEventCallback to deregister this event callback
      */
     virtual std::weak_ptr<::uwb::RegisteredCallbackToken> RegisterDeviceEventCallbacks(std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbacks>) = 0;
 };

--- a/windows/devices/uwb/include/windows/devices/uwb/IUwbSessionDdi.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/IUwbSessionDdi.hxx
@@ -67,7 +67,7 @@ struct IUwbSessionDdiConnector : public IUwbSessionDdi
      * @param callbacks
      * @return RegisteredCallbackToken* You can pass this pointer into DeregisterEventCallback to deregister this event callback
      */
-    virtual ::uwb::RegisteredCallbackToken*
+    virtual std::weak_ptr<RegisteredCallbackToken>
     RegisterSessionEventCallbacks(uint32_t sessionId, std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbacks> callbacks) = 0;
 };
 

--- a/windows/devices/uwb/include/windows/devices/uwb/IUwbSessionDdi.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/IUwbSessionDdi.hxx
@@ -67,7 +67,7 @@ struct IUwbSessionDdiConnector : public IUwbSessionDdi
      * @param callbacks
      * @return RegisteredCallbackToken* You can pass this pointer into DeregisterEventCallback to deregister this event callback
      */
-    virtual std::weak_ptr<RegisteredCallbackToken>
+    virtual std::weak_ptr<::uwb::RegisteredCallbackToken>
     RegisterSessionEventCallbacks(uint32_t sessionId, std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbacks> callbacks) = 0;
 };
 

--- a/windows/devices/uwb/include/windows/devices/uwb/IUwbSessionDdi.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/IUwbSessionDdi.hxx
@@ -65,7 +65,7 @@ struct IUwbSessionDdiConnector : public IUwbSessionDdi
      *
      * @param sessionId
      * @param callbacks
-     * @return RegisteredCallbackToken* You can pass this pointer into DeregisterEventCallback to deregister this event callback
+     * @return std::weak_ptr<::uwb::RegisteredCallbackToken> You can pass this pointer into DeregisterEventCallback to deregister this event callback
      */
     virtual std::weak_ptr<::uwb::RegisteredCallbackToken>
     RegisterSessionEventCallbacks(uint32_t sessionId, std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbacks> callbacks) = 0;

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
@@ -250,21 +250,8 @@ private:
 
     // the following shared_mutex is used to protect access to everything regarding the registered callbacks
     mutable std::shared_mutex m_eventCallbacksGate;
-
-    // map of callbackId to the actual callback
-    std::unordered_map<uint32_t, std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbacks>> m_deviceEventCallbacksIdMap;
-
-    // map of callbackId to tuple of sessionId and the actual callback
-    std::unordered_map<uint32_t, std::pair<uint32_t, std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbacks>>> m_sessionEventCallbacksIdMap;
-
-    // map of sessionId to vector of callbackIds. This is guaranteed to be synced to the m_sessionEventCallbacksIdMap (basically the inverse)
-    std::unordered_map<uint32_t, std::vector<uint32_t>> m_sessionIdToCallbackIdsMap;
-
-    // ensures each generated new callbackId is unique
-    uint32_t m_tokenUniqueState;
-
-    // strictly used for deregistration, the token will be evaluated lazily, and may or may not be synced ith the actual callback storage
-    std::vector<std::shared_ptr<::uwb::RegisteredCallbackToken>> m_tokens;
+    std::unordered_map<uint32_t, std::vector<std::weak_ptr<::uwb::RegisteredSessionCallbackToken>>> m_sessionEventCallbacks;
+    std::vector<std::shared_ptr<::uwb::RegisteredDeviceCallbackToken>> m_deviceEventCallbacks;
 };
 } // namespace windows::devices::uwb
 

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
@@ -235,11 +235,12 @@ private:
      * @brief Internal helper function to insert the callback into the hashmap of ids to callbacks
      * You MUST have grabbed the m_eventCallbacksGate mutex prior to calling this.
      *
+     * @param sessionId
      * @param callback
      * @return std::weak_ptr<::uwb::RegisteredCallbackToken>
      */
     std::shared_ptr<::uwb::RegisteredCallbackToken>
-    InsertSessionEventCallback(std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbacks> callback);
+    InsertSessionEventCallback(uint32_t sessionId, std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbacks> callback);
 
     /**
      * @brief Internal helper function that deregisters event callbacks.
@@ -259,19 +260,19 @@ private:
 
     // the following shared_mutex is used to protect access to everything regarding the registered callbacks
     mutable std::shared_mutex m_eventCallbacksGate;
-    
-    // map of callbackId to tuple of sessionId and the actual callback
-    std::unordered_map<uint32_t, std::pair<uint32_t,std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbacks>>> m_sessionEventCallbacksIdMap;
-    
+
     // map of callbackId to the actual callback
     std::unordered_map<uint32_t, std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbacks>> m_deviceEventCallbacksIdMap;
-    
-    // map of sessionId to vector of callbackIds
+
+    // map of callbackId to tuple of sessionId and the actual callback
+    std::unordered_map<uint32_t, std::pair<uint32_t, std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbacks>>> m_sessionEventCallbacksIdMap;
+
+    // map of sessionId to vector of callbackIds. This is guaranteed to be synced to the m_sessionEventCallbacksIdMap (basically the inverse)
     std::unordered_map<uint32_t, std::vector<uint32_t>> m_sessionIdToCallbackIdsMap;
-    
+
     // ensures each generated new callbackId is unique
     uint32_t m_tokenUniqueState;
-    
+
     // strictly used for deregistration, the token will be evaluated lazily, and may or may not be synced ith the actual callback storage
     std::vector<std::shared_ptr<::uwb::RegisteredCallbackToken>> m_tokens;
 };

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
@@ -23,11 +23,6 @@
 namespace windows::devices::uwb
 {
 /**
- * @brief Opaque class forward declaration to help with the deregistration
- */
-// class ::uwb::RegisteredCallbackToken;
-
-/**
  * @brief Class representing a logical communication channel with a UWB driver.
  *
  * This class exposes functions which map 1-1 to the UWB LRP DDI as defined in
@@ -65,7 +60,7 @@ public:
      * @brief Sets the callbacks for the UwbDevice that owns this UwbConnector
      *
      * @param callbacks
-     * @return ::uwb::RegisteredCallbackToken* You can pass this pointer into DeregisterEventCallback to deregister this event callback
+     * @return std::weak_ptr<::uwb::RegisteredCallbackToken> You can pass this pointer into DeregisterEventCallback to deregister this event callback
      */
     virtual std::weak_ptr<::uwb::RegisteredCallbackToken>
     RegisterDeviceEventCallbacks(std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbacks> callbacks) override;
@@ -77,7 +72,7 @@ public:
      *
      * @param sessionId
      * @param callbacks
-     * @return ::uwb::RegisteredCallbackToken* You can pass this pointer into DeregisterEventCallback to deregister this event callback
+     * @return std::weak_ptr<::uwb::RegisteredCallbackToken> You can pass this pointer into DeregisterEventCallback to deregister this event callback
      */
     virtual std::weak_ptr<::uwb::RegisteredCallbackToken>
     RegisterSessionEventCallbacks(uint32_t sessionId, std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbacks> callbacks) override;

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
@@ -20,6 +20,12 @@
 #include <windows/devices/uwb/IUwbDeviceDdi.hxx>
 #include <windows/devices/uwb/IUwbSessionDdi.hxx>
 
+namespace uwb
+{
+class RegisteredSessionCallbackToken;
+class RegisteredDeviceCallbackToken;
+} // namespace uwb
+
 namespace windows::devices::uwb
 {
 /**

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
@@ -25,7 +25,7 @@ namespace windows::devices::uwb
 /**
  * @brief Opaque class forward declaration to help with the deregistration
  */
-class RegisteredCallbackToken;
+// class ::uwb::RegisteredCallbackToken;
 
 /**
  * @brief Class representing a logical communication channel with a UWB driver.
@@ -65,9 +65,9 @@ public:
      * @brief Sets the callbacks for the UwbDevice that owns this UwbConnector
      *
      * @param callbacks
-     * @return RegisteredCallbackToken* You can pass this pointer into DeregisterEventCallback to deregister this event callback
+     * @return ::uwb::RegisteredCallbackToken* You can pass this pointer into DeregisterEventCallback to deregister this event callback
      */
-    virtual std::weak_ptr<RegisteredCallbackToken>
+    virtual std::weak_ptr<::uwb::RegisteredCallbackToken>
     RegisterDeviceEventCallbacks(std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbacks> callbacks) override;
 
 public:
@@ -77,9 +77,9 @@ public:
      *
      * @param sessionId
      * @param callbacks
-     * @return RegisteredCallbackToken* You can pass this pointer into DeregisterEventCallback to deregister this event callback
+     * @return ::uwb::RegisteredCallbackToken* You can pass this pointer into DeregisterEventCallback to deregister this event callback
      */
-    virtual std::weak_ptr<RegisteredCallbackToken>
+    virtual std::weak_ptr<::uwb::RegisteredCallbackToken>
     RegisterSessionEventCallbacks(uint32_t sessionId, std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbacks> callbacks) override;
 
 public:
@@ -90,7 +90,7 @@ public:
      * @param token
      */
     void
-    DeregisterEventCallback(std::weak_ptr<RegisteredCallbackToken> token);
+    DeregisterEventCallback(std::weak_ptr<::uwb::RegisteredCallbackToken> token);
 
 public:
     // IUwbDeviceDdi
@@ -229,32 +229,32 @@ private:
     /**
      * @brief Internal helper function to insert the callback into the hashmap of ids to callbacks
      * You MUST have grabbed the m_eventCallbacksGate mutex prior to calling this.
-     * 
-     * @param callback 
-     * @return std::weak_ptr<RegisteredCallbackToken>
+     *
+     * @param callback
+     * @return std::weak_ptr<::uwb::RegisteredCallbackToken>
      */
-    std::shared_ptr<RegisteredCallbackToken>
+    std::shared_ptr<::uwb::RegisteredCallbackToken>
     InsertDeviceEventCallback(std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbacks> callback);
 
     /**
      * @brief Internal helper function to insert the callback into the hashmap of ids to callbacks
      * You MUST have grabbed the m_eventCallbacksGate mutex prior to calling this.
-     * 
-     * @param callback 
-     * @return std::weak_ptr<RegisteredCallbackToken>
+     *
+     * @param callback
+     * @return std::weak_ptr<::uwb::RegisteredCallbackToken>
      */
-    std::shared_ptr<RegisteredCallbackToken>
+    std::shared_ptr<::uwb::RegisteredCallbackToken>
     InsertSessionEventCallback(std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbacks> callback);
 
     /**
-     * @brief Internal helper function that deregisters event callbacks. 
+     * @brief Internal helper function that deregisters event callbacks.
      * If you pass in a token that is no longer valid, this function does nothing
      * You must have grabbed the m_eventCallbacksGate mutex prior to calling this
      *
      * @param token
      */
     void
-    DeregisterEventCallback(RegisteredCallbackToken token);
+    DeregisterEventCallback(::uwb::RegisteredCallbackToken token);
 
 private:
     // the following shared_mutex is used to protect access to both session and device event callbacks
@@ -269,9 +269,9 @@ private:
 private:
     // the following is related to how the UwbConnector keeps track of its callbacks
     uint32_t m_tokenUniqueState;
-    std::unordered_map<uint32_t,std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbacks>> m_sessionEventCallbacksIdMap;
-    std::unordered_map<uint32_t,std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbacks>> m_deviceEventCallbacksIdMap;
-    std::vector<std::shared_ptr<RegisteredCallbackToken>> m_tokens;
+    std::unordered_map<uint32_t, std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbacks>> m_sessionEventCallbacksIdMap;
+    std::unordered_map<uint32_t, std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbacks>> m_deviceEventCallbacksIdMap;
+    std::vector<std::shared_ptr<::uwb::RegisteredCallbackToken>> m_tokens;
 };
 } // namespace windows::devices::uwb
 

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
@@ -22,6 +22,10 @@
 
 namespace uwb
 {
+/**
+ * @brief The following are opaque class declarations that are used in this file
+ * 
+ */
 class RegisteredSessionCallbackToken;
 class RegisteredDeviceCallbackToken;
 } // namespace uwb

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
@@ -230,28 +230,7 @@ private:
      */
     std::vector<std::shared_ptr<::uwb::UwbRegisteredDeviceEventCallbacks>>
     GetResolvedDeviceEventCallbacks();
-
-    /**
-     * @brief Internal helper function to insert the callback into the hashmap of ids to callbacks
-     * You MUST have grabbed the m_eventCallbacksGate mutex prior to calling this.
-     *
-     * @param callback
-     * @return std::weak_ptr<::uwb::RegisteredCallbackToken>
-     */
-    std::shared_ptr<::uwb::RegisteredCallbackToken>
-    InsertDeviceEventCallback(std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbacks> callback);
-
-    /**
-     * @brief Internal helper function to insert the callback into the hashmap of ids to callbacks
-     * You MUST have grabbed the m_eventCallbacksGate mutex prior to calling this.
-     *
-     * @param sessionId
-     * @param callback
-     * @return std::weak_ptr<::uwb::RegisteredCallbackToken>
-     */
-    std::shared_ptr<::uwb::RegisteredCallbackToken>
-    InsertSessionEventCallback(uint32_t sessionId, std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbacks> callback);
-
+    
 private:
     std::string m_deviceName{};
     std::jthread m_notificationThread;

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
@@ -250,7 +250,7 @@ private:
 
     // the following shared_mutex is used to protect access to everything regarding the registered callbacks
     mutable std::shared_mutex m_eventCallbacksGate;
-    std::unordered_map<uint32_t, std::vector<std::weak_ptr<::uwb::RegisteredSessionCallbackToken>>> m_sessionEventCallbacks;
+    std::unordered_map<uint32_t, std::vector<std::shared_ptr<::uwb::RegisteredSessionCallbackToken>>> m_sessionEventCallbacks;
     std::vector<std::shared_ptr<::uwb::RegisteredDeviceCallbackToken>> m_deviceEventCallbacks;
 };
 } // namespace windows::devices::uwb

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
@@ -242,16 +242,6 @@ private:
     std::shared_ptr<::uwb::RegisteredCallbackToken>
     InsertSessionEventCallback(uint32_t sessionId, std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbacks> callback);
 
-    /**
-     * @brief Internal helper function that deregisters event callbacks.
-     * If you pass in a token that is no longer valid, this function does nothing
-     * You must have grabbed the m_eventCallbacksGate mutex prior to calling this
-     *
-     * @param token
-     */
-    void
-    DeregisterEventCallback(::uwb::RegisteredCallbackToken token);
-
 private:
     std::string m_deviceName{};
     std::jthread m_notificationThread;

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
@@ -156,7 +156,7 @@ private:
     std::shared_ptr<IUwbDeviceDdiConnector> m_uwbDeviceConnector;
     std::shared_ptr<IUwbSessionDdiConnector> m_uwbSessionConnector;
     std::shared_ptr<::uwb::UwbRegisteredDeviceEventCallbacks> m_callbacks;
-    ::uwb::RegisteredCallbackToken* m_callbacksToken;
+    std::weak_ptr<::uwb::RegisteredCallbackToken> m_callbacksToken;
 };
 } // namespace windows::devices::uwb
 

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
@@ -106,7 +106,7 @@ protected:
 private:
     std::shared_ptr<IUwbSessionDdiConnector> m_uwbSessionConnector;
     std::shared_ptr<::uwb::UwbRegisteredSessionEventCallbacks> m_registeredCallbacks;
-    ::uwb::RegisteredCallbackToken* m_registeredCallbacksToken;
+    std::weak_ptr<::uwb::RegisteredCallbackToken> m_registeredCallbacksToken;
 };
 
 } // namespace windows::devices::uwb


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [X] Infrastructure

### Goals

Allow the deregistration of callbacks

### Technical Details

* Every callback has an id, this map is stored in m_[session|device]EventCallbacksIdMap. 
* m_[session|device]EventCallbacks now stores the callback ids, not the callbacks themselves.
* m_tokens holds the list of tokens so that the memory is not released when we return the tokens to the caller of the register callback functions

### Test Results

* the basic ranging scenario works

### Reviewer Focus

Currently the interface maintains the invariant that m_tokens, m_[session|device]EventCallbacks, and m_[session|device]EventCallbacksIdMap are always in sync. However, this may result in a slow runtime for GetResolved[Session|Device]EventCallbacks(). Consider if relaxing that invariant makes sense.

### Future Work


### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
