### PR TITLE
Match the FiRa UCI spec for GetApplicationConfigurationParameters

### DIFF
--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -1436,8 +1436,6 @@ windows::devices::uwb::ddi::lrp::To(const UWB_SET_APP_CONFIG_PARAMS &setApplicat
             uwbAppConfigParam = To(destinationMacAddresses.value(), ::uwb::UwbMacAddressType::Short);
         }
         uwbSetApplicationConfigurationParameters.Parameters.push_back(std::move(uwbAppConfigParam));
-    } else {
-        PLOG_ERROR << "missing DestinationMacAddresses value";
     }
 
     return std::move(uwbSetApplicationConfigurationParameters);

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -1410,11 +1410,34 @@ windows::devices::uwb::ddi::lrp::To(const UWB_SET_APP_CONFIG_PARAMS &setApplicat
     };
     uwbSetApplicationConfigurationParameters.Parameters.reserve(setApplicationConfigurationParameters.appConfigParamsCount);
 
+    std::optional<::uwb::UwbMacAddressType> macAddressMode;
+    std::optional<UWB_APP_CONFIG_PARAM> destinationMacAddresses;
     auto *appConfigParam = reinterpret_cast<const UWB_APP_CONFIG_PARAM *>(&setApplicationConfigurationParameters.appConfigParams[0]);
     for (auto i = 0; i < setApplicationConfigurationParameters.appConfigParamsCount; i++) {
-        auto uwbAppConfigParam = To(*appConfigParam);
-        uwbSetApplicationConfigurationParameters.Parameters.push_back(std::move(uwbAppConfigParam));
+        // If parameter is MacAddressMode or DestinationMacAddresses, store value
+        if (To(appConfigParam->paramType) == UwbApplicationConfigurationParameterType::MacAddressMode) {
+            macAddressMode = std::get<::uwb::UwbMacAddressType>(To(*appConfigParam).Value);
+        } else if (To(appConfigParam->paramType) == UwbApplicationConfigurationParameterType::DestinationMacAddresses) {
+            destinationMacAddresses = *appConfigParam;
+        } else {
+            auto uwbAppConfigParam = To(*appConfigParam);
+            uwbSetApplicationConfigurationParameters.Parameters.push_back(std::move(uwbAppConfigParam));
+        }
+
         appConfigParam = reinterpret_cast<const UWB_APP_CONFIG_PARAM *>(reinterpret_cast<uintptr_t>(appConfigParam) + appConfigParam->size);
+    }
+
+    // Now that the other parameters have been converted, convert DestinationMacAddresses with special conversion function
+    if (destinationMacAddresses.has_value()) {
+        UwbApplicationConfigurationParameter uwbAppConfigParam;
+        if (macAddressMode.has_value()) {
+            uwbAppConfigParam = To(destinationMacAddresses.value(), macAddressMode.value());
+        } else {
+            uwbAppConfigParam = To(destinationMacAddresses.value(), ::uwb::UwbMacAddressType::Short);
+        }
+        uwbSetApplicationConfigurationParameters.Parameters.push_back(std::move(uwbAppConfigParam));
+    } else {
+        PLOG_ERROR << "missing DestinationMacAddresses value";
     }
 
     return std::move(uwbSetApplicationConfigurationParameters);

--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -229,8 +229,7 @@ std::vector<UwbApplicationConfigurationParameter>
 UwbSession::GetApplicationConfigurationParametersImpl()
 {
     uint32_t sessionId = GetId();
-    constexpr auto allParameterTypesArray = magic_enum::enum_values<UwbApplicationConfigurationParameterType>();
-    std::vector<UwbApplicationConfigurationParameterType> applicationConfigurationParameterTypes(std::cbegin(allParameterTypesArray), std::cend(allParameterTypesArray));
+    std::vector<UwbApplicationConfigurationParameterType> applicationConfigurationParameterTypes{}; // Leaving empty in order to get ALL set parameters from the device
 
     auto resultFuture = m_uwbSessionConnector->GetApplicationConfigurationParameters(sessionId, applicationConfigurationParameterTypes);
     if (!resultFuture.valid()) {


### PR DESCRIPTION
### Type

- [x] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

This PR fixes a bug (#219 ) where we attempted to get all of the app config parameters from the device by supplying a list of all of the parameter types, when the FiRa UCI spec says we should supply nothing (specifically, a 0 for NumberOfAppConfigParameters).

While fixing this bug, another bug was found (and fixed) with regards to converting DestinationMacAddresses during SetApplicationConfigurationParameters.

### Technical Details

- Supply an empty vector in UwbSession::GetApplicationConfigurationParametersImpl().
- Update the Simulator driver code to properly handle the case where the caller-supplied number of app config parameters is 0.
- Use the special conversion function for DestinationMacAddresses in the conversion function for SetApplicationConfigurationParameters.

### Test Results

nocli outputs expected results when running a basic ranging session with the Simulator driver, which gets the app config parameters after setting them.

### Reviewer Focus

None.

### Future Work

None.

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
