### PR TITLE
Drop const from session event callbacks

### DIFF
--- a/lib/uwb/include/uwb/UwbRegisteredCallbacks.hxx
+++ b/lib/uwb/include/uwb/UwbRegisteredCallbacks.hxx
@@ -40,7 +40,7 @@ using OnRangingStopped = std::function<bool()>;
  * @param peersChanged A list of peers whose properties changed.
  * @return true if this callback needs to be deregistered
  */
-using OnPeerPropertiesChanged = std::function<bool(const std::vector<UwbPeer> peersChanged)>;
+using OnPeerPropertiesChanged = std::function<bool(std::vector<UwbPeer> peersChanged)>;
 
 /**
  * @brief Invoked when membership of one or more near peers involved in
@@ -51,7 +51,7 @@ using OnPeerPropertiesChanged = std::function<bool(const std::vector<UwbPeer> pe
  * @param peersRemoved A list of peers that were removed from the session.
  * @return true if this callback needs to be deregistered
  */
-using OnSessionMembershipChanged = std::function<bool(const std::vector<UwbPeer> peersAdded, const std::vector<UwbPeer> peersRemoved)>;
+using OnSessionMembershipChanged = std::function<bool(std::vector<UwbPeer> peersAdded, std::vector<UwbPeer> peersRemoved)>;
 }; // namespace UwbRegisteredSessionEventCallbackTypes
 
 namespace UwbRegisteredDeviceEventCallbackTypes

--- a/lib/uwb/include/uwb/UwbSessionEventCallbacks.hxx
+++ b/lib/uwb/include/uwb/UwbSessionEventCallbacks.hxx
@@ -83,7 +83,7 @@ struct UwbSessionEventCallbacks
      * @param peersChanged A list of peers whose properties changed.
      */
     virtual void
-    OnPeerPropertiesChanged(UwbSession *session, const std::vector<UwbPeer> peersChanged) = 0;
+    OnPeerPropertiesChanged(UwbSession *session, std::vector<UwbPeer> peersChanged) = 0;
 
     /**
      * @brief Invoked when membership of one or more near peers involved in
@@ -95,7 +95,7 @@ struct UwbSessionEventCallbacks
      * @param peersRemoved A list of peers that were removed from the session.
      */
     virtual void
-    OnSessionMembershipChanged(UwbSession *session, const std::vector<UwbPeer> peersAdded, const std::vector<UwbPeer> peersRemoved) = 0;
+    OnSessionMembershipChanged(UwbSession *session, std::vector<UwbPeer> peersAdded, std::vector<UwbPeer> peersRemoved) = 0;
 
     /**
      * @brief Destroy the UwbSessionEventCallbacks object, defined to support

--- a/tools/cli/NearObjectCliUwbSessionEventCallbacks.cxx
+++ b/tools/cli/NearObjectCliUwbSessionEventCallbacks.cxx
@@ -72,7 +72,7 @@ NearObjectCliUwbSessionEventCallbacks::OnRangingStopped(::uwb::UwbSession* sessi
 }
 
 void
-NearObjectCliUwbSessionEventCallbacks::OnPeerPropertiesChanged(::uwb::UwbSession* session, const std::vector<::uwb::UwbPeer> peersChanged)
+NearObjectCliUwbSessionEventCallbacks::OnPeerPropertiesChanged(::uwb::UwbSession* session, std::vector<::uwb::UwbPeer> peersChanged)
 {
     std::cout << LogPrefix(session->GetId()) << "Peer Properties Changed" << std::endl;
 
@@ -82,7 +82,7 @@ NearObjectCliUwbSessionEventCallbacks::OnPeerPropertiesChanged(::uwb::UwbSession
 }
 
 void
-NearObjectCliUwbSessionEventCallbacks::OnSessionMembershipChanged(::uwb::UwbSession* session, const std::vector<::uwb::UwbPeer> peersAdded, const std::vector<::uwb::UwbPeer> peersRemoved)
+NearObjectCliUwbSessionEventCallbacks::OnSessionMembershipChanged(::uwb::UwbSession* session, std::vector<::uwb::UwbPeer> peersAdded, std::vector<::uwb::UwbPeer> peersRemoved)
 {
     std::cout << LogPrefix(session->GetId()) << "Membership Changed" << std::endl;
 

--- a/tools/cli/include/nearobject/cli/NearObjectCliUwbSessionEventCallbacks.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliUwbSessionEventCallbacks.hxx
@@ -54,7 +54,7 @@ struct NearObjectCliUwbSessionEventCallbacks :
      * @param peersChanged A list of peers whose properties changed.
      */
     void
-    OnPeerPropertiesChanged(::uwb::UwbSession *session, const std::vector<::uwb::UwbPeer> peersChanged);
+    OnPeerPropertiesChanged(::uwb::UwbSession *session, std::vector<::uwb::UwbPeer> peersChanged);
 
     /**
      * @brief Invoked when membership of one or more near peers involved in
@@ -66,7 +66,7 @@ struct NearObjectCliUwbSessionEventCallbacks :
      * @param peersRemoved A list of peers that were removed from the session.
      */
     void
-    OnSessionMembershipChanged(::uwb::UwbSession *session, const std::vector<::uwb::UwbPeer> peersAdded, const std::vector<::uwb::UwbPeer> peersRemoved);
+    OnSessionMembershipChanged(::uwb::UwbSession *session, std::vector<::uwb::UwbPeer> peersAdded, std::vector<::uwb::UwbPeer> peersRemoved);
 
 private:
     std::function<void()> m_onSessionEndedCallback;

--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -51,7 +51,7 @@ UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<::uwb::UwbDevice> devic
             return false;
         });
     m_onPeerPropertiesChangedCallback =
-        std::make_shared<::uwb::UwbRegisteredSessionEventCallbackTypes::OnPeerPropertiesChanged>([this](const std::vector<::uwb::UwbPeer> peersChanged) {
+        std::make_shared<::uwb::UwbRegisteredSessionEventCallbackTypes::OnPeerPropertiesChanged>([this](std::vector<::uwb::UwbPeer> peersChanged) {
             auto callbacks = ResolveEventCallbacks();
             if (callbacks == nullptr) {
                 PLOG_WARNING << "missing session event callback for ranging data, skipping";
@@ -61,7 +61,7 @@ UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<::uwb::UwbDevice> devic
             return false;
         });
     m_onSessionMembershipChangedCallback =
-        std::make_shared<::uwb::UwbRegisteredSessionEventCallbackTypes::OnSessionMembershipChanged>([this](const std::vector<::uwb::UwbPeer> peersAdded, const std::vector<::uwb::UwbPeer> peersRemoved) {
+        std::make_shared<::uwb::UwbRegisteredSessionEventCallbackTypes::OnSessionMembershipChanged>([this](std::vector<::uwb::UwbPeer> peersAdded, std::vector<::uwb::UwbPeer> peersRemoved) {
             auto callbacks = ResolveEventCallbacks();
             if (callbacks == nullptr) {
                 PLOG_WARNING << "missing session event callback for peer list changes, skipping";


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Allow callback clients to do whatever they like with the callback data. Fixes #229.

### Technical Details

Drop `const` from `std::vector` data passed to the `OnPeerPropertiesChanged` and `OnSessionMembershipChanged` callbacks.

### Test Results

Compile-tested only.

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
