### PR TITLE
Dereg followup

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -36,7 +36,7 @@
                 "1",
                 "--DeviceMacAddress",
                 "12:34",
-                "--DestinationMacAddress",
+                "--DestinationMacAddresses",
                 "23:45",
                 "--DeviceType",
                 "0"

--- a/lib/uwb/include/uwb/UwbRegisteredCallbacks.hxx
+++ b/lib/uwb/include/uwb/UwbRegisteredCallbacks.hxx
@@ -40,21 +40,21 @@ struct UwbRegisteredSessionEventCallbacks
      * @param session The session for which the event occurred.
      * @param reason The reason the session ended.
      */
-    std::shared_ptr<UwbRegisteredSessionEventCallbacks::OnSessionEnded> OnSessionEnded;
+    std::shared_ptr<UwbRegisteredSessionEventCallbackTypes::OnSessionEnded> OnSessionEnded;
 
     /**
      * @brief Invoked when active ranging starts.
      *
      * @param session The session for which the event occurred.
      */
-    std::shared_ptr<UwbRegisteredSessionEventCallbacks::OnRangingStarted> OnRangingStarted;
+    std::shared_ptr<UwbRegisteredSessionEventCallbackTypes::OnRangingStarted> OnRangingStarted;
 
     /**
      * @brief Invoked when active ranging stops.
      *
      * @param session The session for which the event occurred.
      */
-    std::shared_ptr<UwbRegisteredSessionEventCallbacks::OnRangingStopped> OnRangingStopped;
+    std::shared_ptr<UwbRegisteredSessionEventCallbackTypes::OnRangingStopped> OnRangingStopped;
 
     /**
      * @brief Invoked when the properties of a peer involved in the session
@@ -63,7 +63,7 @@ struct UwbRegisteredSessionEventCallbacks
      * @param session The session for which the event occurred.
      * @param peersChanged A list of peers whose properties changed.
      */
-    std::shared_ptr<UwbRegisteredSessionEventCallbacks::OnPeerPropertiesChanged> OnPeerPropertiesChanged;
+    std::shared_ptr<UwbRegisteredSessionEventCallbackTypes::OnPeerPropertiesChanged> OnPeerPropertiesChanged;
 
     /**
      * @brief Invoked when membership of one or more near peers involved in
@@ -74,7 +74,7 @@ struct UwbRegisteredSessionEventCallbacks
      * @param peersAdded A list of peers that were added to the session.
      * @param peersRemoved A list of peers that were removed from the session.
      */
-    std::shared_ptr<UwbRegisteredSessionEventCallbacks::OnSessionMembershipChanged> OnSessionMembershipChanged;
+    std::shared_ptr<UwbRegisteredSessionEventCallbackTypes::OnSessionMembershipChanged> OnSessionMembershipChanged;
 };
 
 /**
@@ -88,21 +88,21 @@ struct UwbRegisteredDeviceEventCallbacks
      *
      * @param status The generic error that occurred.
      */
-    std::shared_ptr<UwbRegisteredDeviceEventCallbacks::OnStatusChanged> OnStatusChanged;
+    std::shared_ptr<UwbRegisteredDeviceEventCallbackTypes::OnStatusChanged> OnStatusChanged;
 
     /**
      * @brief Invoked when the device status changes.
      *
      * @param statusDevice
      */
-    std::shared_ptr<UwbRegisteredDeviceEventCallbacks::OnDeviceStatusChanged> OnDeviceStatusChanged;
+    std::shared_ptr<UwbRegisteredDeviceEventCallbackTypes::OnDeviceStatusChanged> OnDeviceStatusChanged;
 
     /**
      * @brief Invoked when the status of a session changes.
      *
      * @param statusSession The new status of the session.
      */
-    std::shared_ptr<UwbRegisteredDeviceEventCallbacks::OnSessionStatusChanged> OnSessionStatusChanged;
+    std::shared_ptr<UwbRegisteredDeviceEventCallbackTypes::OnSessionStatusChanged> OnSessionStatusChanged;
 };
 
 /**

--- a/lib/uwb/include/uwb/UwbRegisteredCallbacks.hxx
+++ b/lib/uwb/include/uwb/UwbRegisteredCallbacks.hxx
@@ -11,6 +11,22 @@
 
 namespace uwb
 {
+namespace UwbRegisteredSessionEventCallbackTypes
+{
+using OnSessionEnded = std::function<void(::uwb::UwbSessionEndReason reason)>;
+using OnRangingStarted = std::function<void()>;
+using OnRangingStopped = std::function<void()>;
+using OnPeerPropertiesChanged = std::function<void(const std::vector<UwbPeer> peersChanged)>;
+using OnSessionMembershipChanged = std::function<void(const std::vector<UwbPeer> peersAdded, const std::vector<UwbPeer> peersRemoved)>;
+}; // namespace UwbRegisteredSessionEventCallbackTypes
+
+namespace UwbRegisteredDeviceEventCallbackTypes
+{
+using OnStatusChanged = std::function<void(::uwb::protocol::fira::UwbStatus)>;
+using OnDeviceStatusChanged = std::function<void(::uwb::protocol::fira::UwbStatusDevice)>;
+using OnSessionStatusChanged = std::function<void(::uwb::protocol::fira::UwbSessionStatus)>;
+}; // namespace UwbRegisteredDeviceEventCallbackTypes
+
 /**
  * @brief Interface for receiving events from a UwbSession. This is the primary
  * method to receive information from near peers.
@@ -24,21 +40,21 @@ struct UwbRegisteredSessionEventCallbacks
      * @param session The session for which the event occurred.
      * @param reason The reason the session ended.
      */
-    std::function<void(UwbSessionEndReason reason)> OnSessionEnded;
+    std::shared_ptr<UwbRegisteredSessionEventCallbacks::OnSessionEnded> OnSessionEnded;
 
     /**
      * @brief Invoked when active ranging starts.
      *
      * @param session The session for which the event occurred.
      */
-    std::function<void()> OnRangingStarted;
+    std::shared_ptr<UwbRegisteredSessionEventCallbacks::OnRangingStarted> OnRangingStarted;
 
     /**
      * @brief Invoked when active ranging stops.
      *
      * @param session The session for which the event occurred.
      */
-    std::function<void()> OnRangingStopped;
+    std::shared_ptr<UwbRegisteredSessionEventCallbacks::OnRangingStopped> OnRangingStopped;
 
     /**
      * @brief Invoked when the properties of a peer involved in the session
@@ -47,7 +63,7 @@ struct UwbRegisteredSessionEventCallbacks
      * @param session The session for which the event occurred.
      * @param peersChanged A list of peers whose properties changed.
      */
-    std::function<void(const std::vector<UwbPeer> peersChanged)> OnPeerPropertiesChanged;
+    std::shared_ptr<UwbRegisteredSessionEventCallbacks::OnPeerPropertiesChanged> OnPeerPropertiesChanged;
 
     /**
      * @brief Invoked when membership of one or more near peers involved in
@@ -58,7 +74,7 @@ struct UwbRegisteredSessionEventCallbacks
      * @param peersAdded A list of peers that were added to the session.
      * @param peersRemoved A list of peers that were removed from the session.
      */
-    std::function<void(const std::vector<UwbPeer> peersAdded, const std::vector<UwbPeer> peersRemoved)> OnSessionMembershipChanged;
+    std::shared_ptr<UwbRegisteredSessionEventCallbacks::OnSessionMembershipChanged> OnSessionMembershipChanged;
 };
 
 /**
@@ -72,21 +88,21 @@ struct UwbRegisteredDeviceEventCallbacks
      *
      * @param status The generic error that occurred.
      */
-    std::function<void(::uwb::protocol::fira::UwbStatus)> OnStatusChanged;
+    std::shared_ptr<UwbRegisteredDeviceEventCallbacks::OnStatusChanged> OnStatusChanged;
 
     /**
      * @brief Invoked when the device status changes.
      *
      * @param statusDevice
      */
-    std::function<void(::uwb::protocol::fira::UwbStatusDevice)> OnDeviceStatusChanged;
+    std::shared_ptr<UwbRegisteredDeviceEventCallbacks::OnDeviceStatusChanged> OnDeviceStatusChanged;
 
     /**
      * @brief Invoked when the status of a session changes.
      *
      * @param statusSession The new status of the session.
      */
-    std::function<void(::uwb::protocol::fira::UwbSessionStatus)> OnSessionStatusChanged;
+    std::shared_ptr<UwbRegisteredDeviceEventCallbacks::OnSessionStatusChanged> OnSessionStatusChanged;
 };
 
 /**

--- a/lib/uwb/include/uwb/UwbRegisteredCallbacks.hxx
+++ b/lib/uwb/include/uwb/UwbRegisteredCallbacks.hxx
@@ -40,21 +40,21 @@ struct UwbRegisteredSessionEventCallbacks
      * @param session The session for which the event occurred.
      * @param reason The reason the session ended.
      */
-    std::shared_ptr<UwbRegisteredSessionEventCallbackTypes::OnSessionEnded> OnSessionEnded;
+    std::weak_ptr<UwbRegisteredSessionEventCallbackTypes::OnSessionEnded> OnSessionEnded;
 
     /**
      * @brief Invoked when active ranging starts.
      *
      * @param session The session for which the event occurred.
      */
-    std::shared_ptr<UwbRegisteredSessionEventCallbackTypes::OnRangingStarted> OnRangingStarted;
+    std::weak_ptr<UwbRegisteredSessionEventCallbackTypes::OnRangingStarted> OnRangingStarted;
 
     /**
      * @brief Invoked when active ranging stops.
      *
      * @param session The session for which the event occurred.
      */
-    std::shared_ptr<UwbRegisteredSessionEventCallbackTypes::OnRangingStopped> OnRangingStopped;
+    std::weak_ptr<UwbRegisteredSessionEventCallbackTypes::OnRangingStopped> OnRangingStopped;
 
     /**
      * @brief Invoked when the properties of a peer involved in the session
@@ -63,7 +63,7 @@ struct UwbRegisteredSessionEventCallbacks
      * @param session The session for which the event occurred.
      * @param peersChanged A list of peers whose properties changed.
      */
-    std::shared_ptr<UwbRegisteredSessionEventCallbackTypes::OnPeerPropertiesChanged> OnPeerPropertiesChanged;
+    std::weak_ptr<UwbRegisteredSessionEventCallbackTypes::OnPeerPropertiesChanged> OnPeerPropertiesChanged;
 
     /**
      * @brief Invoked when membership of one or more near peers involved in
@@ -74,7 +74,7 @@ struct UwbRegisteredSessionEventCallbacks
      * @param peersAdded A list of peers that were added to the session.
      * @param peersRemoved A list of peers that were removed from the session.
      */
-    std::shared_ptr<UwbRegisteredSessionEventCallbackTypes::OnSessionMembershipChanged> OnSessionMembershipChanged;
+    std::weak_ptr<UwbRegisteredSessionEventCallbackTypes::OnSessionMembershipChanged> OnSessionMembershipChanged;
 };
 
 /**
@@ -88,21 +88,21 @@ struct UwbRegisteredDeviceEventCallbacks
      *
      * @param status The generic error that occurred.
      */
-    std::shared_ptr<UwbRegisteredDeviceEventCallbackTypes::OnStatusChanged> OnStatusChanged;
+    std::weak_ptr<UwbRegisteredDeviceEventCallbackTypes::OnStatusChanged> OnStatusChanged;
 
     /**
      * @brief Invoked when the device status changes.
      *
      * @param statusDevice
      */
-    std::shared_ptr<UwbRegisteredDeviceEventCallbackTypes::OnDeviceStatusChanged> OnDeviceStatusChanged;
+    std::weak_ptr<UwbRegisteredDeviceEventCallbackTypes::OnDeviceStatusChanged> OnDeviceStatusChanged;
 
     /**
      * @brief Invoked when the status of a session changes.
      *
      * @param statusSession The new status of the session.
      */
-    std::shared_ptr<UwbRegisteredDeviceEventCallbackTypes::OnSessionStatusChanged> OnSessionStatusChanged;
+    std::weak_ptr<UwbRegisteredDeviceEventCallbackTypes::OnSessionStatusChanged> OnSessionStatusChanged;
 };
 
 /**

--- a/lib/uwb/include/uwb/UwbRegisteredCallbacks.hxx
+++ b/lib/uwb/include/uwb/UwbRegisteredCallbacks.hxx
@@ -12,12 +12,6 @@
 namespace uwb
 {
 /**
- * @brief Opaque class forward declaration to help with the deregistration
- *
- */
-class RegisteredCallbackToken;
-
-/**
  * @brief Interface for receiving events from a UwbSession. This is the primary
  * method to receive information from near peers.
  *
@@ -93,6 +87,36 @@ struct UwbRegisteredDeviceEventCallbacks
      * @param statusSession The new status of the session.
      */
     std::function<void(::uwb::protocol::fira::UwbSessionStatus)> OnSessionStatusChanged;
+};
+
+/**
+ * @brief Opaque class forward declaration to help with the deregistration
+ *
+ */
+class RegisteredCallbackToken;
+
+/**
+ * @brief structure containing the tokens corresponding to the callbacks you register
+ * 
+ */
+struct UwbRegisteredSessionEventCallbackTokens
+{
+    std::weak_ptr<RegisteredCallbackToken> OnSessionEndedToken;
+    std::weak_ptr<RegisteredCallbackToken> OnRangingStartedToken;
+    std::weak_ptr<RegisteredCallbackToken> OnRangingStoppedToken;
+    std::weak_ptr<RegisteredCallbackToken> OnPeerPropertiesChangedToken;
+    std::weak_ptr<RegisteredCallbackToken> OnSessionMembershipChangedToken;
+};
+
+/**
+ * @brief structure containing the tokens corresponding to the callbacks you register
+ * 
+ */
+struct UwbRegisteredDeviceEventCallbackToken
+{
+    std::weak_ptr<RegisteredCallbackToken> OnStatusChangedToken;
+    std::weak_ptr<RegisteredCallbackToken> OnDeviceStatusChangedToken;
+    std::weak_ptr<RegisteredCallbackToken> OnSessionStatusChangedToken;
 };
 
 } // namespace uwb

--- a/lib/uwb/include/uwb/UwbRegisteredCallbacks.hxx
+++ b/lib/uwb/include/uwb/UwbRegisteredCallbacks.hxx
@@ -17,28 +17,30 @@ namespace UwbRegisteredSessionEventCallbackTypes
  * @brief Invoked when the session is ended.
  *
  * @param reason The reason the session ended.
+ * @return true if this callback needs to be deregistered
  */
-using OnSessionEnded = std::function<void(::uwb::UwbSessionEndReason reason)>;
+using OnSessionEnded = std::function<bool(::uwb::UwbSessionEndReason reason)>;
 
 /**
  * @brief Invoked when active ranging starts.
- *
+ * @return true if this callback needs to be deregistered
  */
-using OnRangingStarted = std::function<void()>;
+using OnRangingStarted = std::function<bool()>;
 
 /**
  * @brief Invoked when active ranging stops.
- *
+ * @return true if this callback needs to be deregistered
  */
-using OnRangingStopped = std::function<void()>;
+using OnRangingStopped = std::function<bool()>;
 
 /**
  * @brief Invoked when the properties of a peer involved in the session
  * changes. This includes the spatial properties of the peer(s).
  *
  * @param peersChanged A list of peers whose properties changed.
+ * @return true if this callback needs to be deregistered
  */
-using OnPeerPropertiesChanged = std::function<void(const std::vector<UwbPeer> peersChanged)>;
+using OnPeerPropertiesChanged = std::function<bool(const std::vector<UwbPeer> peersChanged)>;
 
 /**
  * @brief Invoked when membership of one or more near peers involved in
@@ -47,8 +49,9 @@ using OnPeerPropertiesChanged = std::function<void(const std::vector<UwbPeer> pe
  *
  * @param peersAdded A list of peers that were added to the session.
  * @param peersRemoved A list of peers that were removed from the session.
+ * @return true if this callback needs to be deregistered
  */
-using OnSessionMembershipChanged = std::function<void(const std::vector<UwbPeer> peersAdded, const std::vector<UwbPeer> peersRemoved)>;
+using OnSessionMembershipChanged = std::function<bool(const std::vector<UwbPeer> peersAdded, const std::vector<UwbPeer> peersRemoved)>;
 }; // namespace UwbRegisteredSessionEventCallbackTypes
 
 namespace UwbRegisteredDeviceEventCallbackTypes
@@ -57,22 +60,25 @@ namespace UwbRegisteredDeviceEventCallbackTypes
  * @brief Invoked when a generic error occurs.
  *
  * @param status The generic error that occurred.
+ * @return true if this callback needs to be deregistered
  */
-using OnStatusChanged = std::function<void(::uwb::protocol::fira::UwbStatus)>;
+using OnStatusChanged = std::function<bool(::uwb::protocol::fira::UwbStatus)>;
 
 /**
  * @brief Invoked when the device status changes.
  *
  * @param statusDevice
+ * @return true if this callback needs to be deregistered
  */
-using OnDeviceStatusChanged = std::function<void(::uwb::protocol::fira::UwbStatusDevice)>;
+using OnDeviceStatusChanged = std::function<bool(::uwb::protocol::fira::UwbStatusDevice)>;
 
 /**
  * @brief Invoked when the status of a session changes.
  *
  * @param statusSession The new status of the session.
+ * @return true if this callback needs to be deregistered
  */
-using OnSessionStatusChanged = std::function<void(::uwb::protocol::fira::UwbSessionStatus)>;
+using OnSessionStatusChanged = std::function<bool(::uwb::protocol::fira::UwbSessionStatus)>;
 }; // namespace UwbRegisteredDeviceEventCallbackTypes
 
 /**

--- a/lib/uwb/include/uwb/UwbRegisteredCallbacks.hxx
+++ b/lib/uwb/include/uwb/UwbRegisteredCallbacks.hxx
@@ -97,7 +97,7 @@ class RegisteredCallbackToken;
 
 /**
  * @brief structure containing the tokens corresponding to the callbacks you register
- * 
+ *
  */
 struct UwbRegisteredSessionEventCallbackTokens
 {
@@ -110,7 +110,7 @@ struct UwbRegisteredSessionEventCallbackTokens
 
 /**
  * @brief structure containing the tokens corresponding to the callbacks you register
- * 
+ *
  */
 struct UwbRegisteredDeviceEventCallbackTokens
 {

--- a/lib/uwb/include/uwb/UwbRegisteredCallbacks.hxx
+++ b/lib/uwb/include/uwb/UwbRegisteredCallbacks.hxx
@@ -13,31 +13,78 @@ namespace uwb
 {
 namespace UwbRegisteredSessionEventCallbackTypes
 {
+/**
+ * @brief Invoked when the session is ended.
+ *
+ * @param reason The reason the session ended.
+ */
 using OnSessionEnded = std::function<void(::uwb::UwbSessionEndReason reason)>;
+
+/**
+ * @brief Invoked when active ranging starts.
+ *
+ */
 using OnRangingStarted = std::function<void()>;
+
+/**
+ * @brief Invoked when active ranging stops.
+ *
+ */
 using OnRangingStopped = std::function<void()>;
+
+/**
+ * @brief Invoked when the properties of a peer involved in the session
+ * changes. This includes the spatial properties of the peer(s).
+ *
+ * @param peersChanged A list of peers whose properties changed.
+ */
 using OnPeerPropertiesChanged = std::function<void(const std::vector<UwbPeer> peersChanged)>;
+
+/**
+ * @brief Invoked when membership of one or more near peers involved in
+ * the session is changed. This can occur when peer members are either
+ * added to or removed from the session.
+ *
+ * @param peersAdded A list of peers that were added to the session.
+ * @param peersRemoved A list of peers that were removed from the session.
+ */
 using OnSessionMembershipChanged = std::function<void(const std::vector<UwbPeer> peersAdded, const std::vector<UwbPeer> peersRemoved)>;
 }; // namespace UwbRegisteredSessionEventCallbackTypes
 
 namespace UwbRegisteredDeviceEventCallbackTypes
 {
+/**
+ * @brief Invoked when a generic error occurs.
+ *
+ * @param status The generic error that occurred.
+ */
 using OnStatusChanged = std::function<void(::uwb::protocol::fira::UwbStatus)>;
+
+/**
+ * @brief Invoked when the device status changes.
+ *
+ * @param statusDevice
+ */
 using OnDeviceStatusChanged = std::function<void(::uwb::protocol::fira::UwbStatusDevice)>;
+
+/**
+ * @brief Invoked when the status of a session changes.
+ *
+ * @param statusSession The new status of the session.
+ */
 using OnSessionStatusChanged = std::function<void(::uwb::protocol::fira::UwbSessionStatus)>;
 }; // namespace UwbRegisteredDeviceEventCallbackTypes
 
 /**
  * @brief Interface for receiving events from a UwbSession. This is the primary
  * method to receive information from near peers.
- *
+ * IMPORTANT The client should save somewhere the shared_ptr to the callbacks that they register.
  */
 struct UwbRegisteredSessionEventCallbacks
 {
     /**
      * @brief Invoked when the session is ended.
      *
-     * @param session The session for which the event occurred.
      * @param reason The reason the session ended.
      */
     std::weak_ptr<UwbRegisteredSessionEventCallbackTypes::OnSessionEnded> OnSessionEnded;
@@ -45,14 +92,12 @@ struct UwbRegisteredSessionEventCallbacks
     /**
      * @brief Invoked when active ranging starts.
      *
-     * @param session The session for which the event occurred.
      */
     std::weak_ptr<UwbRegisteredSessionEventCallbackTypes::OnRangingStarted> OnRangingStarted;
 
     /**
      * @brief Invoked when active ranging stops.
      *
-     * @param session The session for which the event occurred.
      */
     std::weak_ptr<UwbRegisteredSessionEventCallbackTypes::OnRangingStopped> OnRangingStopped;
 
@@ -60,7 +105,6 @@ struct UwbRegisteredSessionEventCallbacks
      * @brief Invoked when the properties of a peer involved in the session
      * changes. This includes the spatial properties of the peer(s).
      *
-     * @param session The session for which the event occurred.
      * @param peersChanged A list of peers whose properties changed.
      */
     std::weak_ptr<UwbRegisteredSessionEventCallbackTypes::OnPeerPropertiesChanged> OnPeerPropertiesChanged;
@@ -70,7 +114,6 @@ struct UwbRegisteredSessionEventCallbacks
      * the session is changed. This can occur when peer members are either
      * added to or removed from the session.
      *
-     * @param session The session for which the event occurred.
      * @param peersAdded A list of peers that were added to the session.
      * @param peersRemoved A list of peers that were removed from the session.
      */

--- a/lib/uwb/include/uwb/UwbRegisteredCallbacks.hxx
+++ b/lib/uwb/include/uwb/UwbRegisteredCallbacks.hxx
@@ -112,7 +112,7 @@ struct UwbRegisteredSessionEventCallbackTokens
  * @brief structure containing the tokens corresponding to the callbacks you register
  * 
  */
-struct UwbRegisteredDeviceEventCallbackToken
+struct UwbRegisteredDeviceEventCallbackTokens
 {
     std::weak_ptr<RegisteredCallbackToken> OnStatusChangedToken;
     std::weak_ptr<RegisteredCallbackToken> OnDeviceStatusChangedToken;

--- a/windows/devices/uwb/UwbConnector.cxx
+++ b/windows/devices/uwb/UwbConnector.cxx
@@ -703,7 +703,7 @@ UwbConnector::HandleNotifications(std::stop_token stopToken)
  */
 template <typename TokenT, typename... ArgTs>
 void
-InvokeCallbacks(std::vector<std::shared_ptr<TokenT>>& tokens, ArgTs... args)
+InvokeCallbacks(std::vector<std::shared_ptr<TokenT>>& tokens, ArgTs&... args)
 {
     if (tokens.empty()) {
         PLOG_INFO << "Ignoring " << typeid(TokenT).name() << " event due to missing callbacks";
@@ -737,7 +737,7 @@ InvokeCallbacks(std::vector<std::shared_ptr<TokenT>>& tokens, ArgTs... args)
  */
 template <typename TokenT, typename... ArgTs>
 void
-InvokeSessionCallbacks(std::unordered_map<uint32_t, std::vector<std::shared_ptr<TokenT>>>& sessionMap, uint32_t sessionId, ArgTs... args)
+InvokeSessionCallbacks(std::unordered_map<uint32_t, std::vector<std::shared_ptr<TokenT>>>& sessionMap, uint32_t sessionId, ArgTs&... args)
 {
     auto node = sessionMap.extract(sessionId);
     if (node.empty()) {
@@ -771,9 +771,11 @@ UwbConnector::OnSessionMulticastListStatus(::uwb::protocol::fira::UwbSessionUpda
         }
     }
 
+    std::vector<::uwb::UwbPeer> peersRemoved{};
+
     PLOG_VERBOSE << "Session with id " << statusMulticastList.SessionId << " executing callback for adding peers";
 
-    InvokeSessionCallbacks<::uwb::OnSessionMembershipChangedToken, std::vector<::uwb::UwbPeer>>(m_onSessionMembershipChangedCallbacks, sessionId, peersAdded, std::vector<::uwb::UwbPeer>{});
+    InvokeSessionCallbacks<::uwb::OnSessionMembershipChangedToken, std::vector<::uwb::UwbPeer>>(m_onSessionMembershipChangedCallbacks, sessionId, peersAdded, peersRemoved);
 
     // Now log the bad status
     IF_PLOG(plog::verbose)

--- a/windows/devices/uwb/UwbConnector.cxx
+++ b/windows/devices/uwb/UwbConnector.cxx
@@ -929,6 +929,10 @@ UwbConnector::RegisterDeviceEventCallbacks(::uwb::UwbRegisteredDeviceEventCallba
             return token;
         });
 
+    if (isFirstCallback) {
+        NotificationListenerStart();
+    }
+
     return {
         OnStatusChangedToken,
         OnDeviceStatusChangedToken,
@@ -1039,6 +1043,10 @@ UwbConnector::RegisterSessionEventCallbacks(uint32_t sessionId, ::uwb::UwbRegist
             return token;
         });
 
+    if (isFirstCallback) {
+        NotificationListenerStart();
+    }
+
     return {
         OnSessionEndedToken,
         OnRangingStartedToken,
@@ -1129,6 +1137,8 @@ UwbConnector::DeregisterEventCallback(std::weak_ptr<::uwb::RegisteredCallbackTok
     }
     std::lock_guard eventCallbacksLockExclusive{ m_eventCallbacksGate };
 
+    auto callbacksPresentPrior = CallbacksPresent();
+
     auto sessionCallback = dynamic_pointer_cast<::uwb::RegisteredSessionCallbackToken>(tokenShared);
     if (sessionCallback) {
         // treat it as a session callback
@@ -1148,5 +1158,8 @@ UwbConnector::DeregisterEventCallback(std::weak_ptr<::uwb::RegisteredCallbackTok
         DeregisterDeviceEventCallback<::uwb::OnStatusChangedToken>(tokenShared, m_onStatusChangedCallbacks) or
             DeregisterDeviceEventCallback<::uwb::OnDeviceStatusChangedToken>(tokenShared, m_onDeviceStatusChangedCallbacks) or
             DeregisterDeviceEventCallback<::uwb::OnSessionStatusChangedToken>(tokenShared, m_onSessionStatusChangedCallbacks);
+    }
+    if ((not CallbacksPresent()) and callbacksPresentPrior) {
+        NotificationListenerStop();
     }
 }

--- a/windows/devices/uwb/UwbConnector.cxx
+++ b/windows/devices/uwb/UwbConnector.cxx
@@ -910,21 +910,21 @@ UwbConnector::RegisterDeviceEventCallbacks(::uwb::UwbRegisteredDeviceEventCallba
         });
 
     auto OnDeviceStatusChangedToken = GetToken<::uwb::UwbRegisteredDeviceEventCallbackTypes::OnDeviceStatusChanged>(
-        callbacks, [](auto&& cbs) {
-            return cbs.OnDeviceStatusChanged;
+        callbacks, [](auto&& callbackStruct) {
+            return callbackStruct.OnDeviceStatusChanged;
         },
-        [this](auto&& cb) {
-            auto token = std::make_shared<::uwb::OnDeviceStatusChangedToken>(cb);
+        [this](auto&& callback) {
+            auto token = std::make_shared<::uwb::OnDeviceStatusChangedToken>(callback);
             m_onDeviceStatusChangedCallbacks.push_back(token);
             return token;
         });
 
     auto OnSessionStatusChangedToken = GetToken<::uwb::UwbRegisteredDeviceEventCallbackTypes::OnSessionStatusChanged>(
-        callbacks, [](auto&& cbs) {
-            return cbs.OnSessionStatusChanged;
+        callbacks, [](auto&& callbackStruct) {
+            return callbackStruct.OnSessionStatusChanged;
         },
-        [this](auto&& cb) {
-            auto token = std::make_shared<::uwb::OnSessionStatusChangedToken>(cb);
+        [this](auto&& callback) {
+            auto token = std::make_shared<::uwb::OnSessionStatusChangedToken>(callback);
             m_onSessionStatusChangedCallbacks.push_back(token);
             return token;
         });
@@ -991,50 +991,50 @@ UwbConnector::RegisterSessionEventCallbacks(uint32_t sessionId, ::uwb::UwbRegist
     bool isFirstCallback = not CallbacksPresent();
 
     auto OnSessionEndedToken = GetToken<::uwb::UwbRegisteredSessionEventCallbackTypes::OnSessionEnded>(
-        sessionId, callbacks, [](auto&& cbs) {
-            return cbs.OnSessionEnded;
+        sessionId, callbacks, [](auto&& callbackStruct) {
+            return callbackStruct.OnSessionEnded;
         },
-        [this](uint32_t sessionId, auto&& cb) {
-            auto token = std::make_shared<::uwb::OnSessionEndedToken>(sessionId, cb);
+        [this](uint32_t sessionId, auto&& callback) {
+            auto token = std::make_shared<::uwb::OnSessionEndedToken>(sessionId, callback);
             InsertSessionToken(m_onSessionEndedCallbacks, sessionId, token);
             return token;
         });
 
     auto OnRangingStartedToken = GetToken<::uwb::UwbRegisteredSessionEventCallbackTypes::OnRangingStarted>(
-        sessionId, callbacks, [](auto&& cbs) {
-            return cbs.OnRangingStarted;
+        sessionId, callbacks, [](auto&& callbackStruct) {
+            return callbackStruct.OnRangingStarted;
         },
-        [this](uint32_t sessionId, auto&& cb) {
-            auto token = std::make_shared<::uwb::OnRangingStartedToken>(sessionId, cb);
+        [this](uint32_t sessionId, auto&& callback) {
+            auto token = std::make_shared<::uwb::OnRangingStartedToken>(sessionId, callback);
             InsertSessionToken(m_onRangingStartedCallbacks, sessionId, token);
             return token;
         });
 
     auto OnRangingStoppedToken = GetToken<::uwb::UwbRegisteredSessionEventCallbackTypes::OnRangingStopped>(
-        sessionId, callbacks, [](auto&& cbs) {
-            return cbs.OnRangingStopped;
+        sessionId, callbacks, [](auto&& callbackStruct) {
+            return callbackStruct.OnRangingStopped;
         },
-        [this](uint32_t sessionId, auto&& cb) {
-            auto token = std::make_shared<::uwb::OnRangingStoppedToken>(sessionId, cb);
+        [this](uint32_t sessionId, auto&& callback) {
+            auto token = std::make_shared<::uwb::OnRangingStoppedToken>(sessionId, callback);
             InsertSessionToken(m_onRangingStoppedCallbacks, sessionId, token);
             return token;
         });
 
     auto OnPeerPropertiesChangedToken = GetToken<::uwb::UwbRegisteredSessionEventCallbackTypes::OnPeerPropertiesChanged>(
-        sessionId, callbacks, [](auto&& cbs) {
-            return cbs.OnPeerPropertiesChanged;
+        sessionId, callbacks, [](auto&& callbackStruct) {
+            return callbackStruct.OnPeerPropertiesChanged;
         },
-        [this](uint32_t sessionId, auto&& cb) {
-            auto token = std::make_shared<::uwb::OnPeerPropertiesChangedToken>(sessionId, cb);
+        [this](uint32_t sessionId, auto&& callback) {
+            auto token = std::make_shared<::uwb::OnPeerPropertiesChangedToken>(sessionId, callback);
             InsertSessionToken(m_onPeerPropertiesChangedCallbacks, sessionId, token);
             return token;
         });
     auto OnSessionMembershipChangedToken = GetToken<::uwb::UwbRegisteredSessionEventCallbackTypes::OnSessionMembershipChanged>(
-        sessionId, callbacks, [](auto&& cbs) {
-            return cbs.OnSessionMembershipChanged;
+        sessionId, callbacks, [](auto&& callbackStruct) {
+            return callbackStruct.OnSessionMembershipChanged;
         },
-        [this](uint32_t sessionId, auto&& cb) {
-            auto token = std::make_shared<::uwb::OnSessionMembershipChangedToken>(sessionId, cb);
+        [this](uint32_t sessionId, auto&& callback) {
+            auto token = std::make_shared<::uwb::OnSessionMembershipChangedToken>(sessionId, callback);
             InsertSessionToken(m_onSessionMembershipChangedCallbacks, sessionId, token);
             return token;
         });

--- a/windows/devices/uwb/UwbConnector.cxx
+++ b/windows/devices/uwb/UwbConnector.cxx
@@ -897,7 +897,7 @@ GetToken(::uwb::UwbRegisteredDeviceEventCallbacks callbacks, std::function<std::
 UwbConnector::RegisterDeviceEventCallbacks(::uwb::UwbRegisteredDeviceEventCallbacks callbacks)
 {
     std::lock_guard eventCallbacksLockExclusive{ m_eventCallbacksGate };
-    bool isFirstCallback = not CallbacksPresent();
+    bool noCallbacksPrior = not CallbacksPresent();
 
     auto OnStatusChangedToken = GetToken<::uwb::UwbRegisteredDeviceEventCallbackTypes::OnStatusChanged>(
         callbacks, [](auto&& callbackStruct) {
@@ -929,7 +929,7 @@ UwbConnector::RegisterDeviceEventCallbacks(::uwb::UwbRegisteredDeviceEventCallba
             return token;
         });
 
-    if (isFirstCallback) {
+    if (noCallbacksPrior and CallbacksPresent()) {
         NotificationListenerStart();
     }
 
@@ -992,7 +992,7 @@ GetToken(uint32_t sessionId, ::uwb::UwbRegisteredSessionEventCallbacks callbacks
 UwbConnector::RegisterSessionEventCallbacks(uint32_t sessionId, ::uwb::UwbRegisteredSessionEventCallbacks callbacks)
 {
     std::lock_guard eventCallbacksLockExclusive{ m_eventCallbacksGate };
-    bool isFirstCallback = not CallbacksPresent();
+    bool noCallbacksPrior = not CallbacksPresent();
 
     auto OnSessionEndedToken = GetToken<::uwb::UwbRegisteredSessionEventCallbackTypes::OnSessionEnded>(
         sessionId, callbacks, [](auto&& callbackStruct) {
@@ -1043,7 +1043,7 @@ UwbConnector::RegisterSessionEventCallbacks(uint32_t sessionId, ::uwb::UwbRegist
             return token;
         });
 
-    if (isFirstCallback) {
+    if (noCallbacksPrior and CallbacksPresent()) {
         NotificationListenerStart();
     }
 

--- a/windows/devices/uwb/UwbConnector.cxx
+++ b/windows/devices/uwb/UwbConnector.cxx
@@ -1134,20 +1134,19 @@ UwbConnector::DeregisterEventCallback(std::weak_ptr<::uwb::RegisteredCallbackTok
         // treat it as a session callback
         auto sessionId = sessionCallback->SessionId;
 
-        DeregisterSessionEventCallback<::uwb::OnSessionEndedToken>(tokenShared, m_onSessionEndedCallbacks)                               ? 0
-            : DeregisterSessionEventCallback<::uwb::OnRangingStartedToken>(tokenShared, m_onRangingStartedCallbacks)                     ? 0
-            : DeregisterSessionEventCallback<::uwb::OnRangingStoppedToken>(tokenShared, m_onRangingStoppedCallbacks)                     ? 0
-            : DeregisterSessionEventCallback<::uwb::OnPeerPropertiesChangedToken>(tokenShared, m_onPeerPropertiesChangedCallbacks)       ? 0
-            : DeregisterSessionEventCallback<::uwb::OnSessionMembershipChangedToken>(tokenShared, m_onSessionMembershipChangedCallbacks) ? 0
-                                                                                                                                         : 0;
+        DeregisterSessionEventCallback<::uwb::OnSessionEndedToken>(tokenShared, m_onSessionEndedCallbacks) or
+            DeregisterSessionEventCallback<::uwb::OnRangingStartedToken>(tokenShared, m_onRangingStartedCallbacks) or
+            DeregisterSessionEventCallback<::uwb::OnRangingStoppedToken>(tokenShared, m_onRangingStoppedCallbacks) or
+            DeregisterSessionEventCallback<::uwb::OnPeerPropertiesChangedToken>(tokenShared, m_onPeerPropertiesChangedCallbacks) or
+            DeregisterSessionEventCallback<::uwb::OnSessionMembershipChangedToken>(tokenShared, m_onSessionMembershipChangedCallbacks);
+
     } else {
         auto deviceCallback = std::dynamic_pointer_cast<::uwb::RegisteredDeviceCallbackToken>(tokenShared);
         if (deviceCallback == nullptr) {
             throw std::runtime_error("invalid callback type used, this is a bug!");
         }
-        DeregisterDeviceEventCallback<::uwb::OnStatusChangedToken>(tokenShared, m_onStatusChangedCallbacks)                     ? 0
-            : DeregisterDeviceEventCallback<::uwb::OnDeviceStatusChangedToken>(tokenShared, m_onDeviceStatusChangedCallbacks)   ? 0
-            : DeregisterDeviceEventCallback<::uwb::OnSessionStatusChangedToken>(tokenShared, m_onSessionStatusChangedCallbacks) ? 0
-                                                                                                                                : 0;
+        DeregisterDeviceEventCallback<::uwb::OnStatusChangedToken>(tokenShared, m_onStatusChangedCallbacks) or
+            DeregisterDeviceEventCallback<::uwb::OnDeviceStatusChangedToken>(tokenShared, m_onDeviceStatusChangedCallbacks) or
+            DeregisterDeviceEventCallback<::uwb::OnSessionStatusChangedToken>(tokenShared, m_onSessionStatusChangedCallbacks);
     }
 }

--- a/windows/devices/uwb/UwbConnector.cxx
+++ b/windows/devices/uwb/UwbConnector.cxx
@@ -822,6 +822,8 @@ UwbConnector::DispatchCallbacks(::uwb::protocol::fira::UwbNotificationData uwbNo
 
     LOG_DEBUG << "received notification: " << ToString(uwbNotificationData);
 
+    std::lock_guard eventCallbacksLockExclusive{ m_eventCallbacksGate };
+
     std::visit([this](auto&& arg) {
         using ValueType = std::decay_t<decltype(arg)>;
 

--- a/windows/devices/uwb/UwbConnector.cxx
+++ b/windows/devices/uwb/UwbConnector.cxx
@@ -28,19 +28,33 @@ struct RegisteredCallbackToken
 
 struct RegisteredSessionCallbackToken : public RegisteredCallbackToken
 {
-    RegisteredSessionCallbackToken(uint32_t sessionId, std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbacks> callbacks) :
+    RegisteredSessionCallbackToken(uint32_t sessionId) :
+        SessionId(sessionId){};
+    uint32_t SessionId;
+};
+
+struct RegisteredDeviceCallbackToken : public RegisteredCallbackToken
+{
+};
+
+class OnSessionEndedToken : public RegisteredSessionCallbackToken
+{
+    OnSessionEndedToken(uint32_t sessionId, std::weak_ptr<::uwb::OnSessionEndedToken> callbacks) :
         SessionId(sessionId),
         Callbacks(std::move(callbacks)){};
     uint32_t SessionId;
     std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbacks> Callbacks;
 };
+class OnRangingStartedToken;
+class OnRangingStoppedToken;
+class OnPeerPropertiesChangedToken;
+class OnSessionMembershipChangedToken;
 
-struct RegisteredDeviceCallbackToken : public RegisteredCallbackToken
-{
-    RegisteredDeviceCallbackToken(std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbacks> callbacks) :
-        Callbacks(Callbacks){};
-    std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbacks> Callbacks;
-};
+class RegisteredDeviceCallbackToken;
+class OnStatusChangedToken;
+class OnDeviceStatusChangedToken;
+class OnSessionStatusChangedToken;
+
 } // namespace uwb
 
 UwbConnector::UwbConnector(std::string deviceName) :

--- a/windows/devices/uwb/UwbConnector.cxx
+++ b/windows/devices/uwb/UwbConnector.cxx
@@ -1062,7 +1062,7 @@ UwbConnector::CallbacksPresent()
  * @tparam T the type to try to dynamic_cast this token to
  * @param token
  * @param tokensMap
- * @return true if this succeeded in removing the token
+ * @return true if this succeeded in finding the class to cast the token to
  * @return false
  */
 template <typename T>
@@ -1077,7 +1077,7 @@ DeregisterSessionEventCallback(std::shared_ptr<::uwb::RegisteredCallbackToken> t
 
     auto node = tokensMap.extract(sessionId);
     if (node.empty()) {
-        return false; // sessionId has no associated tokens
+        return true; // sessionId has no associated tokens
     }
 
     auto tokens = node.mapped();
@@ -1085,7 +1085,7 @@ DeregisterSessionEventCallback(std::shared_ptr<::uwb::RegisteredCallbackToken> t
         return token.get() == callback.get();
     });
     if (tokenIt == std::cend(tokens)) {
-        return false; // no associated token found, bail
+        return true; // no associated token found, bail
     }
     tokens.erase(tokenIt);
     tokensMap.insert(std::move(node));
@@ -1098,7 +1098,7 @@ DeregisterSessionEventCallback(std::shared_ptr<::uwb::RegisteredCallbackToken> t
  * @tparam T the type to try to dynamic_cast this token to
  * @param token
  * @param tokens
- * @return true if this succeeded in removing the token
+ * @return true if this succeeded in finding the class to cast the token to
  * @return false
  */
 template <typename T>
@@ -1114,7 +1114,7 @@ DeregisterDeviceEventCallback(std::shared_ptr<::uwb::RegisteredCallbackToken> to
         return token.get() == callback.get();
     });
     if (tokenIt == std::cend(tokens)) {
-        return false; // no associated token found, bail
+        return true; // no associated token found, bail
     }
     tokens.erase(tokenIt);
     return true;

--- a/windows/devices/uwb/UwbConnector.cxx
+++ b/windows/devices/uwb/UwbConnector.cxx
@@ -720,8 +720,12 @@ InvokeCallbacks(std::vector<std::shared_ptr<TokenT>>& tokens, ArgTs&... args)
             if (not callback) {
                 it = tokens.erase(it);
             }
-            callback(args...);
-            it = std::next(it);
+            auto remove = callback(args...);
+            if (remove) {
+                it = tokens.erase(it);
+            } else {
+                it = std::next(it);
+            }
         }
     }
 }

--- a/windows/devices/uwb/UwbConnector.cxx
+++ b/windows/devices/uwb/UwbConnector.cxx
@@ -21,6 +21,22 @@ using namespace ::uwb::protocol::fira;
 
 namespace uwb
 {
+namespace UwbRegisteredSessionEventCallbackTypes
+{
+using OnSessionEnded = std::function<void(UwbSessionEndReason reason)>;
+using OnRangingStarted = std::function<void()>;
+using OnRangingStopped = std::function<void()>;
+using OnPeerPropertiesChanged = std::function<void(const std::vector<UwbPeer> peersChanged)>;
+using OnSessionMembershipChanged = std::function<void(const std::vector<UwbPeer> peersAdded, const std::vector<UwbPeer> peersRemoved)>;
+}; // namespace UwbRegisteredSessionEventCallbackTypes
+
+namespace UwbRegisteredDeviceEventCallbackTypes
+{
+using OnStatusChanged = std::function<void(::uwb::protocol::fira::UwbStatus)>;
+using OnDeviceStatusChanged = std::function<void(::uwb::protocol::fira::UwbStatusDevice)>;
+using OnSessionStatusChanged = std::function<void(::uwb::protocol::fira::UwbSessionStatus)>;
+}; // namespace UwbRegisteredDeviceEventCallbackTypes
+
 struct RegisteredCallbackToken
 {
     virtual ~RegisteredCallbackToken() = default;
@@ -33,28 +49,63 @@ struct RegisteredSessionCallbackToken : public RegisteredCallbackToken
     uint32_t SessionId;
 };
 
+class OnSessionEndedToken : public RegisteredSessionCallbackToken
+{
+    OnSessionEndedToken(uint32_t sessionId, std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbackTypes::OnSessionEnded> callback) :
+        RegisteredSessionCallbackToken(sessionId),
+        Callback(std::move(callback)){};
+    std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbackTypes::OnSessionEnded> Callback;
+};
+class OnRangingStartedToken : public RegisteredSessionCallbackToken
+{
+    OnRangingStartedToken(uint32_t sessionId, std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbackTypes::OnRangingStarted> callback) :
+        RegisteredSessionCallbackToken(sessionId),
+        Callback(std::move(callback)){};
+    std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbackTypes::OnRangingStarted> Callback;
+};
+class OnRangingStoppedToken : public RegisteredSessionCallbackToken
+{
+    OnRangingStoppedToken(uint32_t sessionId, std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbackTypes::OnRangingStopped> callback) :
+        RegisteredSessionCallbackToken(sessionId),
+        Callback(std::move(callback)){};
+    std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbackTypes::OnRangingStopped> Callback;
+};
+class OnPeerPropertiesChangedToken : public RegisteredSessionCallbackToken
+{
+    OnPeerPropertiesChangedToken(uint32_t sessionId, std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbackTypes::OnPeerPropertiesChanged> callback) :
+        RegisteredSessionCallbackToken(sessionId),
+        Callback(std::move(callback)){};
+    std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbackTypes::OnPeerPropertiesChanged> Callback;
+};
+class OnSessionMembershipChangedToken : public RegisteredSessionCallbackToken
+{
+    OnSessionMembershipChangedToken(uint32_t sessionId, std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbackTypes::OnSessionMembershipChanged> callback) :
+        RegisteredSessionCallbackToken(sessionId),
+        Callback(std::move(callback)){};
+    std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbackTypes::OnSessionMembershipChanged> Callback;
+};
+
 struct RegisteredDeviceCallbackToken : public RegisteredCallbackToken
 {
 };
-
-class OnSessionEndedToken : public RegisteredSessionCallbackToken
+class OnStatusChangedToken : public RegisteredDeviceCallbackToken
 {
-    OnSessionEndedToken(uint32_t sessionId, std::weak_ptr<::uwb::OnSessionEndedToken> callbacks) :
-        SessionId(sessionId),
-        Callbacks(std::move(callbacks)){};
-    uint32_t SessionId;
-    std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbacks> Callbacks;
+    OnStatusChangedToken(std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbackTypes::OnStatusChanged> callback) :
+        Callback(std::move(callback)){};
+    std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbackTypes::OnStatusChanged> Callback;
 };
-class OnRangingStartedToken;
-class OnRangingStoppedToken;
-class OnPeerPropertiesChangedToken;
-class OnSessionMembershipChangedToken;
-
-class RegisteredDeviceCallbackToken;
-class OnStatusChangedToken;
-class OnDeviceStatusChangedToken;
-class OnSessionStatusChangedToken;
-
+class OnDeviceStatusChangedToken : public RegisteredDeviceCallbackToken
+{
+    OnDeviceStatusChangedToken(std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbackTypes::OnDeviceStatusChanged> callback) :
+        Callback(std::move(callback)){};
+    std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbackTypes::OnDeviceStatusChanged> Callback;
+};
+class OnSessionStatusChangedToken : public RegisteredDeviceCallbackToken
+{
+    OnSessionStatusChangedToken(std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbackTypes::OnSessionStatusChanged> callback) :
+        Callback(std::move(callback)){};
+    std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbackTypes::OnSessionStatusChanged> Callback;
+};
 } // namespace uwb
 
 UwbConnector::UwbConnector(std::string deviceName) :

--- a/windows/devices/uwb/UwbDevice.cxx
+++ b/windows/devices/uwb/UwbDevice.cxx
@@ -23,15 +23,15 @@ UwbDevice::UwbDevice(std::string deviceName) :
     m_deviceName(std::move(deviceName))
 {
     m_callbacks = std::make_shared<::uwb::UwbRegisteredDeviceEventCallbacks>(
-        [this](::uwb::protocol::fira::UwbStatus status) {
+        std::make_shared<::uwb::UwbRegisteredDeviceEventCallbackTypes::OnStatusChanged>([this](::uwb::protocol::fira::UwbStatus status) {
             return OnStatusChanged(status);
-        },
-        [this](::uwb::protocol::fira::UwbStatusDevice status) {
+        }),
+        std::make_shared<::uwb::UwbRegisteredDeviceEventCallbackTypes::OnDeviceStatusChanged>([this](::uwb::protocol::fira::UwbStatusDevice status) {
             return OnDeviceStatusChanged(status);
-        },
-        [this](::uwb::protocol::fira::UwbSessionStatus status) {
+        }),
+        std::make_shared<::uwb::UwbRegisteredDeviceEventCallbackTypes::OnSessionStatusChanged>([this](::uwb::protocol::fira::UwbSessionStatus status) {
             return OnSessionStatusChanged(status);
-        });
+        }));
 }
 
 /* static */

--- a/windows/devices/uwb/UwbDevice.cxx
+++ b/windows/devices/uwb/UwbDevice.cxx
@@ -22,16 +22,15 @@ using namespace ::uwb::protocol::fira;
 UwbDevice::UwbDevice(std::string deviceName) :
     m_deviceName(std::move(deviceName))
 {
-    m_callbacks = std::make_shared<::uwb::UwbRegisteredDeviceEventCallbacks>(
-        std::make_shared<::uwb::UwbRegisteredDeviceEventCallbackTypes::OnStatusChanged>([this](::uwb::protocol::fira::UwbStatus status) {
-            return OnStatusChanged(status);
-        }),
-        std::make_shared<::uwb::UwbRegisteredDeviceEventCallbackTypes::OnDeviceStatusChanged>([this](::uwb::protocol::fira::UwbStatusDevice status) {
-            return OnDeviceStatusChanged(status);
-        }),
-        std::make_shared<::uwb::UwbRegisteredDeviceEventCallbackTypes::OnSessionStatusChanged>([this](::uwb::protocol::fira::UwbSessionStatus status) {
-            return OnSessionStatusChanged(status);
-        }));
+    m_onStatusChangedCallback = std::make_shared<::uwb::UwbRegisteredDeviceEventCallbackTypes::OnStatusChanged>([this](::uwb::protocol::fira::UwbStatus status) {
+        return OnStatusChanged(status);
+    });
+    m_onDeviceStatusChangedCallback = std::make_shared<::uwb::UwbRegisteredDeviceEventCallbackTypes::OnDeviceStatusChanged>([this](::uwb::protocol::fira::UwbStatusDevice status) {
+        return OnDeviceStatusChanged(status);
+    });
+    m_onSessionStatusChangedCallback = std::make_shared<::uwb::UwbRegisteredDeviceEventCallbackTypes::OnSessionStatusChanged>([this](::uwb::protocol::fira::UwbSessionStatus status) {
+        return OnSessionStatusChanged(status);
+    });
 }
 
 /* static */
@@ -180,7 +179,7 @@ UwbDevice::InitializeImpl()
     auto uwbConnector = std::make_shared<UwbConnector>(m_deviceName);
     m_uwbDeviceConnector = uwbConnector;
     m_uwbSessionConnector = uwbConnector;
-    m_callbacksToken = m_uwbDeviceConnector->RegisterDeviceEventCallbacks(m_callbacks);
+    m_callbacksToken = m_uwbDeviceConnector->RegisterDeviceEventCallbacks({ m_onStatusChangedCallback, m_onDeviceStatusChangedCallback, m_onSessionStatusChangedCallback });
     return true;
 }
 

--- a/windows/devices/uwb/UwbDevice.cxx
+++ b/windows/devices/uwb/UwbDevice.cxx
@@ -23,13 +23,16 @@ UwbDevice::UwbDevice(std::string deviceName) :
     m_deviceName(std::move(deviceName))
 {
     m_onStatusChangedCallback = std::make_shared<::uwb::UwbRegisteredDeviceEventCallbackTypes::OnStatusChanged>([this](::uwb::protocol::fira::UwbStatus status) {
-        return OnStatusChanged(status);
+        OnStatusChanged(status);
+        return false;
     });
     m_onDeviceStatusChangedCallback = std::make_shared<::uwb::UwbRegisteredDeviceEventCallbackTypes::OnDeviceStatusChanged>([this](::uwb::protocol::fira::UwbStatusDevice status) {
-        return OnDeviceStatusChanged(status);
+        OnDeviceStatusChanged(status);
+        return false;
     });
     m_onSessionStatusChangedCallback = std::make_shared<::uwb::UwbRegisteredDeviceEventCallbackTypes::OnSessionStatusChanged>([this](::uwb::protocol::fira::UwbSessionStatus status) {
-        return OnSessionStatusChanged(status);
+        OnSessionStatusChanged(status);
+        return false;
     });
 }
 

--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -22,48 +22,48 @@ UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<::uwb::UwbDevice> devic
     m_uwbSessionConnector(std::move(uwbSessionConnector))
 {
     m_registeredCallbacks = std::make_shared<::uwb::UwbRegisteredSessionEventCallbacks>(
-        [this](::uwb::UwbSessionEndReason reason) {
+        std::make_shared<::uwb::UwbRegisteredSessionEventCallbackTypes::OnSessionEnded>([this](::uwb::UwbSessionEndReason reason) {
             auto callbacks = ResolveEventCallbacks();
             if (callbacks == nullptr) {
                 PLOG_WARNING << "missing session event callback for UwbSessionEndReason, skipping";
                 // TODO deregister
             }
             return callbacks->OnSessionEnded(this, reason);
-        },
-        [this]() {
+        }),
+        std::make_shared<::uwb::UwbRegisteredSessionEventCallbackTypes::OnRangingStarted>([this]() {
             auto callbacks = ResolveEventCallbacks();
             if (callbacks == nullptr) {
                 PLOG_WARNING << "missing session event callback for ranging started, skipping";
                 // TODO deregister
             }
             return callbacks->OnRangingStarted(this);
-        },
-        [this]() {
+        }),
+        std::make_shared<::uwb::UwbRegisteredSessionEventCallbackTypes::OnRangingStopped>([this]() {
             auto callbacks = ResolveEventCallbacks();
             if (callbacks == nullptr) {
                 PLOG_WARNING << "missing session event callback for ranging stopped, skipping";
                 // TODO deregister
             }
             return callbacks->OnRangingStopped(this);
-        },
-        [this](const std::vector<::uwb::UwbPeer> peersChanged) {
+        }),
+        std::make_shared<::uwb::UwbRegisteredSessionEventCallbackTypes::OnPeerPropertiesChanged>([this](const std::vector<::uwb::UwbPeer> peersChanged) {
             auto callbacks = ResolveEventCallbacks();
             if (callbacks == nullptr) {
                 PLOG_WARNING << "missing session event callback for ranging data, skipping";
                 // TODO deregister
             }
             return callbacks->OnPeerPropertiesChanged(this, peersChanged);
-        },
-        [this](const std::vector<::uwb::UwbPeer> peersAdded, const std::vector<::uwb::UwbPeer> peersRemoved) {
+        }),
+        std::make_shared<::uwb::UwbRegisteredSessionEventCallbackTypes::OnSessionMembershipChanged>([this](const std::vector<::uwb::UwbPeer> peersAdded, const std::vector<::uwb::UwbPeer> peersRemoved) {
             auto callbacks = ResolveEventCallbacks();
             if (callbacks == nullptr) {
                 PLOG_WARNING << "missing session event callback for peer list changes, skipping";
                 // TODO deregister
             }
             return callbacks->OnSessionMembershipChanged(this, peersAdded, peersRemoved);
-        });
+        }));
 
-    m_registeredCallbacksToken = m_uwbSessionConnector->RegisterSessionEventCallbacks(m_sessionId, m_registeredCallbacks);
+    m_registeredCallbacksTokens = m_uwbSessionConnector->RegisterSessionEventCallbacks(m_sessionId, m_registeredCallbacks);
 }
 
 UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<::uwb::UwbDevice> device, std::shared_ptr<IUwbSessionDdiConnector> uwbSessionConnector, ::uwb::protocol::fira::DeviceType deviceType) :

--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -26,44 +26,49 @@ UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<::uwb::UwbDevice> devic
             auto callbacks = ResolveEventCallbacks();
             if (callbacks == nullptr) {
                 PLOG_WARNING << "missing session event callback for UwbSessionEndReason, skipping";
-                // TODO deregister
+                return true;
             }
-            return callbacks->OnSessionEnded(this, reason);
+            callbacks->OnSessionEnded(this, reason);
+            return false;
         });
     m_onRangingStartedCallback = std::make_shared<::uwb::UwbRegisteredSessionEventCallbackTypes::OnRangingStarted>([this]() {
         auto callbacks = ResolveEventCallbacks();
         if (callbacks == nullptr) {
             PLOG_WARNING << "missing session event callback for ranging started, skipping";
-            // TODO deregister
+            return true;
         }
-        return callbacks->OnRangingStarted(this);
+        callbacks->OnRangingStarted(this);
+        return false;
     });
     m_onRangingStoppedCallback =
         std::make_shared<::uwb::UwbRegisteredSessionEventCallbackTypes::OnRangingStopped>([this]() {
             auto callbacks = ResolveEventCallbacks();
             if (callbacks == nullptr) {
                 PLOG_WARNING << "missing session event callback for ranging stopped, skipping";
-                // TODO deregister
+                return true;
             }
-            return callbacks->OnRangingStopped(this);
+            callbacks->OnRangingStopped(this);
+            return false;
         });
     m_onPeerPropertiesChangedCallback =
         std::make_shared<::uwb::UwbRegisteredSessionEventCallbackTypes::OnPeerPropertiesChanged>([this](const std::vector<::uwb::UwbPeer> peersChanged) {
             auto callbacks = ResolveEventCallbacks();
             if (callbacks == nullptr) {
                 PLOG_WARNING << "missing session event callback for ranging data, skipping";
-                // TODO deregister
+                return true;
             }
-            return callbacks->OnPeerPropertiesChanged(this, peersChanged);
+            callbacks->OnPeerPropertiesChanged(this, peersChanged);
+            return false;
         });
     m_onSessionMembershipChangedCallback =
         std::make_shared<::uwb::UwbRegisteredSessionEventCallbackTypes::OnSessionMembershipChanged>([this](const std::vector<::uwb::UwbPeer> peersAdded, const std::vector<::uwb::UwbPeer> peersRemoved) {
             auto callbacks = ResolveEventCallbacks();
             if (callbacks == nullptr) {
                 PLOG_WARNING << "missing session event callback for peer list changes, skipping";
-                // TODO deregister
+                return true;
             }
-            return callbacks->OnSessionMembershipChanged(this, peersAdded, peersRemoved);
+            callbacks->OnSessionMembershipChanged(this, peersAdded, peersRemoved);
+            return false;
         });
 
     m_registeredCallbacksTokens = m_uwbSessionConnector->RegisterSessionEventCallbacks(m_sessionId, { m_onSessionEndedCallback, m_onRangingStartedCallback, m_onRangingStoppedCallback, m_onPeerPropertiesChangedCallback, m_onSessionMembershipChangedCallback });

--- a/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
@@ -47,9 +47,9 @@ struct IUwbDeviceDdiConnector : public IUwbDeviceDdi
      * @brief Sets the callbacks for the UwbDevice that owns this UwbConnector
      *
      * @param callbacks
-     * @return std::weak_ptr<::uwb::RegisteredCallbackToken> You can pass this pointer into DeregisterEventCallback to deregister this event callback
+     * @return ::uwb::UwbRegisteredDeviceEventCallbackTokens You can pass the pointers into DeregisterEventCallback to deregister the event callbacks
      */
-    virtual std::weak_ptr<::uwb::RegisteredCallbackToken> RegisterDeviceEventCallbacks(std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbacks>) = 0;
+    virtual ::uwb::UwbRegisteredDeviceEventCallbackTokens RegisterDeviceEventCallbacks(std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbacks> callbacks) = 0;
 };
 
 } // namespace windows::devices::uwb

--- a/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
@@ -49,7 +49,8 @@ struct IUwbDeviceDdiConnector : public IUwbDeviceDdi
      * @param callbacks
      * @return ::uwb::UwbRegisteredDeviceEventCallbackTokens You can pass the pointers into DeregisterEventCallback to deregister the event callbacks
      */
-    virtual ::uwb::UwbRegisteredDeviceEventCallbackTokens RegisterDeviceEventCallbacks(std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbacks> callbacks) = 0;
+    virtual ::uwb::UwbRegisteredDeviceEventCallbackTokens
+    RegisterDeviceEventCallbacks(std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbacks> callbacks) = 0;
 };
 
 } // namespace windows::devices::uwb

--- a/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/IUwbDeviceDdi.hxx
@@ -50,7 +50,7 @@ struct IUwbDeviceDdiConnector : public IUwbDeviceDdi
      * @return ::uwb::UwbRegisteredDeviceEventCallbackTokens You can pass the pointers into DeregisterEventCallback to deregister the event callbacks
      */
     virtual ::uwb::UwbRegisteredDeviceEventCallbackTokens
-    RegisterDeviceEventCallbacks(std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbacks> callbacks) = 0;
+    RegisterDeviceEventCallbacks(::uwb::UwbRegisteredDeviceEventCallbacks callbacks) = 0;
 };
 
 } // namespace windows::devices::uwb

--- a/windows/devices/uwb/include/windows/devices/uwb/IUwbSessionDdi.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/IUwbSessionDdi.hxx
@@ -68,7 +68,7 @@ struct IUwbSessionDdiConnector : public IUwbSessionDdi
      * @return ::uwb::UwbRegisteredSessionEventCallbackTokens You can pass the pointers into DeregisterEventCallback to deregister the event callbacks
      */
     virtual ::uwb::UwbRegisteredSessionEventCallbackTokens
-    RegisterSessionEventCallbacks(uint32_t sessionId, std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbacks> callbacks) = 0;
+    RegisterSessionEventCallbacks(uint32_t sessionId, ::uwb::UwbRegisteredSessionEventCallbacks callbacks) = 0;
 };
 
 } // namespace windows::devices::uwb

--- a/windows/devices/uwb/include/windows/devices/uwb/IUwbSessionDdi.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/IUwbSessionDdi.hxx
@@ -65,9 +65,9 @@ struct IUwbSessionDdiConnector : public IUwbSessionDdi
      *
      * @param sessionId
      * @param callbacks
-     * @return std::weak_ptr<::uwb::RegisteredCallbackToken> You can pass this pointer into DeregisterEventCallback to deregister this event callback
+     * @return ::uwb::UwbRegisteredSessionEventCallbackTokens You can pass the pointers into DeregisterEventCallback to deregister the event callbacks
      */
-    virtual std::weak_ptr<::uwb::RegisteredCallbackToken>
+    virtual ::uwb::UwbRegisteredSessionEventCallbackTokens
     RegisterSessionEventCallbacks(uint32_t sessionId, std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbacks> callbacks) = 0;
 };
 

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
@@ -222,27 +222,6 @@ private:
     bool
     CallbacksPresent();
 
-    /**
-     * @brief Get a copy of the resolved session event callbacks for a particular session.
-     *
-     * This function removes expired callbacks in the process of making the copies.
-     *
-     * @param sessionId The session id to obtain registered callbacks for.
-     * @return std::vector<std::shared_ptr<::uwb::UwbRegisteredSessionEventCallbacks>>
-     */
-    std::vector<std::shared_ptr<::uwb::UwbRegisteredSessionEventCallbacks>>
-    GetResolvedSessionEventCallbacks(uint32_t sessionId);
-
-    /**
-     * @brief Get a copy of the resolved device event callbacks.
-     *
-     * This function removes expired callbacks in the process of making the copies.
-     *
-     * @return std::vector<std::shared_ptr<::uwb::UwbRegisteredDeviceEventCallbacks>>
-     */
-    std::vector<std::shared_ptr<::uwb::UwbRegisteredDeviceEventCallbacks>>
-    GetResolvedDeviceEventCallbacks();
-
 private:
     std::string m_deviceName{};
     std::jthread m_notificationThread;

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
@@ -255,7 +255,7 @@ private:
     std::unordered_map<uint32_t, std::vector<std::shared_ptr<::uwb::OnRangingStartedToken>>> m_onRangingStartedCallbacks;
     std::unordered_map<uint32_t, std::vector<std::shared_ptr<::uwb::OnRangingStoppedToken>>> m_onRangingStoppedCallbacks;
     std::unordered_map<uint32_t, std::vector<std::shared_ptr<::uwb::OnPeerPropertiesChangedToken>>> m_onPeerPropertiesChangedCallbacks;
-    std::unordered_map<uint32_t, std::vector<std::shared_ptr<::uwb::OnSessionMembershipChangedToken>>> m_onSessionMembershipChangedToken;
+    std::unordered_map<uint32_t, std::vector<std::shared_ptr<::uwb::OnSessionMembershipChangedToken>>> m_onSessionMembershipChangedCallbacks;
 
     std::vector<std::shared_ptr<::uwb::OnStatusChangedToken>> m_onStatusChangedCallbacks;
     std::vector<std::shared_ptr<::uwb::OnDeviceStatusChangedToken>> m_onDeviceStatusChangedCallbacks;

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
@@ -27,7 +27,17 @@ namespace uwb
  *
  */
 class RegisteredSessionCallbackToken;
+class OnSessionEndedToken;
+class OnRangingStartedToken;
+class OnRangingStoppedToken;
+class OnPeerPropertiesChangedToken;
+class OnSessionMembershipChangedToken;
+
 class RegisteredDeviceCallbackToken;
+class OnStatusChangedToken;
+class OnDeviceStatusChangedToken;
+class OnSessionStatusChangedToken;
+
 } // namespace uwb
 
 namespace windows::devices::uwb
@@ -241,8 +251,15 @@ private:
 
     // the following shared_mutex is used to protect access to everything regarding the registered callbacks
     mutable std::shared_mutex m_eventCallbacksGate;
-    std::unordered_map<uint32_t, std::vector<std::shared_ptr<::uwb::RegisteredSessionCallbackToken>>> m_sessionEventCallbacks;
-    std::vector<std::shared_ptr<::uwb::RegisteredDeviceCallbackToken>> m_deviceEventCallbacks;
+    std::unordered_map<uint32_t, std::vector<std::shared_ptr<::uwb::OnSessionEndedToken>>> m_onSessionEndedCallbacks;
+    std::unordered_map<uint32_t, std::vector<std::shared_ptr<::uwb::OnRangingStartedToken>>> m_onRangingStartedCallbacks;
+    std::unordered_map<uint32_t, std::vector<std::shared_ptr<::uwb::OnRangingStoppedToken>>> m_onRangingStoppedCallbacks;
+    std::unordered_map<uint32_t, std::vector<std::shared_ptr<::uwb::OnPeerPropertiesChangedToken>>> m_onPeerPropertiesChangedCallbacks;
+    std::unordered_map<uint32_t, std::vector<std::shared_ptr<::uwb::OnSessionMembershipChangedToken>>> m_onSessionMembershipChangedToken;
+
+    std::vector<std::shared_ptr<::uwb::OnStatusChangedToken>> m_onStatusChangedCallbacks;
+    std::vector<std::shared_ptr<::uwb::OnDeviceStatusChangedToken>> m_onDeviceStatusChangedCallbacks;
+    std::vector<std::shared_ptr<::uwb::OnSessionStatusChangedToken>> m_OnSessionStatusChangedCallbacks;
 };
 } // namespace windows::devices::uwb
 

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
@@ -259,7 +259,7 @@ private:
 
     std::vector<std::shared_ptr<::uwb::OnStatusChangedToken>> m_onStatusChangedCallbacks;
     std::vector<std::shared_ptr<::uwb::OnDeviceStatusChangedToken>> m_onDeviceStatusChangedCallbacks;
-    std::vector<std::shared_ptr<::uwb::OnSessionStatusChangedToken>> m_OnSessionStatusChangedCallbacks;
+    std::vector<std::shared_ptr<::uwb::OnSessionStatusChangedToken>> m_onSessionStatusChangedCallbacks;
 };
 } // namespace windows::devices::uwb
 

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
@@ -228,8 +228,8 @@ private:
     wil::shared_hfile m_notificationHandleDriver;
     OVERLAPPED m_notificationOverlapped;
 
-    // the following recursive_mutex is used to protect access to everything regarding the registered callbacks
-    mutable std::recursive_mutex m_eventCallbacksGate;
+    // the following shared_mutex is used to protect access to everything regarding the registered callbacks
+    mutable std::shared_mutex m_eventCallbacksGate;
     std::unordered_map<uint32_t, std::vector<std::shared_ptr<::uwb::OnSessionEndedToken>>> m_onSessionEndedCallbacks;
     std::unordered_map<uint32_t, std::vector<std::shared_ptr<::uwb::OnRangingStartedToken>>> m_onRangingStartedCallbacks;
     std::unordered_map<uint32_t, std::vector<std::shared_ptr<::uwb::OnRangingStoppedToken>>> m_onRangingStoppedCallbacks;

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
@@ -228,8 +228,8 @@ private:
     wil::shared_hfile m_notificationHandleDriver;
     OVERLAPPED m_notificationOverlapped;
 
-    // the following shared_mutex is used to protect access to everything regarding the registered callbacks
-    mutable std::shared_mutex m_eventCallbacksGate;
+    // the following recursive_mutex is used to protect access to everything regarding the registered callbacks
+    mutable std::recursive_mutex m_eventCallbacksGate;
     std::unordered_map<uint32_t, std::vector<std::shared_ptr<::uwb::OnSessionEndedToken>>> m_onSessionEndedCallbacks;
     std::unordered_map<uint32_t, std::vector<std::shared_ptr<::uwb::OnRangingStartedToken>>> m_onRangingStartedCallbacks;
     std::unordered_map<uint32_t, std::vector<std::shared_ptr<::uwb::OnRangingStoppedToken>>> m_onRangingStoppedCallbacks;

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
@@ -84,7 +84,7 @@ public:
      * @return ::uwb::UwbRegisteredDeviceEventCallbackTokens You can pass the pointers into DeregisterEventCallback to deregister the event callbacks
      */
     virtual ::uwb::UwbRegisteredDeviceEventCallbackTokens
-    RegisterDeviceEventCallbacks(std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbacks> callbacks) override;
+    RegisterDeviceEventCallbacks(::uwb::UwbRegisteredDeviceEventCallbacks callbacks) override;
 
 public:
     // IUwbSessionDdiConnector
@@ -97,7 +97,7 @@ public:
      * @return ::uwb::UwbRegisteredSessionEventCallbackTokens You can pass the pointers into DeregisterEventCallback to deregister the event callbacks
      */
     virtual ::uwb::UwbRegisteredSessionEventCallbackTokens
-    RegisterSessionEventCallbacks(uint32_t sessionId, std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbacks> callbacks) override;
+    RegisterSessionEventCallbacks(uint32_t sessionId, ::uwb::UwbRegisteredSessionEventCallbacks callbacks) override;
 
 public:
     /**

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
@@ -24,7 +24,7 @@ namespace uwb
 {
 /**
  * @brief The following are opaque class declarations that are used in this file
- * 
+ *
  */
 class RegisteredSessionCallbackToken;
 class RegisteredDeviceCallbackToken;
@@ -68,23 +68,25 @@ public:
     // IUwbDeviceDdiConnector
     /**
      * @brief Sets the callbacks for the UwbDevice that owns this UwbConnector
+     * You can pass in a partially filled in struct, in which case this function returns a partially filled in struct of tokens corresponding to those callbacks.
      *
      * @param callbacks
-     * @return std::weak_ptr<::uwb::RegisteredCallbackToken> You can pass this pointer into DeregisterEventCallback to deregister this event callback
+     * @return ::uwb::UwbRegisteredDeviceEventCallbackTokens You can pass the pointers into DeregisterEventCallback to deregister the event callbacks
      */
-    virtual std::weak_ptr<::uwb::RegisteredCallbackToken>
+    virtual ::uwb::UwbRegisteredDeviceEventCallbackTokens
     RegisterDeviceEventCallbacks(std::weak_ptr<::uwb::UwbRegisteredDeviceEventCallbacks> callbacks) override;
 
 public:
     // IUwbSessionDdiConnector
     /**
-     * @brief Registers the callbacks for a particular session
+     * @brief Registers the callbacks for a particular session.
+     * You can pass in a partially filled in struct, in which case this function returns a partially filled in struct of tokens corresponding to those callbacks.
      *
      * @param sessionId
      * @param callbacks
-     * @return std::weak_ptr<::uwb::RegisteredCallbackToken> You can pass this pointer into DeregisterEventCallback to deregister this event callback
+     * @return ::uwb::UwbRegisteredSessionEventCallbackTokens You can pass the pointers into DeregisterEventCallback to deregister the event callbacks
      */
-    virtual std::weak_ptr<::uwb::RegisteredCallbackToken>
+    virtual ::uwb::UwbRegisteredSessionEventCallbackTokens
     RegisterSessionEventCallbacks(uint32_t sessionId, std::weak_ptr<::uwb::UwbRegisteredSessionEventCallbacks> callbacks) override;
 
 public:
@@ -230,7 +232,7 @@ private:
      */
     std::vector<std::shared_ptr<::uwb::UwbRegisteredDeviceEventCallbacks>>
     GetResolvedDeviceEventCallbacks();
-    
+
 private:
     std::string m_deviceName{};
     std::jthread m_notificationThread;

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
@@ -155,7 +155,9 @@ private:
     const std::string m_deviceName;
     std::shared_ptr<IUwbDeviceDdiConnector> m_uwbDeviceConnector;
     std::shared_ptr<IUwbSessionDdiConnector> m_uwbSessionConnector;
-    std::shared_ptr<::uwb::UwbRegisteredDeviceEventCallbacks> m_callbacks;
+    std::shared_ptr<::uwb::UwbRegisteredDeviceEventCallbackTypes::OnStatusChanged> m_onStatusChangedCallback;
+    std::shared_ptr<::uwb::UwbRegisteredDeviceEventCallbackTypes::OnDeviceStatusChanged> m_onDeviceStatusChangedCallback;
+    std::shared_ptr<::uwb::UwbRegisteredDeviceEventCallbackTypes::OnSessionStatusChanged> m_onSessionStatusChangedCallback;
     ::uwb::UwbRegisteredDeviceEventCallbackTokens m_callbacksToken;
 };
 } // namespace windows::devices::uwb

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
@@ -156,7 +156,7 @@ private:
     std::shared_ptr<IUwbDeviceDdiConnector> m_uwbDeviceConnector;
     std::shared_ptr<IUwbSessionDdiConnector> m_uwbSessionConnector;
     std::shared_ptr<::uwb::UwbRegisteredDeviceEventCallbacks> m_callbacks;
-    std::weak_ptr<::uwb::RegisteredCallbackToken> m_callbacksToken;
+    ::uwb::UwbRegisteredDeviceEventCallbackTokens m_callbacksToken;
 };
 } // namespace windows::devices::uwb
 

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
@@ -105,7 +105,11 @@ protected:
 
 private:
     std::shared_ptr<IUwbSessionDdiConnector> m_uwbSessionConnector;
-    std::shared_ptr<::uwb::UwbRegisteredSessionEventCallbacks> m_registeredCallbacks;
+    std::shared_ptr<::uwb::UwbRegisteredSessionEventCallbackTypes::OnSessionEnded> m_onSessionEndedCallback;
+    std::shared_ptr<::uwb::UwbRegisteredSessionEventCallbackTypes::OnRangingStarted> m_onRangingStartedCallback;
+    std::shared_ptr<::uwb::UwbRegisteredSessionEventCallbackTypes::OnRangingStopped> m_onRangingStoppedCallback;
+    std::shared_ptr<::uwb::UwbRegisteredSessionEventCallbackTypes::OnPeerPropertiesChanged> m_onPeerPropertiesChangedCallback;
+    std::shared_ptr<::uwb::UwbRegisteredSessionEventCallbackTypes::OnSessionMembershipChanged> m_onSessionMembershipChangedCallback;
     ::uwb::UwbRegisteredSessionEventCallbackTokens m_registeredCallbacksTokens;
 };
 

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
@@ -106,7 +106,7 @@ protected:
 private:
     std::shared_ptr<IUwbSessionDdiConnector> m_uwbSessionConnector;
     std::shared_ptr<::uwb::UwbRegisteredSessionEventCallbacks> m_registeredCallbacks;
-    std::weak_ptr<::uwb::RegisteredCallbackToken> m_registeredCallbacksToken;
+    ::uwb::UwbRegisteredSessionEventCallbackTokens m_registeredCallbacksTokens;
 };
 
 } // namespace windows::devices::uwb


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [X] Infrastructure

### Goals

* Allow callbacks to signal to UwbConnector that they should be deregistered.
* Since the tokens know what type they are, leverage polymorphism with virtual Deregister functions.

### Technical Details


### Test Results


### Reviewer Focus


### Future Work


### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
