### PR TITLE
Streamline vcpkg build environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,9 @@ if (NOF_VCPKG_ENABLE)
   set(NOF_BUILD_ENVIRONMENT ${NOF_BUILD_ENVIRONMENT_VCPKG} CACHE STRING "override" FORCE)
 endif()
 
+# Configure vcpkg to resolve dependencies.
+vcpkg_configure(SUBMODULE_ROOT ${NOF_VCPKG_SUBMODULE_ROOT})
+
 # Apply build-environment specific settings and configuration.
 if (NOF_BUILD_ENVIRONMENT STREQUAL NOF_BUILD_ENVIRONMENT_VCPKG)
   # Enable static runtime linking if requested via vcpkg feature.
@@ -63,10 +66,7 @@ if (NOF_BUILD_ENVIRONMENT STREQUAL NOF_BUILD_ENVIRONMENT_VCPKG)
     set(NOF_VCPKG_TARGET ${NOF_VCPKG_TARGET_DEVELOPMENT} CACHE STRING "override") 
   endif()
 elseif (NOF_BUILD_ENVIRONMENT STREQUAL NOF_BUILD_ENVIRONMENT_DEVELOPMENT)
-  # If using vcpkg to resolve dependencies, clone the vcpkg github repository so
-  # that it's usable directly in the project without having to install it
-  # manually. This must occur prior to the first project statement.
-  vcpkg_configure(SUBMODULE_ROOT ${NOF_VCPKG_SUBMODULE_ROOT})
+  # Nothing special needed for the development build envrionment.
 else()
   MESSAGE(FATAL_ERROR "Unknown build environment '${NOF_BUILD_ENVIRONMENT}' specified")
 endif()
@@ -89,11 +89,6 @@ endif()
 
 MESSAGE(STATUS "Target OS ${CMAKE_SYSTEM_NAME} detected")
 
-# Ensure FetchContent-based dependencies are rebuilt if their URL changes.
-if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
-  cmake_policy(SET CMP0135 NEW)
-endif()
-
 # Set language configutation options. The C++ standard used must be the lowest
 # common denominator for all the OS-dependent projects. In practice, since this
 # project must build under the Windows build system (build.exe), its toolchain
@@ -109,7 +104,6 @@ set_property(GLOBAL PROPERTY CTEST_TARGETS_ADDED 1)
 include(CheckPIESupported)
 include(CTest)
 include(GNUInstallDirs)
-include(FetchContent)
 include(cmake/cpack.cmake)
 
 # Set external dependency target versions.
@@ -222,21 +216,23 @@ elseif (BUILD_FOR_WINDOWS)
   set(WIL_BUILD_PACKAGING OFF CACHE INTERNAL "Turn off wil packaging")
 
   find_package(wil CONFIG REQUIRED)
-  find_package(cppwinrt CONFIG REQUIRED)
-  # Find nuget and restore packages for this project.
-  # Get nuget program (assumes it is on PATH).
-  find_program(nuget NAMES nuget REQUIRED)
 
-  # Configure the nuget packages configuration with variable substitutions.
-  configure_file(
-    ${CMAKE_CURRENT_LIST_DIR}/packages.config.in
-    ${CMAKE_CURRENT_LIST_DIR}/packages.config
-  )
+  if (NOT NOF_VCPKG_ENABLE)
+    # Find nuget and restore packages for this project.
+    # Get nuget program (assumes it is on PATH).
+    find_program(nuget NAMES nuget REQUIRED)
 
-  # Restore nuget package dependencies.
-  include(cmake/cppwinrt.cmake)
-  include(cmake/nuget.cmake)
-  restore_nuget_packages()
+    # Configure the nuget packages configuration with variable substitutions.
+    configure_file(
+      ${CMAKE_CURRENT_LIST_DIR}/packages.config.in
+      ${CMAKE_CURRENT_LIST_DIR}/packages.config
+    )
+
+    # Restore nuget package dependencies.
+    include(cmake/cppwinrt.cmake)
+    include(cmake/nuget.cmake)
+    restore_nuget_packages()
+  endif()
 
   # Add Windows-specific global compile definitions.
   add_compile_definitions(
@@ -246,7 +242,7 @@ elseif (BUILD_FOR_WINDOWS)
       WIN32_LEAN_AND_MEAN
   )
 
-  # Allow more than default number of section in object files.
+  # Allow more than default number of sections in object files.
   add_compile_options(
     /bigobj
   )
@@ -271,8 +267,11 @@ endif()
 
 add_subdirectory(external)
 add_subdirectory(lib)
-add_subdirectory(tools)
 add_subdirectory(packaging)
+
+if (NOT NOF_DISABLE_TOOLS)
+  add_subdirectory(tools)
+endif()
 
 if (NOT NOF_DISABLE_TESTS)
   add_subdirectory(tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ if (NOF_BUILD_ENVIRONMENT STREQUAL NOF_BUILD_ENVIRONMENT_VCPKG)
     set(NOF_VCPKG_TARGET ${NOF_VCPKG_TARGET_DEVELOPMENT} CACHE STRING "override") 
   endif()
 elseif (NOF_BUILD_ENVIRONMENT STREQUAL NOF_BUILD_ENVIRONMENT_DEVELOPMENT)
-  # Nothing special needed for the development build envrionment.
+  # Nothing special needed for the development build environment.
 else()
   MESSAGE(FATAL_ERROR "Unknown build environment '${NOF_BUILD_ENVIRONMENT}' specified")
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -117,6 +117,18 @@
             }
         },
         {
+            "name": "external-build",
+            "displayName": "External build",
+            "description": "external vcpkg-based build with release (stable) sources",
+            "inherits": [
+                "vcpkg-dev"
+            ],
+            "cacheVariables": {
+                "NOF_DISABLE_TESTS": true,
+                "NOF_VCPKG_ENABLE": true
+            }
+        },
+        {
             "name": "cicd",
             "displayName": "CI/CD",
             "description": "Continuous integration and continuous delivery (CI/CD) based build",

--- a/external/windows/CMakeLists.txt
+++ b/external/windows/CMakeLists.txt
@@ -1,1 +1,4 @@
-add_subdirectory(winrt)
+
+if (NOT NOF_VCPKG_ENABLE)
+  add_subdirectory(winrt)
+endif()

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -1,4 +1,7 @@
 add_subdirectory(devices)
 add_subdirectory(nearobject)
 add_subdirectory(nearobjectd)
-add_subdirectory(tools)
+
+if (NOT NOF_DISABLE_TOOLS)
+  add_subdirectory(tools)
+endif()

--- a/packaging/vcpkg/ports/nearobject-framework/portfile.cmake.in
+++ b/packaging/vcpkg/ports/nearobject-framework/portfile.cmake.in
@@ -18,6 +18,7 @@ vcpkg_cmake_configure(
     OPTIONS
         -DNOF_VCPKG_ENABLE=TRUE
         -DNOF_DISABLE_TESTS=TRUE
+        -DNOF_DISABLE_TOOLS=TRUE
         ${FEATURE_OPTIONS}
 )
 

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -2,4 +2,7 @@ add_subdirectory(devices)
 add_subdirectory(drivers)
 add_subdirectory(nearobject)
 add_subdirectory(shared)
-add_subdirectory(tools)
+
+if (NOT NOF_DISABLE_TOOLS)
+  add_subdirectory(tools)
+endif()

--- a/windows/tools/CMakeLists.txt
+++ b/windows/tools/CMakeLists.txt
@@ -1,4 +1,7 @@
 
 add_subdirectory(devicemon)
-add_subdirectory(nocli)
 add_subdirectory(uwb)
+
+if (NOT NOF_VCPKG_ENABLE)
+  add_subdirectory(nocli)
+endif()


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [X] Infrastructure

### Goals
Simplify build environment options.

### Technical Details

* Remove last bits related to FetchContent.
* Gate use of nuget for when not building a vcpkg port.
* Add preset for simulating an external build from a vcpkg port.
* Add ability to skip building tools.

### Test Results

* Built project tree and simulator driver with a few presets from a clean state and verified no errors.

### Reviewer Focus

None

### Future Work

More simplification might be possible. The changes have to be targeted and slow since there are at least 4 build environments that need to be supported (dev loop build, dev simulator driver build, windows build, github runner build).

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
