### PR TITLE
Fix nocli help hanging bug

### DIFF
--- a/tools/cli/NearObjectCli.cxx
+++ b/tools/cli/NearObjectCli.cxx
@@ -71,7 +71,9 @@ NearObjectCli::SignalCliAppOperationCompleted(CLI::App* app)
 void
 NearObjectCli::WaitForExecutionComplete()
 {
-    m_cliControlFlowContext->OperationsWaitForComplete();
+    if (m_cliAppOperations.size() > 0) {
+        m_cliControlFlowContext->OperationsWaitForComplete();
+    }
 }
 
 void


### PR DESCRIPTION
### Type

- [x] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

This PR fixes a bug (#206 ) where the --help command in nocli causes the tool to hang indefinitely. This is happening because nocli waits for operations to complete, but the --help command is not considered an operation, so it waits forever.

### Technical Details

- Added check for size of m_cliAppOperations in WaitForExecutionComplete().

### Test Results

The --help command in nocli no longer hangs. Tested with "nocli.exe --help", "nocli.exe uwb --help", and "nocli.exe uwb raw --help". Non-help usage of nocli is not affected and continues to work as expected.

### Reviewer Focus

None.

### Future Work

None.

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
