### PR TITLE
Rename UwbSession::AddPeer to TryAddControlee

### DIFF
--- a/lib/uwb/UwbSession.cxx
+++ b/lib/uwb/UwbSession.cxx
@@ -74,10 +74,9 @@ UwbSession::TryAddControlee(UwbMacAddress controleeMacAddress)
 {
     std::scoped_lock peersLock{ m_peerGate };
     PLOG_VERBOSE << "Session with id " << m_sessionId << " requesting to add controlee with mac address " << controleeMacAddress.ToString();
-    AddPeerImpl(std::move(controleeMacAddress));
 
-    // TODO: return result from TryAddControleeImpl
-    return UwbStatusOk;
+    auto uwbStatus = TryAddControleeImpl(std::move(controleeMacAddress));
+    return uwbStatus;
 }
 
 void

--- a/lib/uwb/UwbSession.cxx
+++ b/lib/uwb/UwbSession.cxx
@@ -69,12 +69,15 @@ UwbSession::SetMacAddressType(UwbMacAddressType uwbMacAddressType) noexcept
     // TODO: update driver with new mac address type (aka "mode" in FiRa-speak).
 }
 
-void
-UwbSession::AddPeer(UwbMacAddress peerMacAddress)
+UwbStatus
+UwbSession::TryAddControlee(UwbMacAddress controleeMacAddress)
 {
     std::scoped_lock peersLock{ m_peerGate };
-    PLOG_VERBOSE << "Session with id " << m_sessionId << " requesting to add peer via DDI with mac address " << peerMacAddress.ToString();
-    AddPeerImpl(std::move(peerMacAddress));
+    PLOG_VERBOSE << "Session with id " << m_sessionId << " requesting to add controlee with mac address " << controleeMacAddress.ToString();
+    AddPeerImpl(std::move(controleeMacAddress));
+
+    // TODO: return result from TryAddControleeImpl
+    return UwbStatusOk;
 }
 
 void

--- a/lib/uwb/include/uwb/UwbSession.hxx
+++ b/lib/uwb/include/uwb/UwbSession.hxx
@@ -13,6 +13,7 @@
 #include <uwb/UwbMacAddress.hxx>
 #include <uwb/UwbPeer.hxx>
 #include <uwb/UwbSessionEventCallbacks.hxx>
+#include <uwb/protocols/fira/FiraDevice.hxx>
 #include <uwb/protocols/fira/UwbSessionData.hxx>
 
 namespace uwb
@@ -109,8 +110,17 @@ public:
      * @param peerMacAddress The mac address of the peer. This is expected to be
      * in the mac address format configured for the session.
      */
-    void
-    AddPeer(UwbMacAddress peerMacAddress);
+
+    /**
+     * @brief Attempt to add a controlee to this session.
+     * 
+     * @param controleeMacAddress The mac address of the controlee. This is
+     * expected to be in the mac address format configured for the session.
+     * @return UwbStatus The status of the operation. UwbStatusGeneric::Ok is
+     * returned if the controlee was successfully added.
+     */
+    uwb::protocol::fira::UwbStatus
+    TryAddControlee(uwb::protocol::fira::UwbMacAddress controleeMacAddress);
 
     /**
      * @brief Start ranging.

--- a/lib/uwb/include/uwb/UwbSession.hxx
+++ b/lib/uwb/include/uwb/UwbSession.hxx
@@ -105,13 +105,6 @@ public:
     SetMacAddressType(UwbMacAddressType uwbMacAddressType) noexcept;
 
     /**
-     * @brief Add a peer to this session.
-     *
-     * @param peerMacAddress The mac address of the peer. This is expected to be
-     * in the mac address format configured for the session.
-     */
-
-    /**
      * @brief Attempt to add a controlee to this session.
      * 
      * @param controleeMacAddress The mac address of the controlee. This is
@@ -228,12 +221,15 @@ private:
     StopRangingImpl() = 0;
 
     /**
-     * @brief Add a new peer to the session.
-     *
-     * @param peerMacAddress
+     * @brief Attempt to add a controlee to this session.
+     * 
+     * @param controleeMacAddress The mac address of the controlee. This is
+     * expected to be in the mac address format configured for the session.
+     * @return UwbStatus The status of the operation. UwbStatusGeneric::Ok is
+     * returned if the controlee was successfully added.
      */
-    virtual void
-    AddPeerImpl(UwbMacAddress peerMacAddress) = 0;
+    virtual uwb::protocol::fira::UwbStatus
+    TryAddControleeImpl(UwbMacAddress controleeMacAddress) = 0;
 
     /**
      * @brief Get the application configuration parameters for this session.

--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -174,10 +174,11 @@ UwbSession::StopRangingImpl()
     // TODO: return uwbStatus;
 }
 
-void
-UwbSession::AddPeerImpl([[maybe_unused]] ::uwb::UwbMacAddress peerMacAddress)
+UwbStatus
+UwbSession::TryAddControleeImpl([[maybe_unused]] ::uwb::UwbMacAddress controleeMacAddress)
 {
-    PLOG_VERBOSE << "AddPeerImpl";
+    PLOG_VERBOSE << "TryAddControleeImpl";
+    return UwbStatusGeneric::Rejected;
 
     // TODO: convert code below to invoke IOCTL_UWB_SET_APP_CONFIG_PARAMS to use connector
 

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
@@ -67,10 +67,15 @@ private:
     StopRangingImpl() override;
 
     /**
-     * @brief Add a new peer to the session.
+     * @brief Attempt to add a controlee to this session.
+     *
+     * @param controleeMacAddress The mac address of the controlee. This is
+     * expected to be in the mac address format configured for the session.
+     * @return UwbStatus The status of the operation. UwbStatusGeneric::Ok is
+     * returned if the controlee was successfully added.
      */
-    virtual void
-    AddPeerImpl(::uwb::UwbMacAddress peerMacAddress) override;
+    virtual ::uwb::protocol::fira::UwbStatus
+    TryAddControleeImpl(::uwb::UwbMacAddress controleeMacAddress) override;
 
     /**
      * @brief Get the application configuration parameters for this session.


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Name internal API functions so they better reflect their functionality.

### Technical Details

* Rename `UwbSession::AddPeer` to `UwbSession::TryAddControlee` to better reflect that this is adding a controlee to a session where the host is the controller.

### Test Results

* Compile tested only.

### Reviewer Focus

None

### Future Work

* Possibly rename the `InsertPeer` function as well.

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
