### PR TITLE
Compile with /bigobj on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,11 @@ elseif (BUILD_FOR_WINDOWS)
       WIN32_LEAN_AND_MEAN
   )
 
+  # Allow more than default number of section in object files.
+  add_compile_options(
+    /bigobj
+  )
+
   if (NOF_USE_MSVC_STATIC_RUNTIME)
     # Enable explicit selection of MSVC runtime library.
     if (POLICY CMP0091)


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [X] Infrastructure

### Goals

Allow building framework on ARM64 Compiled Hybrid Portable Executable (CHPE) platforms.

### Technical Details

* Compile with `/bigobj` with MSVC on Windows to allow static libraries to have more than the default number of sections, which seems to occur on ARM64 CHPE.

### Test Results

Compile-tested only.

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
