### PR TITLE
Update nocli help description for mac addresses

### DIFF
--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -762,15 +762,8 @@ NearObjectCli::AddSubcommandUwbRangeStart(CLI::App* parent)
     detail::AddEnumOption(rangeStartApp, applicationConfigurationParametersData.deviceRole, true);
     detail::AddEnumOption(rangeStartApp, applicationConfigurationParametersData.multiNodeMode, true);
     rangeStartApp->add_option("--NumberOfControlees", applicationConfigurationParametersData.numberOfControlees, "1-byte integer. Value in { 1-8 }")->capture_default_str()->required();
-
-    std::string deviceMacAddressDescription = "2-byte hexadecimal value, colon-delimited. Short MAC address of own device, e.g. 12:34";
-    std::string dstMacAddressDescription = "Comma-delimited array with 2-byte hexadecimal values, colon-delimited. Short MAC address(es) of other device(s). If device is Controller, list NumberOfControlees mac addresses. If device is Controlee, list Controller mac address";
-    if (applicationConfigurationParametersData.macAddressMode == uwb::UwbMacAddressType::Extended) { // TODO: Enable macAddressMode to be set before checking this value. Otherwise, the default empty value will always be used
-        deviceMacAddressDescription = "8-byte hexadecimal value, colon-delimited. Extended MAC address of own device, e.g. 12:34:56:78:87:65:43:21";
-        dstMacAddressDescription = "Comma-delimited array with 8-byte hexadecimal values, colon-delimited. Extended MAC address(es) of other device(s). If device is Controller, list NumberOfControlees mac addresses. If device is Controlee, list Controller mac address";
-    }
-    rangeStartApp->add_option("--DeviceMacAddress", m_cliData->deviceMacAddressString, deviceMacAddressDescription)->capture_default_str()->required();
-    rangeStartApp->add_option("--DestinationMacAddresses", m_cliData->destinationMacAddressesString, dstMacAddressDescription)->capture_default_str()->required();
+    rangeStartApp->add_option("--DeviceMacAddress", m_cliData->deviceMacAddressString, "2-byte/8-byte hexadecimal value, colon-delimited. Short/Extended MAC address of own device, e.g. 12:34")->capture_default_str()->required();
+    rangeStartApp->add_option("--DestinationMacAddresses", m_cliData->destinationMacAddressesString, "Comma-delimited array with 2-byte/8-byte hexadecimal values, colon-delimited. Short/Extended MAC address(es) of other device(s). If device is Controller, list NumberOfControlees mac addresses. If device is Controlee, list Controller mac address, e.g. 12:34,56:78")->capture_default_str()->required();
     detail::AddEnumOption(rangeStartApp, applicationConfigurationParametersData.deviceType, true);
 
     // List remaining params


### PR DESCRIPTION
### Type

- [x] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

This PR addresses the bug described in #198 . Basically, the mac address description for 8-byte extended addresses would never show because it was based on the value of MacAddressMode, but that value does not (and cannot) get set before the options are displayed by --help, so the descriptions need to be generalized for both short/extended addresses.

### Technical Details

- Generalized the nocli --help descriptions for DeviceMacAddress and DestinationMacAddresses.

### Test Results

nocli output is expected.

### Reviewer Focus

None.

### Future Work

None.

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
