### PR TITLE
Fix forward declaration of UwbSession

### DIFF
--- a/lib/uwb/include/uwb/UwbSessionEventCallbacks.hxx
+++ b/lib/uwb/include/uwb/UwbSessionEventCallbacks.hxx
@@ -9,7 +9,7 @@
 
 namespace uwb
 {
-struct UwbSession;
+class UwbSession;
 
 /**
  * @brief The possible reasons for a session ending.


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Ensure compilers with strict compliance checking can use `UwbSession`.

### Technical Details

* Forward-declare `UwbSession` consistently with `class` instead of `struct`.

### Test Results

Compile-tested.

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
