### PR TITLE
Restructure nocli top-level driver subcommand

### DIFF
--- a/tools/cli/include/nearobject/cli/NearObjectCli.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCli.hxx
@@ -81,12 +81,12 @@ public:
     CancelExecution();
 
     /**
-     * @brief Get the app object associated with the "uwb" sub-command.
+     * @brief Get the app object associated with the "driver" sub-command.
      *
      * @return CLI::App&
      */
     CLI::App&
-    GetUwbApp() noexcept;
+    GetDriverApp() noexcept;
 
     /**
      * @brief Get the app object associated with the "service" sub-command.
@@ -97,36 +97,44 @@ public:
     GetServiceApp() noexcept;
 
     /**
-     * @brief Get the app object associated with the "uwb range" sub-command.
-     *
+     * @brief Get the app object associated with the "driver uwb" sub-command.
+     * 
      * @return CLI::App&
      */
     CLI::App&
-    GetUwbRangeApp() noexcept;
+    GetDriverUwbApp() noexcept;
 
     /**
-     * @brief Get the app object associated with the "uwb raw" sub-command.
+     * @brief Get the app object associated with the "driver uwb range" sub-command.
      *
      * @return CLI::App&
      */
     CLI::App&
-    GetUwbRawApp() noexcept;
+    GetDriverUwbRangeApp() noexcept;
 
     /**
-     * @brief Get the app object associated with the "uwb range start" sub-command.
+     * @brief Get the app object associated with the "driver uwb raw" sub-command.
      *
      * @return CLI::App&
      */
     CLI::App&
-    GetUwbRangeStartApp() noexcept;
+    GetDriverUwbRawApp() noexcept;
 
     /**
-     * @brief Get the app object associated with the "uwb range stop" sub-command.
+     * @brief Get the app object associated with the "driver uwb range start" sub-command.
      *
      * @return CLI::App&
      */
     CLI::App&
-    GetUwbRangeStopApp() noexcept;
+    GetDriverUwbRangeStartApp() noexcept;
+
+    /**
+     * @brief Get the app object associated with the "driver uwb range stop" sub-command.
+     *
+     * @return CLI::App&
+     */
+    CLI::App&
+    GetDriverUwbRangeStopApp() noexcept;
 
     /**
      * @brief Get the app object associated with the "service range" sub-command.
@@ -197,13 +205,13 @@ private:
     CreateParser() noexcept;
 
     /**
-     * @brief Add the 'uwb' sub-command.
+     * @brief Add the 'driver' sub-command.
      *
      * @param parent The parent app to add the command to.
      * @return CLI::App*
      */
     CLI::App*
-    AddSubcommandUwb(CLI::App* parent);
+    AddSubcommandDriver(CLI::App* parent);
 
     /**
      * @brief Add the 'service' sub-command.
@@ -215,31 +223,40 @@ private:
     AddSubcommandService(CLI::App* parent);
 
     /**
-     * @brief Add the 'uwb monitor' sub-command.
-     *
+     * @brief Add the 'driver uwb' sub-command.
+     * 
      * @param parent The parent app to add the command to.
      * @return CLI::App*
      */
     CLI::App*
-    AddSubcommandUwbMonitor(CLI::App* parent);
+    AddSubcommandDriverUwb(CLI::App* parent);
 
     /**
-     * @brief Add the 'uwb raw' sub-command.
+     * @brief Add the 'driver uwb raw' sub-command.
      *
      * @param parent The parent app to add the command to.
      * @return CLI::App*
      */
     CLI::App*
-    AddSubcommandUwbRaw(CLI::App* parent);
+    AddSubcommandDriverUwbRaw(CLI::App* parent);
 
     /**
-     * @brief Add the 'uwb range' sub-command.
+     * @brief Add the 'driver uwb range' sub-command.
      *
      * @param parent The parent app to add the command to.
      * @return CLI::App*
      */
     CLI::App*
-    AddSubcommandUwbRange(CLI::App* parent);
+    AddSubcommandDriverUwbRange(CLI::App* parent);
+
+    /**
+     * @brief Add the 'service monitor' sub-command.
+     *
+     * @param parent The parent app to add the command to.
+     * @return CLI::App*
+     */
+    CLI::App*
+    AddSubcommandServiceMonitor(CLI::App* parent);
 
     /**
      * @brief Add the 'service range' sub-command.
@@ -251,67 +268,67 @@ private:
     AddSubcommandServiceRange(CLI::App* parent);
 
     /**
-     * @brief Add the 'uwb raw devicereset' sub-command.
+     * @brief Add the 'driver uwb raw devicereset' sub-command.
      *
      * @param parent The parent app to add the command to.
      * @return CLI::App*
      */
     CLI::App*
-    AddSubcommandUwbRawDeviceReset(CLI::App* parent);
+    AddSubcommandDriverUwbRawDeviceReset(CLI::App* parent);
 
     /**
-     * @brief Add the 'uwb raw getdeviceinfo' sub-command.
+     * @brief Add the 'driver uwb raw getdeviceinfo' sub-command.
      *
      * @param parent The parent app to add the command to.
      * @return CLI::App*
      */
     CLI::App*
-    AddSubcommandUwbRawGetDeviceInfo(CLI::App* parent);
+    AddSubcommandDriverUwbRawGetDeviceInfo(CLI::App* parent);
 
     /**
-     * @brief Add the 'uwb raw sessiondeinit' sub-command.
+     * @brief Add the 'driver uwb raw sessiondeinit' sub-command.
      *
      * @param parent The parent app to add the command.
      * @return CLI::App*
      */
     CLI::App*
-    AddSubcommandUwbRawSessionDeinitialize(CLI::App* parent);
+    AddSubcommandDriverUwbRawSessionDeinitialize(CLI::App* parent);
 
     /**
-     * @brief Add the 'uwb raw getsessioncount' sub-command.
+     * @brief Add the 'driver uwb raw getsessioncount' sub-command.
      *
      * @param parent The parent app to add the command.
      * @return CLI::App*
      */
     CLI::App*
-    AddSubcommandUwbRawGetSessionCount(CLI::App* parent);
+    AddSubcommandDriverUwbRawGetSessionCount(CLI::App* parent);
 
     /**
-     * @brief Add the 'uwb raw getsessionstate' sub-command.
+     * @brief Add the 'driver uwb raw getsessionstate' sub-command.
      *
      * @param parent The parent app to add the command.
      * @return CLI::App*
      */
     CLI::App*
-    AddSubcommandUwbRawGetSessionState(CLI::App* parent);
+    AddSubcommandDriverUwbRawGetSessionState(CLI::App* parent);
 
     /**
-     * @brief Add the 'uwb range start' sub-command.
+     * @brief Add the 'driver uwb range start' sub-command.
      *
      * @param parent
      * @return CLI::App*
      */
     CLI::App*
-    AddSubcommandUwbRangeStart(CLI::App* parent);
+    AddSubcommandDriverUwbRangeStart(CLI::App* parent);
 
     /**
-     * @brief Add the 'uwb range stop' sub-command.
+     * @brief Add the 'driver uwb range stop' sub-command.
      *
      * @param parent The parent app to add the command to.
      * @return CLI::App*
      */
     CLI::App*
-    AddSubcommandUwbRangeStop(CLI::App* parent);
+    AddSubcommandDriverUwbRangeStop(CLI::App* parent);
 
     /**
      * @brief Add the 'service range start' sub-command.
@@ -339,14 +356,15 @@ private:
 
     std::unique_ptr<CLI::App> m_cliApp;
     // The following are helper references to the subcommands of m_cliApp, the memory is managed by CLI11.
-    CLI::App* m_uwbApp;
+    CLI::App* m_driverApp;
     CLI::App* m_serviceApp;
-    CLI::App* m_monitorApp;
-    CLI::App* m_uwbRawApp;
-    CLI::App* m_uwbRangeApp;
+    CLI::App* m_driverUwbApp;
+    CLI::App* m_driverUwbRawApp;
+    CLI::App* m_driverUwbRangeApp;
+    CLI::App* m_serviceMonitorApp;
     CLI::App* m_serviceRangeApp;
-    CLI::App* m_uwbRangeStartApp;
-    CLI::App* m_uwbRangeStopApp;
+    CLI::App* m_driverUwbRangeStartApp;
+    CLI::App* m_driverUwbRangeStopApp;
     CLI::App* m_serviceRangeStartApp;
     CLI::App* m_serviceRangeStopApp;
 };

--- a/tools/cli/include/nearobject/cli/NearObjectCli.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCli.hxx
@@ -98,7 +98,7 @@ public:
 
     /**
      * @brief Get the app object associated with the "driver uwb" sub-command.
-     * 
+     *
      * @return CLI::App&
      */
     CLI::App&
@@ -224,7 +224,7 @@ private:
 
     /**
      * @brief Add the 'driver uwb' sub-command.
-     * 
+     *
      * @param parent The parent app to add the command to.
      * @return CLI::App*
      */

--- a/windows/tools/nocli/Main.cxx
+++ b/windows/tools/nocli/Main.cxx
@@ -42,7 +42,7 @@ try {
     nearobject::cli::NearObjectCli cli{ cliData, cliHandler };
 
     // Configure the cli parsing app with Windows-specific options.
-    auto& uwbApp = cli.GetUwbApp();
+    auto& uwbApp = cli.GetDriverUwbApp();
     uwbApp.add_option("--deviceName", cliData->DeviceName, "uwb device name (path)");
     uwbApp.add_option("--deviceClass", cliData->DeviceClassGuid, "uwb device class guid (override)");
     uwbApp.add_flag("--probe", cliData->DeviceNameProbe, "probe for the uwb device name to use");


### PR DESCRIPTION
### Type

- [x] Bug fix
- [ ] Feature addition
- [x] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

This PR restructures the nocli tool subcommands at the top-level to more accurately represent the flexibility of the NearObject service. Specifically, the "uwb" subcommand is demoted a level and is under the new "driver" subcommand. This is because theoretically, there could be drivers of other technology types besides UWB that are used for NearObject functionality.

Closes #191 

### Technical Details

- Added "driver" top-level subcommand and placed all "uwb" related subcommands below that.
- Slightly improved the subcommand descriptions in nocli.
- Removed weird "[0]" output automatically added by CLI11. These occur when "capture_default_str()" is used for a non-std::optional value.

### Test Results

Verified nocli --help output in all branches.

### Reviewer Focus

I moved monitor mode into the "service" subcommand, but I'm not too familiar with what it actually does. Is this a good place, or should it be its own top-level command (alongside "driver" and "service")?

### Future Work

The subcommands under "service" will be heavily revamped to call the public WinRT APIs of the NearObject Service.

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
