### PR TITLE
Update DDI copy to match official DDI

### DIFF
--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -437,21 +437,13 @@ windows::devices::uwb::ddi::lrp::From(const ::uwb::protocol::fira::UwbRangingMea
         .status = From(uwbRangingMeasurement.Status),
         .lineOfSightIndicator = From(uwbRangingMeasurement.LineOfSightIndicator),
         .distance = uwbRangingMeasurement.Distance,
-        .aoaAzimuth = {
-            (uwbRangingMeasurement.AoAAzimuth.Result & 0x00FFU),
-            (uwbRangingMeasurement.AoAAzimuth.Result & 0xFF00U) >> 8U },
+        .aoaAzimuth = uwbRangingMeasurement.AoAAzimuth.Result,
         .aoaAzimuthFigureOfMerit = uwbRangingMeasurement.AoAAzimuth.FigureOfMerit.value_or(0),
-        .aoaElevation = {
-            (uwbRangingMeasurement.AoAElevation.Result & 0x00FFU),
-            (uwbRangingMeasurement.AoAElevation.Result & 0xFF00U) >> 8U },
+        .aoaElevation = uwbRangingMeasurement.AoAElevation.Result,
         .aoaElevationFigureOfMerit = uwbRangingMeasurement.AoAElevation.FigureOfMerit.value_or(0),
-        .aoaDestinationAzimuth = {
-            (uwbRangingMeasurement.AoaDestinationAzimuth.Result & 0x00FFU),
-            (uwbRangingMeasurement.AoaDestinationAzimuth.Result & 0xFF00U) >> 8U },
+        .aoaDestinationAzimuth = uwbRangingMeasurement.AoaDestinationAzimuth.Result,
         .aoaDestinationAzimuthFigureOfMerit = uwbRangingMeasurement.AoaDestinationAzimuth.FigureOfMerit.value_or(0),
-        .aoaDestinationElevation = {
-            (uwbRangingMeasurement.AoaDestinationElevation.Result & 0x00FFU),
-            (uwbRangingMeasurement.AoaDestinationElevation.Result & 0xFF00U) >> 8U },
+        .aoaDestinationElevation = uwbRangingMeasurement.AoaDestinationElevation.Result,
         .aoaDestinationElevationFigureOfMerit = uwbRangingMeasurement.AoaDestinationElevation.FigureOfMerit.value_or(0),
         .slotIndex = uwbRangingMeasurement.SlotIndex
     };

--- a/windows/drivers/uwb/cx/include/windows/devices/uwb/UwbCxLrpDevice.h
+++ b/windows/drivers/uwb/cx/include/windows/devices/uwb/UwbCxLrpDevice.h
@@ -495,23 +495,23 @@ typedef struct _UWB_RANGING_MEASUREMENT {
     uint16_t distance;
     // AoA Azimuth in degrees
     // Allowed values range from -180 to +180
-    uint8_t aoaAzimuth[2];
+    uint16_t aoaAzimuth;
     // IEEE 802.15.4z-2020, Section 6.9.1.7: Ranging FoM
     // Figure of Merit goes from 0 to 100
     uint8_t aoaAzimuthFigureOfMerit;
     // AoA Elevation in degrees
     // Allowed values range from -90 to +90
-    uint8_t aoaElevation[2];
+    uint16_t aoaElevation;
     // Figure of Merit goes from 0 to 100
     uint8_t aoaElevationFigureOfMerit;
     // AoA Destination Azimuth in degrees
     // Allowed values range from -180 to +180
-    uint8_t aoaDestinationAzimuth[2];
+    uint16_t aoaDestinationAzimuth;
     // Figure of Merit goes from 0 to 100
     uint8_t aoaDestinationAzimuthFigureOfMerit;
     // AoA Destination Elevation in degrees
     // Allowed values range from -90 to +90
-    uint8_t aoaDestinationElevation[2];
+    uint16_t aoaDestinationElevation;
     // Figure of Merit goes from 0 to 100
     uint8_t aoaDestinationElevationFigureOfMerit;
     // Slot number starts from 0


### PR DESCRIPTION
### Type

- [x] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Updates the UWB_RANGING_MEASUREMENT struct in the DDI copy to match the official DDI.

### Technical Details

- Changed uint8_t[2] to uint16_t in DDI copy.
- Updated conversion function accordingly.

### Test Results

Verified that sizeof(UWB_NOTIFICATION_DATA) is now 80 bytes rather than 76.

### Reviewer Focus

None.

### Future Work

None.

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
