### PR TITLE
Convert device presence detection handler to forwarding lambda

### DIFF
--- a/windows/nearobject/service/include/windows/nearobject/service/NearObjectDeviceDiscoveryAgentUwb.hxx
+++ b/windows/nearobject/service/include/windows/nearobject/service/NearObjectDeviceDiscoveryAgentUwb.hxx
@@ -70,6 +70,16 @@ private:
     std::shared_ptr<::nearobject::service::NearObjectDeviceControllerUwb>
     ExtractCachedNearObjectDevice(const std::string &deviceName);
 
+    /**
+     * @brief Callback function invoked when device presence changes.
+     *
+     * @param deviceGuid The GUID of the device that changed presence.
+     * @param presenceEvent The type of presence change that ocurred.
+     * @param deviceName The device name (interface path) of the device.
+     */
+    void
+    OnDevicePresenceChanged(const GUID &deviceGuid, windows::devices::DevicePresenceEvent presenceEvent, std::string deviceName);
+
 private:
     std::mutex m_nearObjectDeviceCacheGate;
     std::unordered_map<std::string, std::weak_ptr<::nearobject::service::NearObjectDeviceControllerUwb>> m_nearObjectDeviceCache;


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Make debugging of device presence event changes more convenient.

### Technical Details

* Add new member function to handle device presence change events.
* Convert existing `DevicePresenceMonitor` initialization to use a forwarding lambda to the added member function.

### Test Results

Compiled only.

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
