### PR TITLE
Append \\Notifications namespace string to device interface name for notification listener

### DIFF
--- a/windows/devices/util/include/windows/devices/DeviceHandle.hxx
+++ b/windows/devices/util/include/windows/devices/DeviceHandle.hxx
@@ -4,6 +4,7 @@
 
 #include <concepts>
 #include <memory>
+#include <string>
 
 #include <windows.h>
 
@@ -82,6 +83,7 @@ OpenDriverHandleShared(wil::shared_hfile &driverHandle, const char *deviceName, 
 HRESULT
 OpenDriverHandleUnique(wil::unique_hfile &driverHandle, const char *deviceName, bool isOverlapped = false);
 
+const std::string NotificationHandleNamespaceString = "\\Notifications";
 } // namespace windows::devices
 
 #endif // DEVICE_HANDLE_HXX

--- a/windows/devices/util/include/windows/devices/DeviceHandle.hxx
+++ b/windows/devices/util/include/windows/devices/DeviceHandle.hxx
@@ -83,7 +83,6 @@ OpenDriverHandleShared(wil::shared_hfile &driverHandle, const char *deviceName, 
 HRESULT
 OpenDriverHandleUnique(wil::unique_hfile &driverHandle, const char *deviceName, bool isOverlapped = false);
 
-const std::string NotificationHandleNamespaceString = "\\Notifications";
 } // namespace windows::devices
 
 #endif // DEVICE_HANDLE_HXX

--- a/windows/devices/uwb/UwbConnector.cxx
+++ b/windows/devices/uwb/UwbConnector.cxx
@@ -850,9 +850,10 @@ void
 UwbConnector::NotificationListenerStart()
 {
     wil::shared_hfile notificationHandleDriver;
-    auto hr = OpenDriverHandle(notificationHandleDriver, m_deviceName.c_str(), true);
+    std::string notificationHandleDeviceName = m_deviceName + NotificationHandleNamespaceString;
+    auto hr = OpenDriverHandle(notificationHandleDriver, notificationHandleDeviceName.c_str(), true);
     if (FAILED(hr)) {
-        PLOG_ERROR << "failed to obtain driver handle for " << m_deviceName << ", hr=" << hr;
+        PLOG_ERROR << "failed to obtain driver handle for " << notificationHandleDeviceName << ", hr=" << hr;
         return;
     }
 

--- a/windows/devices/uwb/UwbConnector.cxx
+++ b/windows/devices/uwb/UwbConnector.cxx
@@ -850,7 +850,7 @@ void
 UwbConnector::NotificationListenerStart()
 {
     wil::shared_hfile notificationHandleDriver;
-    std::string notificationHandleDeviceName = m_deviceName + NotificationHandleNamespaceString;
+    const std::string notificationHandleDeviceName = m_deviceName + windows::drivers::uwbcx::UwbNotificationNamespace;
     auto hr = OpenDriverHandle(notificationHandleDriver, notificationHandleDeviceName.c_str(), true);
     if (FAILED(hr)) {
         PLOG_ERROR << "failed to obtain driver handle for " << notificationHandleDeviceName << ", hr=" << hr;

--- a/windows/drivers/uwb/cx/include/windows/devices/uwb/UwbCxDdiLrp.hxx
+++ b/windows/drivers/uwb/cx/include/windows/devices/uwb/UwbCxDdiLrp.hxx
@@ -9,4 +9,10 @@
 
 #include <windows/devices/uwb/UwbCxLrpDevice.h>
 
+namespace windows::drivers::uwbcx
+{
+const std::string UwbNotificationNamespace = "\\Notifications";
+
+} // namespace windows::drivers::uwbcx
+
 #endif // UWBCX_DDI_LRP_HXX


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [x] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

This PR updates the UwbConnector to use the "\\Notifications" namespace in the device interface name. This allows the service/nocli to correctly interact with the CX driver when listening for notifications.

### Technical Details

- Added constant variable to hold notification namespace string.
- Appended new string to device interface name in NotificationListenerStart.

### Test Results

Can now get notifications, including ranging data, from the latest CX/TestClient driver using nocli.

### Reviewer Focus

Is DeviceHandle.hxx an okay place to put the new string constant? I'm not really sure where the best place is.

### Future Work

A similar change could be added to the Simulator driver, however the Simulator driver doesn't depend on the CX, so this isn't actually necessary - meaning, the Simulator driver still works as is.

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
