### PR TITLE
Enable plog support in uwb simulator driver

### DIFF
--- a/windows/drivers/uwb/simulator/UwbSimulator.vcxproj
+++ b/windows/drivers/uwb/simulator/UwbSimulator.vcxproj
@@ -18,6 +18,7 @@
     <ClCompile Include="UwbSimulatorIoQueue.cxx" />
     <ClCompile Include="UwbSimulatorDevice.cxx" />
     <ClCompile Include="UwbSimulatorDeviceFile.cxx" />
+    <ClCompile Include="UwbSimulatorLogging.cxx" />
     <ClCompile Include="UwbSimulatorSession.cxx" />
     <ClCompile Include="UwbSimulatorTracelogging.cxx" />
   </ItemGroup>
@@ -37,6 +38,7 @@
     <ClInclude Include="UwbSimulatorDevice.hxx" />
     <ClInclude Include="UwbSimulatorDeviceFile.hxx" />
     <ClInclude Include="IUwbSimulatorSession.hxx" />
+    <ClInclude Include="UwbSimulatorLogging.hxx" />
     <ClInclude Include="UwbSimulatorSession.hxx" />
     <ClInclude Include="UwbSimulatorTracelogging.hxx" />
   </ItemGroup>

--- a/windows/drivers/uwb/simulator/UwbSimulator.vcxproj.filters
+++ b/windows/drivers/uwb/simulator/UwbSimulator.vcxproj.filters
@@ -84,6 +84,9 @@
     <ClInclude Include="UwbSimulatorIoEventQueue.hxx">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="UwbSimulatorLogging.hxx">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="UwbSimulatorIoQueue.cxx">
@@ -111,6 +114,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="UwbSimulatorIoEventQueue.cxx">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="UwbSimulatorLogging.cxx">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/windows/drivers/uwb/simulator/UwbSimulatorDevice.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDevice.cxx
@@ -205,7 +205,7 @@ UwbSimulatorDevice::OnFileCreate(WDFDEVICE device, WDFREQUEST request, WDFFILEOB
         DbgPrint("%p added file object %p\n", m_wdfDevice, file);
     } else {
         uwbSimulatorFileContext->~UwbSimulatorDeviceFileWdfContext();
-        DbgPrint("%p failed to initialize file context object with status 0x%08x\n", uwbSimulatorFileStatus);
+        DbgPrint("%p failed to initialize file context object with status 0x%08x\n", m_wdfDevice, uwbSimulatorFileStatus);
     }
 
     WdfRequestComplete(request, uwbSimulatorFileStatus);
@@ -346,7 +346,7 @@ UwbSimulatorDevice::PushUwbNotification(UwbNotificationData uwbNotificationData)
 void
 UwbSimulatorDevice::DeviceInitialize(std::chrono::duration<double> initializeTime)
 {
-    DbgPrint("initializing device");
+    DbgPrint("initializing device\n");
 
     std::this_thread::sleep_for(initializeTime);
     DeviceUpdateState(UwbDeviceState::Ready);

--- a/windows/drivers/uwb/simulator/UwbSimulatorDriver.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorDriver.cxx
@@ -7,6 +7,7 @@
 
 #include "UwbSimulatorDriver.hxx"
 #include "UwbSimulatorDevice.hxx"
+#include "UwbSimulatorLogging.hxx"
 #include "UwbSimulatorTracelogging.hxx"
 
 /**
@@ -27,6 +28,7 @@
 NTSTATUS
 DriverEntry(PDRIVER_OBJECT driverObject, PUNICODE_STRING registryPath)
 {
+    UwbSimulatorLoggingInitialize();
     TraceLoggingRegister(UwbSimulatorTraceloggingProvider);
     TraceLoggingWrite(UwbSimulatorTraceloggingProvider, "DriverEntry");
 

--- a/windows/drivers/uwb/simulator/UwbSimulatorLogging.cxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorLogging.cxx
@@ -1,0 +1,43 @@
+
+#include <mutex>
+
+#include <plog/Appenders/DebugOutputAppender.h>
+#include <plog/Appenders/RollingFileAppender.h>
+#include <plog/Formatters/TxtFormatter.h>
+#include <plog/Init.h>
+#include <plog/Log.h>
+
+#include <logging/LogUtils.hxx>
+
+#include "UwbSimulatorLogging.hxx"
+
+struct PlogLoggingContext
+{
+    PlogLoggingContext(const char *logIdentity) :
+        RollingFileAppender(logging::GetLogName(logIdentity).c_str())
+    {}
+
+    plog::RollingFileAppender<plog::TxtFormatter> RollingFileAppender;
+    plog::DebugOutputAppender<plog::TxtFormatter> DebugAppender;
+};
+
+PlogLoggingContext &
+GetLoggingContext()
+{
+    // Use magic static to guarantee thread-safe initialization of the logging context.
+    static PlogLoggingContext plogLoggingContext("UwbSimulatorDriver");
+    return plogLoggingContext;
+}
+
+std::once_flag LoggingIsInitializedFlag;
+
+void
+UwbSimulatorLoggingInitialize()
+{
+    std::call_once(LoggingIsInitializedFlag, [] {
+        auto &plogLoggingContext = GetLoggingContext();
+        plog::init(plog::verbose, &plogLoggingContext.RollingFileAppender)
+            .addAppender(&plogLoggingContext.DebugAppender);
+        LOG_INFO << "logging initialized";
+    });
+}

--- a/windows/drivers/uwb/simulator/UwbSimulatorLogging.hxx
+++ b/windows/drivers/uwb/simulator/UwbSimulatorLogging.hxx
@@ -1,0 +1,11 @@
+
+#ifndef UWB_SIMULATOR_LOGGING_HXX
+#define UWB_SIMULATOR_LOGGING_HXX
+
+/**
+ * @brief Initializes logging globally for the driver.
+ */
+void
+UwbSimulatorLoggingInitialize();
+
+#endif UWB_SIMULATOR_LOGGING_HXX


### PR DESCRIPTION
### Type

- [X] Bug fix
- [X] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Ensure plog content from nearobject-framework library code using the plog macros actually goes to a log.

### Technical Details

* Initialize a plog logger on `DriverEntry` with global logging context which includes a rolling log file appender and a debug console appender. The debug appender allows all the plog output to be visible in the immediate and/or output windows in WinDbg/VSDbg.
* Add a missing newline to a driver log print.
* Fix a missing arg from a driver log print.
 
### Test Results

* Ran the standard end-to-end ranging scenario without issue and verified `PLOG_*` content shows up in the debugger immediate Window.

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
