### PR TITLE
Remove FetchContent as depdendency resolution method

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -40,7 +40,6 @@ on:
         type: choice
         options:
           - 'dev'
-          - 'dev-vcpkg'
           - 'dev-driver'
           - 'vcpkg-dev'
           - 'vcpkg-release'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,11 +15,6 @@ set(NOF_BUILD_ENVIRONMENT_DEVELOPMENT "development")
 set(NOF_BUILD_ENVIRONMENT_VCPKG "vcpkg")
 set(NOF_BUILD_ENVIRONMENT ${NOF_BUILD_ENVIRONMENT_DEVELOPMENT} CACHE STRING "Build profile: either local 'development' or 'vcpkg'")
 
-# Dependency resolution configuration.
-set(NOF_DEPENDENCY_RESOLUTION_METHOD_FETCHCONTENT "FetchContent")
-set(NOF_DEPENDENCY_RESOLUTION_METHOD_VCPKG "vcpkg")
-set(NOF_DEPENDENCY_RESOLUTION_METHOD ${NOF_DEPENDENCY_RESOLUTION_METHOD_FETCHCONTENT} CACHE STRING "Method used to resolve dependencies: either 'FetchContent' or 'vcpkg'")
-
 include(cmake/vcpkg.cmake)
 
 # vcpkg feature related variables and options.
@@ -59,8 +54,6 @@ endif()
 
 # Apply build-environment specific settings and configuration.
 if (NOF_BUILD_ENVIRONMENT STREQUAL NOF_BUILD_ENVIRONMENT_VCPKG)
-  # vcpkg build environment must use vcpkg for dependency resolution, so override the cache value.
-  set(NOF_DEPENDENCY_RESOLUTION_METHOD ${NOF_DEPENDENCY_RESOLUTION_METHOD_VCPKG} CACHE STRING "override" FORCE)
   # Enable static runtime linking if requested via vcpkg feature.
   if (NOF_VCPKG_FEATURE_USE_MSVC_STATIC_RUNTIME)
     set(NOF_USE_MSVC_STATIC_RUNTIME TRUE CACHE BOOL "override" FORCE)
@@ -73,14 +66,12 @@ elseif (NOF_BUILD_ENVIRONMENT STREQUAL NOF_BUILD_ENVIRONMENT_DEVELOPMENT)
   # If using vcpkg to resolve dependencies, clone the vcpkg github repository so
   # that it's usable directly in the project without having to install it
   # manually. This must occur prior to the first project statement.
-  if (NOF_DEPENDENCY_RESOLUTION_METHOD STREQUAL NOF_DEPENDENCY_RESOLUTION_METHOD_VCPKG)
-    vcpkg_configure(SUBMODULE_ROOT ${NOF_VCPKG_SUBMODULE_ROOT})
-  endif()
+  vcpkg_configure(SUBMODULE_ROOT ${NOF_VCPKG_SUBMODULE_ROOT})
 else()
   MESSAGE(FATAL_ERROR "Unknown build environment '${NOF_BUILD_ENVIRONMENT}' specified")
 endif()
 
-MESSAGE(STATUS "using build environment '${NOF_BUILD_ENVIRONMENT}' with dependency resolution method '${NOF_DEPENDENCY_RESOLUTION_METHOD}'")
+MESSAGE(STATUS "using build environment '${NOF_BUILD_ENVIRONMENT}'")
 
 project(nearobject-framework 
   LANGUAGES CXX
@@ -129,29 +120,11 @@ set(VERSION_CATCH2 3.1.0)
 set(VERSION_PLOG 1.1.9)
 
 # Pull in external dependencies.
-if (NOF_DEPENDENCY_RESOLUTION_METHOD STREQUAL NOF_DEPENDENCY_RESOLUTION_METHOD_VCPKG)
-  set(nlohmann-json_IMPLICIT_CONVERSIONS OFF)
-  find_package(nlohmann_json CONFIG ${VERSION_NLOHMANN_JSON} REQUIRED)
-  find_package(magic_enum CONFIG ${VERSION_MAGIC_ENUM} REQUIRED)
-  find_package(CLI11 CONFIG ${VERSION_CLI11} REQUIRED)
-  find_package(plog CONFIG REQUIRED)
-elseif (NOF_DEPENDENCY_RESOLUTION_METHOD STREQUAL NOF_DEPENDENCY_RESOLUTION_METHOD_FETCHCONTENT)
-  set(JSON_ImplicitConversions OFF)
-  FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v${VERSION_NLOHMANN_JSON}/json.tar.xz)
-  FetchContent_MakeAvailable(json)
-
-  FetchContent_Declare(magic_enum URL https://github.com/Neargye/magic_enum/archive/refs/tags/v${VERSION_MAGIC_ENUM}.tar.gz)
-  FetchContent_MakeAvailable(magic_enum)
-
-  FetchContent_Declare(cli11 URL https://github.com/CLIUtils/CLI11/archive/refs/tags/v${VERSION_CLI11}.tar.gz)
-  FetchContent_MakeAvailable(cli11)
-
-  FetchContent_Declare(plog URL https://github.com/SergiusTheBest/plog/archive/refs/tags/${VERSION_PLOG}.tar.gz)
-  FetchContent_MakeAvailable(plog)
-else()
-  MESSAGE(FATAL_ERROR "Unknown dependency resolution method '${NOF_DEPENDENCY_RESOLUTION_METHOD}' specified")
-endif() 
-
+set(nlohmann-json_IMPLICIT_CONVERSIONS OFF)
+find_package(nlohmann_json CONFIG ${VERSION_NLOHMANN_JSON} REQUIRED)
+find_package(magic_enum CONFIG ${VERSION_MAGIC_ENUM} REQUIRED)
+find_package(CLI11 CONFIG ${VERSION_CLI11} REQUIRED)
+find_package(plog CONFIG REQUIRED)
 find_package(Threads REQUIRED)
 
 # Uncomment for verbose build information
@@ -248,18 +221,8 @@ elseif (BUILD_FOR_WINDOWS)
   set(WIL_BUILD_TESTS OFF CACHE INTERNAL "Turn off wil tests")
   set(WIL_BUILD_PACKAGING OFF CACHE INTERNAL "Turn off wil packaging")
 
-  if (NOF_DEPENDENCY_RESOLUTION_METHOD STREQUAL NOF_DEPENDENCY_RESOLUTION_METHOD_VCPKG)
-    find_package(wil CONFIG REQUIRED)
-    find_package(cppwinrt CONFIG REQUIRED)
-  else()
-    FetchContent_Declare(WIL
-        GIT_REPOSITORY "https://github.com/microsoft/wil"
-        GIT_TAG "5eb59d60e167482639cc47ffb40442158da7fd04"
-        GIT_SHALLOW OFF
-    )
-    FetchContent_MakeAvailable(WIL)
-  endif()
-
+  find_package(wil CONFIG REQUIRED)
+  find_package(cppwinrt CONFIG REQUIRED)
   # Find nuget and restore packages for this project.
   # Get nuget program (assumes it is on PATH).
   find_program(nuget NAMES nuget REQUIRED)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -24,24 +24,6 @@
             }
         },
         {
-            "name": "resolve-deps-fetchcontent",
-            "hidden": true,
-            "displayName": "Resolve dependencies with FetchContent",
-            "description": "configures project to resolve dependencies with FetchContent",
-            "cacheVariables": {
-                "NOF_DEPENDENCY_RESOLUTION_METHOD": "FetchContent"
-            }
-        },
-        {
-            "name": "resolve-deps-vcpkg",
-            "hidden": true,
-            "displayName": "Resolve dependencies with vcpkg",
-            "description": "configures project to resolve dependencies with vcpkg",
-            "cacheVariables": {
-                "NOF_DEPENDENCY_RESOLUTION_METHOD": "vcpkg"
-            }
-        },
-        {
             "name": "out-of-source-build",
             "hidden": true,
             "displayName": "Out of source build",
@@ -76,7 +58,6 @@
             "displayName": "vcpkg (base)",
             "description": "Base options for all vcpkg presets",
             "inherits":[
-                "resolve-deps-vcpkg",
                 "in-source-build"
             ],
             "cacheVariables": {
@@ -85,20 +66,10 @@
         },
         {
             "name": "dev",
-            "displayName": "Development (with FetchContent)",
-            "description": "Development build for inner-loop with FetchContent",
+            "displayName": "Development",
+            "description": "Development build for inner-loop",
             "inherits": [
-                "dev-base",
-                "resolve-deps-fetchcontent"
-            ]
-        },
-        {
-            "name": "dev-vcpkg",
-            "displayName": "Development (with vcpkg)",
-            "description": "Development build for inner-loop with vcpkg",
-            "inherits": [
-                "dev-base",
-                "resolve-deps-vcpkg"
+                "dev-base"
             ]
         },
         {
@@ -150,7 +121,7 @@
             "displayName": "CI/CD",
             "description": "Continuous integration and continuous delivery (CI/CD) based build",
             "inherits": [
-                "dev-vcpkg"
+                "dev"
             ]
         },
         {


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [X] Infrastructure

### Goals

Simplify maintenance of development inner loop. Note that this is not a breaking change since the build will automatically acquire vcpkg if not installed on the system.

### Technical Details

* Remove `FetchContent`-based dependency resolution, requiring `vcpkg` for all build scenarios.
* Remove CMake presets based on `FetchContent`.
* Drop `vcpkg` suffix from CMake presets and/or rename them to `dev`.

### Test Results

Successfully built project with a few of the remaining presets.

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
