### PR TITLE
Fix multicast typo

### DIFF
--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -709,13 +709,13 @@ struct UwbSessionUpdateMulicastList
     operator<=>(const UwbSessionUpdateMulicastList&) const noexcept = default;
 };
 
-struct UwbSessionUpdateMulicastListStatus
+struct UwbSessionUpdateMulticastListStatus
 {
     uint32_t SessionId;
     std::vector<UwbMulticastListStatus> Status;
 
     auto
-    operator<=>(const UwbSessionUpdateMulicastListStatus&) const noexcept = default;
+    operator<=>(const UwbSessionUpdateMulticastListStatus&) const noexcept = default;
 
     /**
      * @brief Returns a string representation of the object.
@@ -805,7 +805,7 @@ struct UwbRangingData
     ToString() const;
 };
 
-using UwbNotificationData = std::variant<UwbStatus, UwbStatusDevice, UwbSessionStatus, UwbSessionUpdateMulicastListStatus, UwbRangingData>;
+using UwbNotificationData = std::variant<UwbStatus, UwbStatusDevice, UwbSessionStatus, UwbSessionUpdateMulticastListStatus, UwbRangingData>;
 
 /**
  * @brief Returns a string representation of the object.

--- a/lib/uwb/protocols/fira/FiraDevice.cxx
+++ b/lib/uwb/protocols/fira/FiraDevice.cxx
@@ -166,7 +166,7 @@ UwbRangingMeasurementData::ToString() const
 }
 
 std::string
-UwbSessionUpdateMulicastListStatus::ToString() const
+UwbSessionUpdateMulticastListStatus::ToString() const
 {
     std::ostringstream ss{};
     ss << "SessionId: " << SessionId << '\n'
@@ -231,7 +231,7 @@ uwb::protocol::fira::ToString(const UwbNotificationData& uwbNotificationData)
         { std::type_index(typeid(UwbStatus)), "Status" },
         { std::type_index(typeid(UwbStatusDevice)), "Device Status" },
         { std::type_index(typeid(UwbSessionStatus)), "Session Status" },
-        { std::type_index(typeid(UwbSessionUpdateMulicastListStatus)), "Session Multicast List Status" },
+        { std::type_index(typeid(UwbSessionUpdateMulticastListStatus)), "Session Multicast List Status" },
         { std::type_index(typeid(UwbRangingData)), "Ranging Data" },
     };
 
@@ -240,7 +240,7 @@ uwb::protocol::fira::ToString(const UwbNotificationData& uwbNotificationData)
     std::visit([&](auto&& arg) {
         using ValueType = std::decay_t<decltype(arg)>;
         ss << TypeNameMap.at(typeid(ValueType)) << " {";
-        if constexpr (std::is_same_v<ValueType, UwbStatusDevice> || std::is_same_v<ValueType, UwbSessionStatus> || std::is_same_v<ValueType, UwbSessionUpdateMulicastListStatus> || std::is_same_v<ValueType, UwbRangingData>) {
+        if constexpr (std::is_same_v<ValueType, UwbStatusDevice> || std::is_same_v<ValueType, UwbSessionStatus> || std::is_same_v<ValueType, UwbSessionUpdateMulticastListStatus> || std::is_same_v<ValueType, UwbRangingData>) {
             ss << arg;
         } else if constexpr (std::is_enum_v<ValueType>) {
             ss << magic_enum::enum_name(arg);

--- a/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
+++ b/tests/unit/windows/TestUwbCxAdapterDdiLrpConversion.cxx
@@ -231,7 +231,7 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
         }
     }
 
-    SECTION("UwbSessionUpdateMulicastListStatus is stable")
+    SECTION("UwbSessionUpdateMulticastListStatus is stable")
     {
         std::vector<UwbMulticastListStatus> uwbMulticastListStatus{};
         for (const auto& uwbStatusMulticast : magic_enum::enum_values<UwbStatusMulticast>()) {
@@ -241,12 +241,12 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
                 .Status = uwbStatusMulticast });
         }
 
-        const UwbSessionUpdateMulicastListStatus uwbSessionUpdateMulicastListStatus{
+        const UwbSessionUpdateMulticastListStatus uwbSessionUpdateMulticastListStatus{
             .SessionId = RandomDistribution(RandomEngine),
             .Status = std::move(uwbMulticastListStatus)
         };
 
-        test::ValidateRoundtrip(uwbSessionUpdateMulicastListStatus);
+        test::ValidateRoundtrip(uwbSessionUpdateMulticastListStatus);
     }
 
     SECTION("UwbRangingMeasurementType is stable")
@@ -449,7 +449,7 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
         }
     }
 
-    SECTION("UwbNotificationData UwbSessionUpdateMulicastListStatus variant is stable")
+    SECTION("UwbNotificationData UwbSessionUpdateMulticastListStatus variant is stable")
     {
         std::vector<UwbMulticastListStatus> uwbMulticastListStatus{};
         for (const auto& uwbStatusMulticast : magic_enum::enum_values<UwbStatusMulticast>()) {
@@ -459,11 +459,11 @@ TEST_CASE("ddi <-> neutral type conversions are stable", "[basic][conversion][wi
                 .Status = uwbStatusMulticast });
         }
 
-        const UwbSessionUpdateMulicastListStatus uwbSessionUpdateMulicastListStatus{
+        const UwbSessionUpdateMulticastListStatus uwbSessionUpdateMulticastListStatus{
             .SessionId = test::GetRandom<uint32_t>(),
             .Status = std::move(uwbMulticastListStatus)
         };
-        const UwbNotificationData uwbNotificationDataSessionUpdateMulicastListStatus{ uwbSessionUpdateMulicastListStatus };
+        const UwbNotificationData uwbNotificationDataSessionUpdateMulicastListStatus{ uwbSessionUpdateMulticastListStatus };
         test::ValidateRoundtrip(uwbNotificationDataSessionUpdateMulicastListStatus);
     }
 

--- a/windows/devices/uwb/UwbConnector.cxx
+++ b/windows/devices/uwb/UwbConnector.cxx
@@ -829,7 +829,7 @@ UwbConnector::OnSessionEnded(uint32_t sessionId, ::uwb::UwbSessionEndReason sess
 }
 
 void
-UwbConnector::OnSessionMulticastListStatus(::uwb::protocol::fira::UwbSessionUpdateMulicastListStatus statusMulticastList)
+UwbConnector::OnSessionMulticastListStatus(::uwb::protocol::fira::UwbSessionUpdateMulticastListStatus statusMulticastList)
 {
     uint32_t sessionId = statusMulticastList.SessionId;
 
@@ -896,7 +896,7 @@ UwbConnector::DispatchCallbacks(::uwb::protocol::fira::UwbNotificationData uwbNo
             if (arg.State == UwbSessionState::Deinitialized) {
                 OnSessionEnded(arg.SessionId, ::uwb::UwbSessionEndReason::Stopped);
             }
-        } else if constexpr (std::is_same_v<ValueType, UwbSessionUpdateMulicastListStatus>) {
+        } else if constexpr (std::is_same_v<ValueType, UwbSessionUpdateMulticastListStatus>) {
             OnSessionMulticastListStatus(arg);
         } else if constexpr (std::is_same_v<ValueType, UwbRangingData>) {
             OnSessionRangingData(arg);

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -191,18 +191,18 @@ windows::devices::uwb::ddi::lrp::From(const UwbSessionUpdateMulicastList &uwbSes
 }
 
 UwbSessionUpdateMulticastListStatusWrapper
-windows::devices::uwb::ddi::lrp::From(const UwbSessionUpdateMulticastListStatus &UwbSessionUpdateMulticastListStatus)
+windows::devices::uwb::ddi::lrp::From(const UwbSessionUpdateMulticastListStatus &uwbSessionUpdateMulticastListStatus)
 {
-    auto multicastListStatusWrapper = UwbSessionUpdateMulticastListStatusWrapper::from_num_elements<decltype(UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF::statusList)>(std::size(UwbSessionUpdateMulticastListStatus.Status));
+    auto multicastListStatusWrapper = UwbSessionUpdateMulticastListStatusWrapper::from_num_elements<decltype(UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF::statusList)>(std::size(uwbSessionUpdateMulticastListStatus.Status));
     UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF &multicastListStatus = multicastListStatusWrapper;
     multicastListStatus.size = multicastListStatusWrapper.size();
-    multicastListStatus.sessionId = UwbSessionUpdateMulticastListStatus.SessionId;
-    multicastListStatus.numberOfControlees = std::size(UwbSessionUpdateMulticastListStatus.Status);
+    multicastListStatus.sessionId = uwbSessionUpdateMulticastListStatus.SessionId;
+    multicastListStatus.numberOfControlees = std::size(uwbSessionUpdateMulticastListStatus.Status);
     multicastListStatus.remainingMulticastListSize = 0;
 
     for (auto i = 0; i < multicastListStatus.numberOfControlees; i++) {
         auto &status = multicastListStatus.statusList[i];
-        status = From(UwbSessionUpdateMulticastListStatus.Status[i]);
+        status = From(uwbSessionUpdateMulticastListStatus.Status[i]);
     }
 
     return multicastListStatusWrapper;
@@ -518,12 +518,12 @@ windows::devices::uwb::ddi::lrp::From(const UwbNotificationData &uwbNotification
             notificationData.notificationType = NotificationTypeMap.at(typeid(arg));
             notificationData.sessionStatus = From(arg);
         } else if constexpr (std::is_same_v<ValueType, UwbSessionUpdateMulticastListStatus>) {
-            auto UwbSessionUpdateMulticastListStatusWrapper = From(arg);
-            totalSize += std::size(UwbSessionUpdateMulticastListStatusWrapper);
+            auto uwbSessionUpdateMulticastListStatusWrapper = From(arg);
+            totalSize += std::size(uwbSessionUpdateMulticastListStatusWrapper);
             notificationDataWrapper = std::make_unique<UwbNotificationDataWrapper>(totalSize);
             UWB_NOTIFICATION_DATA &notificationData = notificationDataWrapper->value();
             notificationData.notificationType = NotificationTypeMap.at(typeid(arg));
-            auto data = UwbSessionUpdateMulticastListStatusWrapper.data();
+            auto data = uwbSessionUpdateMulticastListStatusWrapper.data();
             std::memcpy(&notificationData.sessionUpdateControllerMulticastList, std::data(data), std::size(data));
         } else if constexpr (std::is_same_v<ValueType, UwbRangingData>) {
             auto uwbRangingDataWrapper = From(arg);
@@ -1115,12 +1115,12 @@ windows::devices::uwb::ddi::lrp::To(const UWB_SESSION_UPDATE_CONTROLLER_MULTICAS
         status.push_back(To(multicastListStatus));
     }
 
-    UwbSessionUpdateMulticastListStatus UwbSessionUpdateMulticastListStatus{
+    UwbSessionUpdateMulticastListStatus uwbSessionUpdateMulticastListStatus{
         .SessionId = sessionUpdateControllerMulticastListNtf.sessionId,
         .Status = std::move(status)
     };
 
-    return UwbSessionUpdateMulticastListStatus;
+    return uwbSessionUpdateMulticastListStatus;
 }
 
 UwbRangingMeasurementType

--- a/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
+++ b/windows/devices/uwb/UwbCxAdapterDdiLrp.cxx
@@ -190,19 +190,19 @@ windows::devices::uwb::ddi::lrp::From(const UwbSessionUpdateMulicastList &uwbSes
     return sessionUpdateControllerMulticastListWrapper;
 }
 
-UwbSessionUpdateMulicastListStatusWrapper
-windows::devices::uwb::ddi::lrp::From(const UwbSessionUpdateMulicastListStatus &uwbSessionUpdateMulicastListStatus)
+UwbSessionUpdateMulticastListStatusWrapper
+windows::devices::uwb::ddi::lrp::From(const UwbSessionUpdateMulticastListStatus &UwbSessionUpdateMulticastListStatus)
 {
-    auto multicastListStatusWrapper = UwbSessionUpdateMulicastListStatusWrapper::from_num_elements<decltype(UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF::statusList)>(std::size(uwbSessionUpdateMulicastListStatus.Status));
+    auto multicastListStatusWrapper = UwbSessionUpdateMulticastListStatusWrapper::from_num_elements<decltype(UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF::statusList)>(std::size(UwbSessionUpdateMulticastListStatus.Status));
     UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF &multicastListStatus = multicastListStatusWrapper;
     multicastListStatus.size = multicastListStatusWrapper.size();
-    multicastListStatus.sessionId = uwbSessionUpdateMulicastListStatus.SessionId;
-    multicastListStatus.numberOfControlees = std::size(uwbSessionUpdateMulicastListStatus.Status);
+    multicastListStatus.sessionId = UwbSessionUpdateMulticastListStatus.SessionId;
+    multicastListStatus.numberOfControlees = std::size(UwbSessionUpdateMulticastListStatus.Status);
     multicastListStatus.remainingMulticastListSize = 0;
 
     for (auto i = 0; i < multicastListStatus.numberOfControlees; i++) {
         auto &status = multicastListStatus.statusList[i];
-        status = From(uwbSessionUpdateMulicastListStatus.Status[i]);
+        status = From(UwbSessionUpdateMulticastListStatus.Status[i]);
     }
 
     return multicastListStatusWrapper;
@@ -479,7 +479,7 @@ windows::devices::uwb::ddi::lrp::From(const UwbNotificationData &uwbNotification
         { std::type_index(typeid(UwbStatus)), UWB_NOTIFICATION_TYPE_GENERIC_ERROR },
         { std::type_index(typeid(UwbStatusDevice)), UWB_NOTIFICATION_TYPE_DEVICE_STATUS },
         { std::type_index(typeid(UwbSessionStatus)), UWB_NOTIFICATION_TYPE_SESSION_STATUS },
-        { std::type_index(typeid(UwbSessionUpdateMulicastListStatus)), UWB_NOTIFICATION_TYPE_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST },
+        { std::type_index(typeid(UwbSessionUpdateMulticastListStatus)), UWB_NOTIFICATION_TYPE_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST },
         { std::type_index(typeid(UwbRangingData)), UWB_NOTIFICATION_TYPE_RANGING_DATA },
     };
 
@@ -517,13 +517,13 @@ windows::devices::uwb::ddi::lrp::From(const UwbNotificationData &uwbNotification
             UWB_NOTIFICATION_DATA &notificationData = notificationDataWrapper->value();
             notificationData.notificationType = NotificationTypeMap.at(typeid(arg));
             notificationData.sessionStatus = From(arg);
-        } else if constexpr (std::is_same_v<ValueType, UwbSessionUpdateMulicastListStatus>) {
-            auto uwbSessionUpdateMulicastListStatusWrapper = From(arg);
-            totalSize += std::size(uwbSessionUpdateMulicastListStatusWrapper);
+        } else if constexpr (std::is_same_v<ValueType, UwbSessionUpdateMulticastListStatus>) {
+            auto UwbSessionUpdateMulticastListStatusWrapper = From(arg);
+            totalSize += std::size(UwbSessionUpdateMulticastListStatusWrapper);
             notificationDataWrapper = std::make_unique<UwbNotificationDataWrapper>(totalSize);
             UWB_NOTIFICATION_DATA &notificationData = notificationDataWrapper->value();
             notificationData.notificationType = NotificationTypeMap.at(typeid(arg));
-            auto data = uwbSessionUpdateMulicastListStatusWrapper.data();
+            auto data = UwbSessionUpdateMulticastListStatusWrapper.data();
             std::memcpy(&notificationData.sessionUpdateControllerMulticastList, std::data(data), std::size(data));
         } else if constexpr (std::is_same_v<ValueType, UwbRangingData>) {
             auto uwbRangingDataWrapper = From(arg);
@@ -1106,7 +1106,7 @@ windows::devices::uwb::ddi::lrp::To(const UWB_SESSION_STATE &sessionState)
     return SessionStateToMap.at(sessionState);
 }
 
-UwbSessionUpdateMulicastListStatus
+UwbSessionUpdateMulticastListStatus
 windows::devices::uwb::ddi::lrp::To(const UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF &sessionUpdateControllerMulticastListNtf)
 {
     std::vector<UwbMulticastListStatus> status{};
@@ -1115,12 +1115,12 @@ windows::devices::uwb::ddi::lrp::To(const UWB_SESSION_UPDATE_CONTROLLER_MULTICAS
         status.push_back(To(multicastListStatus));
     }
 
-    UwbSessionUpdateMulicastListStatus uwbSessionUpdateMulicastListStatus{
+    UwbSessionUpdateMulticastListStatus UwbSessionUpdateMulticastListStatus{
         .SessionId = sessionUpdateControllerMulticastListNtf.sessionId,
         .Status = std::move(status)
     };
 
-    return uwbSessionUpdateMulicastListStatus;
+    return UwbSessionUpdateMulticastListStatus;
 }
 
 UwbRangingMeasurementType

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
@@ -201,7 +201,7 @@ private:
      * @param statusMulticastList
      */
     void
-    OnSessionMulticastListStatus(::uwb::protocol::fira::UwbSessionUpdateMulicastListStatus statusMulticastList);
+    OnSessionMulticastListStatus(::uwb::protocol::fira::UwbSessionUpdateMulticastListStatus statusMulticastList);
 
     /**
      * @brief Internal function that prepares the notification for processing by the m_sessionEventCallbacks

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -106,16 +106,16 @@ using UwbSessionUpdateMulicastListWrapper = notstd::flextype_wrapper<UWB_SESSION
 UwbSessionUpdateMulicastListWrapper
 From(const ::uwb::protocol::fira::UwbSessionUpdateMulicastList &uwbSessionUpdateMulicastList);
 
-using UwbSessionUpdateMulicastListStatusWrapper = notstd::flextype_wrapper<UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF>;
+using UwbSessionUpdateMulticastListStatusWrapper = notstd::flextype_wrapper<UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF>;
 
 /**
- * @brief Converts UwbSessionUpdateMulicastListStatus to UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF.
+ * @brief Converts UwbSessionUpdateMulticastListStatus to UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF.
  *
- * @param uwbSessionUpdateMulicastListStatus
- * @return UwbSessionUpdateMulicastListStatusWrapper
+ * @param UwbSessionUpdateMulticastListStatus
+ * @return UwbSessionUpdateMulticastListStatusWrapper
  */
-UwbSessionUpdateMulicastListStatusWrapper
-From(const ::uwb::protocol::fira::UwbSessionUpdateMulicastListStatus &uwbSessionUpdateMulicastListStatus);
+UwbSessionUpdateMulticastListStatusWrapper
+From(const ::uwb::protocol::fira::UwbSessionUpdateMulticastListStatus &UwbSessionUpdateMulticastListStatus);
 
 /**
  * @brief Converts UwbRangingMeasurementType to UWB_RANGING_MEASUREMENT_TYPE.
@@ -486,12 +486,12 @@ To(const UWB_SESSION_STATUS &sessionStatus);
 To(const UWB_DEVICE_INFO &deviceInfo);
 
 /**
- * @brief Converts UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF to UwbSessionUpdateMulicastListStatus.
+ * @brief Converts UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF to UwbSessionUpdateMulticastListStatus.
  *
  * @param sessionUpdateControllerMulticastListNtf
- * @return ::uwb::protocol::fira::UwbSessionUpdateMulicastListStatus
+ * @return ::uwb::protocol::fira::UwbSessionUpdateMulticastListStatus
  */
-::uwb::protocol::fira::UwbSessionUpdateMulicastListStatus
+::uwb::protocol::fira::UwbSessionUpdateMulticastListStatus
 To(const UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF &sessionUpdateControllerMulticastListNtf);
 
 /**

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbCxAdapterDdiLrp.hxx
@@ -111,11 +111,11 @@ using UwbSessionUpdateMulticastListStatusWrapper = notstd::flextype_wrapper<UWB_
 /**
  * @brief Converts UwbSessionUpdateMulticastListStatus to UWB_SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF.
  *
- * @param UwbSessionUpdateMulticastListStatus
+ * @param uwbSessionUpdateMulticastListStatus
  * @return UwbSessionUpdateMulticastListStatusWrapper
  */
 UwbSessionUpdateMulticastListStatusWrapper
-From(const ::uwb::protocol::fira::UwbSessionUpdateMulticastListStatus &UwbSessionUpdateMulticastListStatus);
+From(const ::uwb::protocol::fira::UwbSessionUpdateMulticastListStatus &uwbSessionUpdateMulticastListStatus);
 
 /**
  * @brief Converts UwbRangingMeasurementType to UWB_RANGING_MEASUREMENT_TYPE.


### PR DESCRIPTION
### Type

- [x] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [x] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Fixes #249.

### Technical Details

- Fixed typo.

### Test Results

Compile tested; CTests pass.

### Reviewer Focus

None.

### Future Work

None.

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
