### PR TITLE
Add peer app config params

### DIFF
--- a/lib/uwb/UwbSession.cxx
+++ b/lib/uwb/UwbSession.cxx
@@ -137,6 +137,20 @@ UwbSession::GetApplicationConfigurationParameters()
     return GetApplicationConfigurationParametersImpl();
 }
 
+std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter>
+UwbSession::GetApplicationConfigurationParameters(std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameterType> requestedTypes)
+{
+    PLOG_VERBOSE << "get application configuration parameters";
+    return GetApplicationConfigurationParametersImpl(requestedTypes);
+}
+
+void
+UwbSession::SetApplicationConfigurationParameters(std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> params)
+{
+    PLOG_VERBOSE << "get application configuration parameters";
+    return SetApplicationConfigurationParametersImpl(params);
+}
+
 UwbSessionState
 UwbSession::GetSessionState()
 {

--- a/lib/uwb/include/uwb/UwbSession.hxx
+++ b/lib/uwb/include/uwb/UwbSession.hxx
@@ -106,7 +106,7 @@ public:
 
     /**
      * @brief Attempt to add a controlee to this session.
-     * 
+     *
      * @param controleeMacAddress The mac address of the controlee. This is
      * expected to be in the mac address format configured for the session.
      * @return UwbStatus The status of the operation. UwbStatusGeneric::Ok is
@@ -142,6 +142,24 @@ public:
      */
     std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter>
     GetApplicationConfigurationParameters();
+
+    /**
+     * @brief Get the Application Configuration Parameters object
+     *
+     * @param requestedTypes
+     * @return std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter>
+     */
+    std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter>
+    GetApplicationConfigurationParameters(std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameterType> requestedTypes);
+
+    /**
+     * @brief Get the Application Configuration Parameters object
+     *
+     * @param requestedTypes
+     * @return std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter>
+     */
+    void
+    SetApplicationConfigurationParameters(std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> params);
 
     /**
      * @brief Get the current state for this session.
@@ -222,7 +240,7 @@ private:
 
     /**
      * @brief Attempt to add a controlee to this session.
-     * 
+     *
      * @param controleeMacAddress The mac address of the controlee. This is
      * expected to be in the mac address format configured for the session.
      * @return UwbStatus The status of the operation. UwbStatusGeneric::Ok is
@@ -238,6 +256,24 @@ private:
      */
     virtual std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter>
     GetApplicationConfigurationParametersImpl() = 0;
+
+    /**
+     * @brief Get the Application Configuration Parameters object
+     *
+     * @param requestedTypes
+     * @return std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter>
+     */
+    virtual std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter>
+    GetApplicationConfigurationParametersImpl(std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameterType> requestedTypes) = 0;
+
+    /**
+     * @brief Get the Application Configuration Parameters object
+     *
+     * @param requestedTypes
+     * @return std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter>
+     */
+    virtual void
+    SetApplicationConfigurationParametersImpl(std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> params) = 0;
 
     /**
      * @brief Get the current state for this session.

--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -357,6 +357,16 @@ using UwbStatus = std::variant<UwbStatusGeneric, UwbStatusSession, UwbStatusRang
 bool
 IsUwbStatusOk(const UwbStatus& uwbStatus) noexcept;
 
+/**
+ * @brief Determines if the specified UWB status describes a retry command
+ *
+ * @param uwbStatus The status to check.
+ * @return true
+ * @return false
+ */
+bool
+IsUwbStatusRetry(const UwbStatus& uwbStatus) noexcept;
+
 enum class UwbStatusMulticast {
     OkUpdate,
     ErrorListFull,

--- a/lib/uwb/protocols/fira/FiraDevice.cxx
+++ b/lib/uwb/protocols/fira/FiraDevice.cxx
@@ -259,6 +259,13 @@ uwb::protocol::fira::IsUwbStatusOk(const UwbStatus& uwbStatus) noexcept
     return (status != nullptr) && (*status == UwbStatusGeneric::Ok);
 }
 
+bool
+uwb::protocol::fira::IsUwbStatusRetry(const UwbStatus& uwbStatus) noexcept
+{
+    const auto* status = std::get_if<UwbStatusGeneric>(&uwbStatus);
+    return (status != nullptr) && (*status == UwbStatusGeneric::CommandRetry);
+}
+
 std::string
 UwbApplicationConfigurationParameter::ToString() const
 {

--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -180,58 +180,43 @@ UwbSession::TryAddControleeImpl([[maybe_unused]] ::uwb::UwbMacAddress controleeM
     PLOG_VERBOSE << "TryAddControleeImpl";
     return UwbStatusGeneric::Rejected;
 
-    // TODO: convert code below to invoke IOCTL_UWB_SET_APP_CONFIG_PARAMS to use connector
+    if (not m_uwbSessionConnector) {
+        PLOG_WARNING << "No associated connector";
+        return UwbStatusGeneric::Rejected;
+    }
 
-    // TODO: two main options for updating the UWB-CLX peer list:
-    //  1) Every time a peer is added (on-demand)
-    //  2) Only when StartRanging() is called.
-    // Below sample code exemplifies 1) for simplicity but this is not necessarily the way to go.
-    //
-    // TODO: request UWB-CLX to update controlee list per below pseudo-code,
-    // which is *very* rough and some parts probably plain wrong:
-    //
+    auto params = GetApplicationConfigurationParameters();
 
-    // const auto macAddressLength = m_uwbMacAddressSelf.GetLength();
-    // const auto macAddressessLength = macAddressLength * m_peers.size();
+    // if (IsUwbStatusOk(uwbStatus)) {
+    {
+        std::unordered_set<::uwb::UwbMacAddress> macAddresses;
+        for (auto &param : params) {
+            auto pvalue = std::get_if<std::unordered_set<::uwb::UwbMacAddress>>(&(param.Value));
+            if (pvalue) {
+                macAddresses = *pvalue;
+                break;
+            }
+        }
+        auto [_, inserted] = macAddresses.insert(controleeMacAddress);
+        if (not inserted) {
+            PLOG_INFO << "controleeMacAddress already added, skipping";
+            return UwbStatusGeneric::Ok;
+        }
+        if (macAddresses.size() > 8) {
+            PLOG_WARNING << "exceeded max number of controlees with numberOfControlees=" << macAddresses.size();
+            return UwbStatusGeneric::Rejected;
+        }
+        UwbApplicationConfigurationParameter dstMacAddresses{ .Type = UwbApplicationConfigurationParameterType::DestinationMacAddresses, .Value = macAddresses };
+        UwbApplicationConfigurationParameter numControlees{ .Type = UwbApplicationConfigurationParameterType::NumberOfControlees, .Value = uint8_t(macAddresses.size()) };
+        UwbStatus overallStatus = UwbStatusGeneric::CommandRetry;
+        while (IsUwbStatusRetry(overallStatus)) {
+            auto fut = m_uwbSessionConnector->SetApplicationConfigurationParameters(m_sessionId, { numControlees, dstMacAddresses });
+            auto [setStatus, paramStatuses] = fut.get();
 
-    // std::size_t appConfigParamsSize = 0;
-    // appConfigParamsSize += macAddressessLength;
-    // // TODO: all other memory required for this structure must be accounted for, the above calculation was left incomplete.
-    // // Also, proper memory alignment of trailing structures in the allocated buffer has not been taken into account.
-    // auto appConfigParamsBuffer = std::make_unique<uint8_t[]>(appConfigParamsSize);
-    // auto *appConfigParams = reinterpret_cast<UWB_SET_APP_CONFIG_PARAMS *>(appConfigParamsBuffer.get());
-    // appConfigParams->sessionId = GetId();
-    // appConfigParams->appConfigParamsCount = 2;
-    // UWB_APP_CONFIG_PARAM *appConfigParamList = reinterpret_cast<UWB_APP_CONFIG_PARAM *>(appConfigParams + 1);
-    // UWB_APP_CONFIG_PARAM *appConfigParamNumberOfControlees = appConfigParamList + 0;
-    // UWB_APP_CONFIG_PARAM *appConfigParamDstMacAddress = appConfigParamList + 1;
-
-    // // Populate NUMBER_OF_CONTROLEES app configuration parameter.
-    // auto &numberOfControleesPayload = *reinterpret_cast<uint8_t *>(appConfigParamNumberOfControlees + 1);
-    // appConfigParamNumberOfControlees->paramType = UWB_APP_CONFIG_PARAM_TYPE_NUMBER_OF_CONTROLEES;
-    // appConfigParamNumberOfControlees->paramLength = 1;
-    // numberOfControleesPayload = static_cast<uint8_t>(m_peers.size());
-
-    // // Populate DST_MAC_ADDRESS app configuration parameter.
-    // auto dstMacAddressPayload = reinterpret_cast<uint8_t *>(appConfigParamDstMacAddress + 1);
-    // appConfigParamDstMacAddress->paramType = UWB_APP_CONFIG_PARAM_TYPE_DST_MAC_ADDRESS;
-    // appConfigParamDstMacAddress->paramLength = static_cast<uint32_t>(macAddressessLength);
-    // auto dstMacAddress = dstMacAddressPayload;
-    // for (const auto &peer : m_peers) {
-    //     const auto value = peer.GetValue();
-    //     std::copy(std::cbegin(value), std::cend(value), dstMacAddress);
-    //     std::advance(dstMacAddress, std::size(value));
-    // }
-
-    // // Attempt to set all new parameters.
-    // DWORD bytesReturned = 0;
-    // UWB_SET_APP_CONFIG_PARAMS_STATUS appConfigParamsStatus; // TODO: this needs to be dynamically allocated to fit returned content
-    // BOOL ioResult = DeviceIoControl(m_handleDriver.get(), IOCTL_UWB_SET_APP_CONFIG_PARAMS, &appConfigParams, static_cast<DWORD>(appConfigParamsSize), &appConfigParamsStatus, sizeof appConfigParamsStatus, &bytesReturned, nullptr);
-    // if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
-    //     // TODO
-    //     HRESULT hr = GetLastError();
-    //     PLOG_ERROR << "could not send params to driver, hr=" << std::showbase << std::hex << hr;
-    // }
+            overallStatus = setStatus;
+        }
+        return overallStatus;
+    }
 }
 
 std::vector<UwbApplicationConfigurationParameter>

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
@@ -86,6 +86,24 @@ private:
     GetApplicationConfigurationParametersImpl() override;
 
     /**
+     * @brief Get the Application Configuration Parameters object
+     *
+     * @param requestedTypes
+     * @return std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter>
+     */
+    virtual std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter>
+    GetApplicationConfigurationParametersImpl(std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameterType> requestedTypes) override;
+
+    /**
+     * @brief Get the Application Configuration Parameters object
+     *
+     * @param requestedTypes
+     * @return std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter>
+     */
+    virtual void
+    SetApplicationConfigurationParametersImpl(std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> params) override;
+
+    /**
      * @brief Get the current state for this session.
      *
      * @return ::uwb::protocol::fira::UwbSessionState


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Implement the command to add a peer before the ranging session is active.

### Technical Details

Added two new functions to the top-level UwbSession interface, which get and set a vector of app config params

### Test Results

Compile tested.


### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
