### PR TITLE
small fix to check for a valid deregister function before executing it

### DIFF
--- a/windows/devices/uwb/UwbConnector.cxx
+++ b/windows/devices/uwb/UwbConnector.cxx
@@ -31,6 +31,10 @@ struct RegisteredCallbackToken
      */
     RegisteredCallbackToken(std::function<void(RegisteredCallbackToken*)> deregister) :
         Deregister([this, deregister = std::move(deregister)]() {
+            if (not deregister) {
+                PLOG_WARNING << "empty callback token";
+                return;
+            }
             return deregister(this);
         })
     {}


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
