### PR TITLE
Use DevicePresenceEnumerator for UWB device detection in NearObjectDeviceDiscoveryAgentUwb

### DIFF
--- a/windows/nearobject/service/NearObjectDeviceDiscoveryAgentUwb.cxx
+++ b/windows/nearobject/service/NearObjectDeviceDiscoveryAgentUwb.cxx
@@ -26,7 +26,7 @@ CreateNearObjectUwbDevice(std::string deviceName)
 
 NearObjectDeviceDiscoveryAgentUwb::NearObjectDeviceDiscoveryAgentUwb() :
     m_devicePresenceMonitor(
-        windows::devices::uwb::InterfaceClassUwb, [&](auto &&deviceGuid, auto &&presenceEvent, auto &&deviceName) {
+        windows::devices::uwb::InterfaceClassUwb, [this](auto &&deviceGuid, auto &&presenceEvent, auto &&deviceName) {
             const auto presenceEventName = magic_enum::enum_name(presenceEvent);
             PLOG_INFO << deviceName << " " << presenceEventName << std::endl;
             switch (presenceEvent) {

--- a/windows/nearobject/service/NearObjectDeviceDiscoveryAgentUwb.cxx
+++ b/windows/nearobject/service/NearObjectDeviceDiscoveryAgentUwb.cxx
@@ -1,5 +1,4 @@
 
-#include <filesystem>
 #include <magic_enum.hpp>
 #include <plog/Log.h>
 #include <string>
@@ -86,43 +85,6 @@ NearObjectDeviceDiscoveryAgentUwb::ExtractCachedNearObjectDevice(const std::stri
     return nearObjectExtractResult.empty()
         ? nullptr
         : nearObjectExtractResult.mapped().lock();
-}
-
-void
-NearObjectDeviceDiscoveryAgentUwb::OnDeviceInterfaceNotification(HCMNOTIFICATION hcmNotificationHandle, CM_NOTIFY_ACTION action, CM_NOTIFY_EVENT_DATA *eventData, DWORD eventDataSize)
-{
-    std::string deviceName;
-    std::filesystem::path devicePath;
-
-    switch (action) {
-    case CM_NOTIFY_ACTION_DEVICEINTERFACEARRIVAL: {
-        devicePath = std::filesystem::path(std::wstring(eventData->u.DeviceInterface.SymbolicLink));
-        deviceName = devicePath.string();
-        auto nearObjectDeviceControllerUwb = AddCachedUwbNearObjectDevice(deviceName);
-        DevicePresenceChanged(NearObjectDevicePresence::Arrived, std::move(nearObjectDeviceControllerUwb));
-        break;
-    }
-    case CM_NOTIFY_ACTION_DEVICEINTERFACEREMOVAL: {
-        devicePath = std::filesystem::path(std::wstring(eventData->u.DeviceInterface.SymbolicLink));
-        deviceName = devicePath.string();
-        auto nearObjectDeviceControllerUwb = ExtractCachedNearObjectDevice(deviceName);
-        if (nearObjectDeviceControllerUwb) {
-            DevicePresenceChanged(NearObjectDevicePresence::Departed, std::move(nearObjectDeviceControllerUwb));
-        }
-        break;
-    }
-    default:
-        break;
-    }
-}
-
-/* static */
-DWORD CALLBACK
-NearObjectDeviceDiscoveryAgentUwb::OnDeviceInterfaceNotificationCallback(HCMNOTIFICATION hcmNotificationHandle, void *context, CM_NOTIFY_ACTION action, CM_NOTIFY_EVENT_DATA *eventData, DWORD eventDataSize)
-{
-    auto self = static_cast<NearObjectDeviceDiscoveryAgentUwb *>(context);
-    self->OnDeviceInterfaceNotification(hcmNotificationHandle, action, eventData, eventDataSize);
-    return S_OK;
 }
 
 /* static */

--- a/windows/nearobject/service/include/windows/nearobject/service/NearObjectDeviceDiscoveryAgentUwb.hxx
+++ b/windows/nearobject/service/include/windows/nearobject/service/NearObjectDeviceDiscoveryAgentUwb.hxx
@@ -70,6 +70,16 @@ private:
     std::shared_ptr<::nearobject::service::NearObjectDeviceControllerUwb>
     ExtractCachedNearObjectDevice(const std::string &deviceName);
 
+    /**
+     * @brief Callback function invoked when device presence changes.
+     *
+     * @param deviceGuid The GUID of the device that changed presence.
+     * @param presenceEvent The type of presence change that ocurred.
+     * @param deviceName The device name (interface path) of the device.
+     */
+    void
+    OnDevicePresenceChanged(const GUID &deviceGuid, windows::devices::DevicePresenceEvent presenceEvent, std::string deviceName);
+
 private:
     std::mutex m_nearObjectDeviceCacheGate;
     std::unordered_map<std::string, std::weak_ptr<::nearobject::service::NearObjectDeviceControllerUwb>> m_nearObjectDeviceCache;

--- a/windows/nearobject/service/include/windows/nearobject/service/NearObjectDeviceDiscoveryAgentUwb.hxx
+++ b/windows/nearobject/service/include/windows/nearobject/service/NearObjectDeviceDiscoveryAgentUwb.hxx
@@ -8,11 +8,6 @@
 #include <unordered_map>
 #include <vector>
 
-// NB: This must come before any other Windows include
-#include <windows.h>
-
-#include <cfgmgr32.h>
-
 #include <nearobject/service/NearObjectDeviceControllerDiscoveryAgent.hxx>
 #include <windows/devices/DevicePresenceMonitor.hxx>
 #include <windows/devices/DeviceResource.hxx>
@@ -76,8 +71,6 @@ private:
     ExtractCachedNearObjectDevice(const std::string &deviceName);
 
 private:
-    unique_hcmnotification m_uwbHcmNotificationHandle;
-
     std::mutex m_nearObjectDeviceCacheGate;
     std::unordered_map<std::string, std::weak_ptr<::nearobject::service::NearObjectDeviceControllerUwb>> m_nearObjectDeviceCache;
 

--- a/windows/nearobject/service/include/windows/nearobject/service/NearObjectDeviceDiscoveryAgentUwb.hxx
+++ b/windows/nearobject/service/include/windows/nearobject/service/NearObjectDeviceDiscoveryAgentUwb.hxx
@@ -12,11 +12,10 @@
 #include <windows.h>
 
 #include <cfgmgr32.h>
-#include <wil/resource.h>
 
 #include <nearobject/service/NearObjectDeviceControllerDiscoveryAgent.hxx>
-#include <windows/devices/DeviceResource.hxx>
 #include <windows/devices/DevicePresenceMonitor.hxx>
+#include <windows/devices/DeviceResource.hxx>
 
 namespace nearobject
 {
@@ -55,30 +54,6 @@ protected:
 private:
     std::vector<std::shared_ptr<::nearobject::service::NearObjectDeviceController>>
     Probe();
-
-    /**
-     * @brief Bound callback function for when a UWB class driver event occurs.
-     *
-     * @param hcmNotificationHandle
-     * @param action
-     * @param eventData
-     * @param eventDataSize
-     */
-    void
-    OnDeviceInterfaceNotification(HCMNOTIFICATION hcmNotificationHandle, CM_NOTIFY_ACTION action, CM_NOTIFY_EVENT_DATA *eventData, DWORD eventDataSize);
-
-    /**
-     * @brief Unbound callback function for when a UWB class driver event occurs.
-     *
-     * @param hcmNotificationHandle
-     * @param context
-     * @param action
-     * @param eventData
-     * @param eventDataSize
-     * @return DWORD
-     */
-    static DWORD CALLBACK
-    OnDeviceInterfaceNotificationCallback(HCMNOTIFICATION hcmNotificationHandle, void *context, CM_NOTIFY_ACTION action, CM_NOTIFY_EVENT_DATA *eventData, DWORD eventDataSize);
 
     /**
      * @brief Create (if necessary) and add NearObjectDeviceControllerUwb wrapper instance

--- a/windows/nearobject/service/include/windows/nearobject/service/NearObjectDeviceDiscoveryAgentUwb.hxx
+++ b/windows/nearobject/service/include/windows/nearobject/service/NearObjectDeviceDiscoveryAgentUwb.hxx
@@ -16,6 +16,7 @@
 
 #include <nearobject/service/NearObjectDeviceControllerDiscoveryAgent.hxx>
 #include <windows/devices/DeviceResource.hxx>
+#include <windows/devices/DevicePresenceMonitor.hxx>
 
 namespace nearobject
 {
@@ -38,6 +39,9 @@ namespace nearobject::service
 class NearObjectDeviceDiscoveryAgentUwb :
     public ::nearobject::service::NearObjectDeviceControllerDiscoveryAgent
 {
+public:
+    NearObjectDeviceDiscoveryAgentUwb();
+
 protected:
     void
     StartImpl() override;
@@ -51,18 +55,6 @@ protected:
 private:
     std::vector<std::shared_ptr<::nearobject::service::NearObjectDeviceController>>
     Probe();
-
-    /**
-     * @brief Register for notifications of UWB device driver events.
-     */
-    void
-    RegisterForUwbDeviceClassNotifications();
-
-    /**
-     * @brief Unregister from notifications of UWB device driver events.
-     */
-    void
-    UnregisterForUwbDeviceClassNotifications();
 
     /**
      * @brief Bound callback function for when a UWB class driver event occurs.
@@ -113,6 +105,9 @@ private:
 
     std::mutex m_nearObjectDeviceCacheGate;
     std::unordered_map<std::string, std::weak_ptr<::nearobject::service::NearObjectDeviceControllerUwb>> m_nearObjectDeviceCache;
+
+    // this member is actually in charge of handling the presence monitoring
+    windows::devices::DevicePresenceMonitor m_devicePresenceMonitor;
 };
 } // namespace nearobject::service
 } // namespace windows


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [X] Infrastructure

### Goals
Use DevicePresenceEnumerator for UWB device detection in NearObjectDeviceDiscoveryAgentUwb

### Technical Details

NearObjectDeviceDiscoveryAgentUwb holds a member variable m_devicePresenceEnumerator which handles all the presence event handling.

### Test Results

Compile tested 

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
