### PR TITLE
Add NavigationView to OobSimulator

### DIFF
--- a/windows/tools/OobSimulator/App.xaml.cpp
+++ b/windows/tools/OobSimulator/App.xaml.cpp
@@ -3,8 +3,8 @@
 #include "pch.h"
 
 #include "App.xaml.h"
+#include "MainPage.xaml.h"
 #include "MainWindow.xaml.h"
-#include "UwbSessionDataPage.xaml.h"
 
 using namespace winrt;
 using namespace Windows::Foundation;
@@ -13,9 +13,6 @@ using namespace Microsoft::UI::Xaml::Controls;
 using namespace Microsoft::UI::Xaml::Navigation;
 using namespace OobSimulator;
 using namespace OobSimulator::implementation;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 /// <summary>
 /// Initializes the singleton application object.  This is the first line of authored code
@@ -42,10 +39,8 @@ App::App()
 void
 App::OnLaunched(LaunchActivatedEventArgs const& e)
 {
-    Frame rootFrame = Frame();
-    rootFrame.Navigate(xaml_typename<OobSimulator::UwbSessionDataPage>(), box_value(e.Arguments()));
-
+    auto mainPage = make<MainPage>();
     window = make<MainWindow>();
-    window.Content(rootFrame);
+    window.Content(mainPage);
     window.Activate();
 }

--- a/windows/tools/OobSimulator/App.xaml.h
+++ b/windows/tools/OobSimulator/App.xaml.h
@@ -12,7 +12,7 @@ struct App : AppT<App>
     App();
 
     void
-    OnLaunched(Microsoft::UI::Xaml::LaunchActivatedEventArgs const&);
+    OnLaunched(Microsoft::UI::Xaml::LaunchActivatedEventArgs const &);
 
 private:
     winrt::Microsoft::UI::Xaml::Window window{ nullptr };

--- a/windows/tools/OobSimulator/MainPage.idl
+++ b/windows/tools/OobSimulator/MainPage.idl
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation and Contributors.
+// Licensed under the MIT License.
+
+namespace OobSimulator
+{
+    [default_interface]
+    runtimeclass MainPage : Microsoft.UI.Xaml.Controls.Page
+    {
+        MainPage();
+
+        Double NavViewCompactModeThresholdWidth
+        { 
+            get; 
+        };
+    }
+}

--- a/windows/tools/OobSimulator/MainPage.xaml
+++ b/windows/tools/OobSimulator/MainPage.xaml
@@ -1,0 +1,42 @@
+<!-- Copyright (c) Microsoft Corporation and Contributors. -->
+<!-- Licensed under the MIT License. -->
+
+<Page
+    x:Class="OobSimulator.MainPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:OobSimulator"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <muxc:NavigationView x:Name="NavView" Loaded="NavView_Loaded" ItemInvoked="NavView_ItemInvoked" BackRequested="NavView_BackRequested">
+        <muxc:NavigationView.MenuItems>
+            <muxc:NavigationViewItem Tag="uwbsessiondata" Icon="Home" Content="Home" />
+            <muxc:NavigationViewItemSeparator />
+            <muxc:NavigationViewItemHeader x:Name="MainPagesHeader" Content="Main pages" />
+        </muxc:NavigationView.MenuItems>
+        <ScrollViewer>
+            <Frame x:Name="ContentFrame" Padding="12,0,12,24" IsTabStop="True" NavigationFailed="ContentFrame_NavigationFailed" Navigated="ContentFrame_Navigated"/>
+        </ScrollViewer>
+    </muxc:NavigationView>
+
+    <VisualStateManager.VisualStateGroups>
+        <VisualStateGroup>
+            <VisualState>
+                <VisualState.StateTriggers>
+                    <AdaptiveTrigger MinWindowWidth="{x:Bind NavViewCompactModeThresholdWidth}" />
+                </VisualState.StateTriggers>
+                <VisualState.Setters>
+                    <!-- Remove the next 3 lines for left-only navigation. -->
+                    <Setter Target="NavView.PaneDisplayMode" Value="Top"/>
+                    <Setter Target="NavViewSearchBox.Width" Value="200"/>
+                    <Setter Target="MainPagesHeader.Visibility" Value="Collapsed"/>
+                    <!-- Leave the next line for left-only navigation. -->
+                    <Setter Target="ContentFrame.Padding" Value="24,0,24,24"/>
+                </VisualState.Setters>
+            </VisualState>
+        </VisualStateGroup>
+    </VisualStateManager.VisualStateGroups>
+</Page>

--- a/windows/tools/OobSimulator/MainPage.xaml
+++ b/windows/tools/OobSimulator/MainPage.xaml
@@ -11,14 +11,14 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <muxc:NavigationView x:Name="NavView" Loaded="NavView_Loaded" ItemInvoked="NavView_ItemInvoked" BackRequested="NavView_BackRequested">
+    <muxc:NavigationView x:Name="NavView" Loaded="NavView_Loaded" ItemInvoked="NavView_ItemInvoked" BackRequested="NavView_BackRequested" PaneDisplayMode="Top" AlwaysShowHeader="False">
         <muxc:NavigationView.MenuItems>
-            <muxc:NavigationViewItem Tag="uwbsessiondata" Icon="Home" Content="Home" />
+            <muxc:NavigationViewItemHeader Content="UWB" />
             <muxc:NavigationViewItemSeparator />
-            <muxc:NavigationViewItemHeader x:Name="MainPagesHeader" Content="Main pages" />
+            <muxc:NavigationViewItem Tag="uwbsessiondata" Icon="Home" Content="Session Data Generator" />
         </muxc:NavigationView.MenuItems>
         <ScrollViewer>
-            <Frame x:Name="ContentFrame" Padding="12,0,12,24" IsTabStop="True" NavigationFailed="ContentFrame_NavigationFailed" Navigated="ContentFrame_Navigated"/>
+            <Frame x:Name="ContentFrame" IsTabStop="True" NavigationFailed="ContentFrame_NavigationFailed" Navigated="ContentFrame_Navigated"/>
         </ScrollViewer>
     </muxc:NavigationView>
 
@@ -28,14 +28,6 @@
                 <VisualState.StateTriggers>
                     <AdaptiveTrigger MinWindowWidth="{x:Bind NavViewCompactModeThresholdWidth}" />
                 </VisualState.StateTriggers>
-                <VisualState.Setters>
-                    <!-- Remove the next 3 lines for left-only navigation. -->
-                    <Setter Target="NavView.PaneDisplayMode" Value="Top"/>
-                    <Setter Target="NavViewSearchBox.Width" Value="200"/>
-                    <Setter Target="MainPagesHeader.Visibility" Value="Collapsed"/>
-                    <!-- Leave the next line for left-only navigation. -->
-                    <Setter Target="ContentFrame.Padding" Value="24,0,24,24"/>
-                </VisualState.Setters>
             </VisualState>
         </VisualStateGroup>
     </VisualStateManager.VisualStateGroups>

--- a/windows/tools/OobSimulator/MainPage.xaml.cpp
+++ b/windows/tools/OobSimulator/MainPage.xaml.cpp
@@ -1,0 +1,199 @@
+// Copyright (c) Microsoft Corporation and Contributors.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "MainPage.xaml.h"
+#if __has_include("MainPage.g.cpp")
+#include "MainPage.g.cpp"
+#endif
+
+#include "UwbSessionDataPage.xaml.h"
+#include "winrt/Microsoft.UI.Xaml.Media.Animation.h"
+
+using namespace winrt;
+using namespace Microsoft::UI::Xaml;
+
+namespace winrt::OobSimulator::implementation
+{
+// List of ValueTuple holding the Navigation Tag and the relative Navigation Page
+// std::vector<std::pair<std::wstring, Windows::UI::Xaml::Interop::TypeName>> m_pages;
+
+MainPage::MainPage()
+{
+    InitializeComponent();
+
+    m_pages.push_back(std::make_pair<std::wstring, Windows::UI::Xaml::Interop::TypeName>
+        (L"uwbsessiondata", winrt::xaml_typename<OobSimulator::UwbSessionDataPage>()));
+}
+
+double
+MainPage::NavViewCompactModeThresholdWidth()
+{
+    return NavView().CompactModeThresholdWidth();
+}
+
+void 
+winrt::OobSimulator::implementation::MainPage::NavView_Loaded(winrt::Windows::Foundation::IInspectable const& /*sender*/, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& /*e*/)
+{
+    // Add handler for ContentFrame navigation.
+    ContentFrame().Navigated({ this, &MainPage::ContentFrame_Navigated });
+
+    // NavView doesn't load any page by default, so load home page.
+    NavView().SelectedItem(NavView().MenuItems().GetAt(0));
+    // If navigation occurs on SelectionChanged, then this isn't needed.
+    // Because we use ItemInvoked to navigate, we need to call Navigate
+    // here to load the home page.
+    NavView_Navigate(L"uwbsessiondata", Microsoft::UI::Xaml::Media::Animation::EntranceNavigationTransitionInfo());
+
+    // Listen to the window directly so the app responds
+    // to accelerator keys regardless of which element has focus.
+    winrt::Windows::UI::Xaml::Window::Current().CoreWindow().Dispatcher().AcceleratorKeyActivated({ this, &MainPage::CoreDispatcher_AcceleratorKeyActivated });
+    winrt::Windows::UI::Xaml::Window::Current().CoreWindow().PointerPressed({ this, &MainPage::CoreWindow_PointerPressed });
+    Windows::UI::Core::SystemNavigationManager::GetForCurrentView().BackRequested({ this, &MainPage::System_BackRequested });
+}
+
+void MainPage::NavView_ItemInvoked(Windows::Foundation::IInspectable const& /* sender */, muxc::NavigationViewItemInvokedEventArgs const& args)
+{
+    if (args.IsSettingsInvoked())
+    {
+        // TODO: settings page
+        // NavView_Navigate(L"settings", args.RecommendedNavigationTransitionInfo());
+    }
+    else if (args.InvokedItemContainer())
+    {
+        NavView_Navigate(winrt::unbox_value_or<winrt::hstring>(args.InvokedItemContainer().Tag(), L"").c_str(), args.RecommendedNavigationTransitionInfo());
+    }
+}
+
+void MainPage::NavView_Navigate(std::wstring navItemTag, Microsoft::UI::Xaml::Media::Animation::NavigationTransitionInfo const& transitionInfo)
+{
+    Windows::UI::Xaml::Interop::TypeName pageTypeName;
+    
+    // TOOD: settings page
+    //if (navItemTag == L"settings")
+    //{
+    //    pageTypeName = winrt::xaml_typename<NavigationViewCppWinRT::SettingsPage>();
+    //}
+    //else
+    {
+        for (auto&& eachPage : m_pages)
+        {
+            if (eachPage.first == navItemTag)
+            {
+                pageTypeName = eachPage.second;
+                break;
+            }
+        }
+    }
+    // Get the page type before navigation so you can prevent duplicate
+    // entries in the backstack.
+    Windows::UI::Xaml::Interop::TypeName preNavPageType = ContentFrame().CurrentSourcePageType();
+
+    // Navigate only if the selected page isn't currently loaded.
+    if (pageTypeName.Name != L"" && preNavPageType.Name != pageTypeName.Name)
+    {
+        ContentFrame().Navigate(pageTypeName, nullptr, transitionInfo);
+    }
+}
+
+void
+winrt::OobSimulator::implementation::MainPage::NavView_BackRequested(winrt::Microsoft::UI::Xaml::Controls::NavigationView const& /*sender*/, winrt::Microsoft::UI::Xaml::Controls::NavigationViewBackRequestedEventArgs const& /*args*/)
+{
+    TryGoBack();
+}
+
+void
+winrt::OobSimulator::implementation::MainPage::ContentFrame_NavigationFailed(winrt::Windows::Foundation::IInspectable const& /*sender*/, winrt::Microsoft::UI::Xaml::Navigation::NavigationFailedEventArgs const& args)
+{
+    throw winrt::hresult_error(E_FAIL, winrt::hstring(L"Failed to load Page ") + args.SourcePageType().Name);
+}
+
+void
+winrt::OobSimulator::implementation::MainPage::ContentFrame_Navigated(winrt::Windows::Foundation::IInspectable const& /*sender*/, winrt::Microsoft::UI::Xaml::Navigation::NavigationEventArgs const& args)
+{
+    NavView().IsBackEnabled(ContentFrame().CanGoBack());
+
+    // TODO: settings page
+    //if (ContentFrame().SourcePageType().Name ==
+    //    winrt::xaml_typename<NavigationViewCppWinRT::SettingsPage>().Name)
+    //{
+    //    // SettingsItem is not part of NavView.MenuItems, and doesn't have a Tag.
+    //    NavView().SelectedItem(NavView().SettingsItem().as<muxc::NavigationViewItem>());
+    //    NavView().Header(winrt::box_value(L"Settings"));
+    //}
+    //else if (ContentFrame().SourcePageType().Name != L"")
+    if (ContentFrame().SourcePageType().Name != L"")
+    {
+        for (auto&& eachPage : m_pages)
+        {
+            if (eachPage.second.Name == args.SourcePageType().Name)
+            {
+                for (auto&& eachMenuItem : NavView().MenuItems())
+                {
+                    auto navigationViewItem = eachMenuItem.try_as<muxc::NavigationViewItem>();
+                    {
+                        if (navigationViewItem)
+                        {
+                            winrt::hstring hstringValue = winrt::unbox_value_or<winrt::hstring>(navigationViewItem.Tag(), L"");
+                            if (hstringValue == eachPage.first)
+                            {
+                                NavView().SelectedItem(navigationViewItem);
+                                NavView().Header(navigationViewItem.Content());
+                            }
+                        }
+                    }
+                }
+                break;
+            }
+        }
+    }
+}
+
+bool
+MainPage::TryGoBack()
+{
+    if (!ContentFrame().CanGoBack())
+        return false;
+
+    // Don't go back if the nav pane is overlayed.
+    if (NavView().IsPaneOpen() &&
+        (NavView().DisplayMode() == muxc::NavigationViewDisplayMode::Compact || NavView().DisplayMode() == muxc::NavigationViewDisplayMode::Minimal))
+        return false;
+
+    ContentFrame().GoBack();
+    return true;
+}
+
+void
+MainPage::CoreDispatcher_AcceleratorKeyActivated(Windows::UI::Core::CoreDispatcher const& /* sender */, Windows::UI::Core::AcceleratorKeyEventArgs const& args)
+{
+    // When Alt+Left are pressed navigate back
+    if (args.EventType() == Windows::UI::Core::CoreAcceleratorKeyEventType::SystemKeyDown
+        && args.VirtualKey() == Windows::System::VirtualKey::Left
+        && args.KeyStatus().IsMenuKeyDown
+        && !args.Handled())
+    {
+        args.Handled(TryGoBack());
+    }
+}
+
+void
+MainPage::CoreWindow_PointerPressed(Windows::UI::Core::CoreWindow const& /* sender */, Windows::UI::Core::PointerEventArgs const& args)
+{
+    // Handle mouse back button.
+    if (args.CurrentPoint().Properties().IsXButton1Pressed())
+    {
+        args.Handled(TryGoBack());
+    }
+}
+
+void 
+MainPage::System_BackRequested(Windows::Foundation::IInspectable const& /* sender */, Windows::UI::Core::BackRequestedEventArgs const& args)
+{
+    if (!args.Handled())
+    {
+        args.Handled(TryGoBack());
+    }
+}
+
+} // namespace winrt::OobSimulator::implementation

--- a/windows/tools/OobSimulator/MainPage.xaml.cpp
+++ b/windows/tools/OobSimulator/MainPage.xaml.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "pch.h"
+
 #include "MainPage.xaml.h"
 #if __has_include("MainPage.g.cpp")
 #include "MainPage.g.cpp"
@@ -20,8 +21,7 @@ MainPage::MainPage()
     InitializeComponent();
 
     // Map of page string tags to their corresponding xaml type.
-    m_pages.push_back(std::make_pair<std::wstring, Windows::UI::Xaml::Interop::TypeName>
-        (L"uwbsessiondata", winrt::xaml_typename<OobSimulator::UwbSessionDataPage>()));
+    m_pages.push_back(std::make_pair<std::wstring, Windows::UI::Xaml::Interop::TypeName>(L"uwbsessiondata", winrt::xaml_typename<OobSimulator::UwbSessionDataPage>()));
 }
 
 double
@@ -46,34 +46,31 @@ winrt::OobSimulator::implementation::MainPage::NavView_Loaded(winrt::Windows::Fo
     NavView_Navigate(m_pages.front().first, Microsoft::UI::Xaml::Media::Animation::EntranceNavigationTransitionInfo());
 }
 
-void MainPage::NavView_ItemInvoked(Windows::Foundation::IInspectable const& /* sender */, muxc::NavigationViewItemInvokedEventArgs const& args)
+void
+MainPage::NavView_ItemInvoked(Windows::Foundation::IInspectable const& /* sender */, muxc::NavigationViewItemInvokedEventArgs const& args)
 {
-    if (args.IsSettingsInvoked())
-    {
+    if (args.IsSettingsInvoked()) {
         // TODO: settings page
         // NavView_Navigate(L"settings", args.RecommendedNavigationTransitionInfo());
-    }
-    else if (args.InvokedItemContainer())
-    {
+    } else if (args.InvokedItemContainer()) {
         NavView_Navigate(winrt::unbox_value_or<winrt::hstring>(args.InvokedItemContainer().Tag(), L"").c_str(), args.RecommendedNavigationTransitionInfo());
     }
 }
 
-void MainPage::NavView_Navigate(std::wstring navItemTag, Microsoft::UI::Xaml::Media::Animation::NavigationTransitionInfo const& transitionInfo)
+void
+MainPage::NavView_Navigate(std::wstring navItemTag, Microsoft::UI::Xaml::Media::Animation::NavigationTransitionInfo const& transitionInfo)
 {
     Windows::UI::Xaml::Interop::TypeName pageTypeName;
-    
+
     // TOOD: settings page
-    //if (navItemTag == L"settings")
+    // if (navItemTag == L"settings")
     //{
     //    pageTypeName = winrt::xaml_typename<NavigationViewCppWinRT::SettingsPage>();
     //}
-    //else
+    // else
     {
-        for (auto&& eachPage : m_pages)
-        {
-            if (eachPage.first == navItemTag)
-            {
+        for (auto&& eachPage : m_pages) {
+            if (eachPage.first == navItemTag) {
                 pageTypeName = eachPage.second;
                 break;
             }
@@ -84,8 +81,7 @@ void MainPage::NavView_Navigate(std::wstring navItemTag, Microsoft::UI::Xaml::Me
     Windows::UI::Xaml::Interop::TypeName preNavPageType = ContentFrame().CurrentSourcePageType();
 
     // Navigate only if the selected page isn't currently loaded.
-    if (pageTypeName.Name != L"" && preNavPageType.Name != pageTypeName.Name)
-    {
+    if (pageTypeName.Name != L"" && preNavPageType.Name != pageTypeName.Name) {
         ContentFrame().Navigate(pageTypeName, nullptr, transitionInfo);
     }
 }
@@ -108,29 +104,23 @@ winrt::OobSimulator::implementation::MainPage::ContentFrame_Navigated(winrt::Win
     NavView().IsBackEnabled(ContentFrame().CanGoBack());
 
     // TODO: settings page
-    //if (ContentFrame().SourcePageType().Name ==
+    // if (ContentFrame().SourcePageType().Name ==
     //    winrt::xaml_typename<NavigationViewCppWinRT::SettingsPage>().Name)
     //{
     //    // SettingsItem is not part of NavView.MenuItems, and doesn't have a Tag.
     //    NavView().SelectedItem(NavView().SettingsItem().as<muxc::NavigationViewItem>());
     //    NavView().Header(winrt::box_value(L"Settings"));
     //}
-    //else if (ContentFrame().SourcePageType().Name != L"")
-    if (ContentFrame().SourcePageType().Name != L"")
-    {
-        for (auto&& eachPage : m_pages)
-        {
-            if (eachPage.second.Name == args.SourcePageType().Name)
-            {
-                for (auto&& eachMenuItem : NavView().MenuItems())
-                {
+    // else if (ContentFrame().SourcePageType().Name != L"")
+    if (ContentFrame().SourcePageType().Name != L"") {
+        for (auto&& eachPage : m_pages) {
+            if (eachPage.second.Name == args.SourcePageType().Name) {
+                for (auto&& eachMenuItem : NavView().MenuItems()) {
                     auto navigationViewItem = eachMenuItem.try_as<muxc::NavigationViewItem>();
                     {
-                        if (navigationViewItem)
-                        {
+                        if (navigationViewItem) {
                             winrt::hstring hstringValue = winrt::unbox_value_or<winrt::hstring>(navigationViewItem.Tag(), L"");
-                            if (hstringValue == eachPage.first)
-                            {
+                            if (hstringValue == eachPage.first) {
                                 NavView().SelectedItem(navigationViewItem);
                                 NavView().Header(navigationViewItem.Content());
                             }

--- a/windows/tools/OobSimulator/MainPage.xaml.cpp
+++ b/windows/tools/OobSimulator/MainPage.xaml.cpp
@@ -15,13 +15,11 @@ using namespace Microsoft::UI::Xaml;
 
 namespace winrt::OobSimulator::implementation
 {
-// List of ValueTuple holding the Navigation Tag and the relative Navigation Page
-// std::vector<std::pair<std::wstring, Windows::UI::Xaml::Interop::TypeName>> m_pages;
-
 MainPage::MainPage()
 {
     InitializeComponent();
 
+    // Map of page string tags to their corresponding xaml type.
     m_pages.push_back(std::make_pair<std::wstring, Windows::UI::Xaml::Interop::TypeName>
         (L"uwbsessiondata", winrt::xaml_typename<OobSimulator::UwbSessionDataPage>()));
 }
@@ -32,7 +30,7 @@ MainPage::NavViewCompactModeThresholdWidth()
     return NavView().CompactModeThresholdWidth();
 }
 
-void 
+void
 winrt::OobSimulator::implementation::MainPage::NavView_Loaded(winrt::Windows::Foundation::IInspectable const& /*sender*/, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& /*e*/)
 {
     // Add handler for ContentFrame navigation.
@@ -40,16 +38,12 @@ winrt::OobSimulator::implementation::MainPage::NavView_Loaded(winrt::Windows::Fo
 
     // NavView doesn't load any page by default, so load home page.
     NavView().SelectedItem(NavView().MenuItems().GetAt(0));
+
     // If navigation occurs on SelectionChanged, then this isn't needed.
     // Because we use ItemInvoked to navigate, we need to call Navigate
     // here to load the home page.
-    NavView_Navigate(L"uwbsessiondata", Microsoft::UI::Xaml::Media::Animation::EntranceNavigationTransitionInfo());
-
-    // Listen to the window directly so the app responds
-    // to accelerator keys regardless of which element has focus.
-    winrt::Windows::UI::Xaml::Window::Current().CoreWindow().Dispatcher().AcceleratorKeyActivated({ this, &MainPage::CoreDispatcher_AcceleratorKeyActivated });
-    winrt::Windows::UI::Xaml::Window::Current().CoreWindow().PointerPressed({ this, &MainPage::CoreWindow_PointerPressed });
-    Windows::UI::Core::SystemNavigationManager::GetForCurrentView().BackRequested({ this, &MainPage::System_BackRequested });
+    // Load the first page.
+    NavView_Navigate(m_pages.front().first, Microsoft::UI::Xaml::Media::Animation::EntranceNavigationTransitionInfo());
 }
 
 void MainPage::NavView_ItemInvoked(Windows::Foundation::IInspectable const& /* sender */, muxc::NavigationViewItemInvokedEventArgs const& args)
@@ -162,38 +156,6 @@ MainPage::TryGoBack()
 
     ContentFrame().GoBack();
     return true;
-}
-
-void
-MainPage::CoreDispatcher_AcceleratorKeyActivated(Windows::UI::Core::CoreDispatcher const& /* sender */, Windows::UI::Core::AcceleratorKeyEventArgs const& args)
-{
-    // When Alt+Left are pressed navigate back
-    if (args.EventType() == Windows::UI::Core::CoreAcceleratorKeyEventType::SystemKeyDown
-        && args.VirtualKey() == Windows::System::VirtualKey::Left
-        && args.KeyStatus().IsMenuKeyDown
-        && !args.Handled())
-    {
-        args.Handled(TryGoBack());
-    }
-}
-
-void
-MainPage::CoreWindow_PointerPressed(Windows::UI::Core::CoreWindow const& /* sender */, Windows::UI::Core::PointerEventArgs const& args)
-{
-    // Handle mouse back button.
-    if (args.CurrentPoint().Properties().IsXButton1Pressed())
-    {
-        args.Handled(TryGoBack());
-    }
-}
-
-void 
-MainPage::System_BackRequested(Windows::Foundation::IInspectable const& /* sender */, Windows::UI::Core::BackRequestedEventArgs const& args)
-{
-    if (!args.Handled())
-    {
-        args.Handled(TryGoBack());
-    }
 }
 
 } // namespace winrt::OobSimulator::implementation

--- a/windows/tools/OobSimulator/MainPage.xaml.h
+++ b/windows/tools/OobSimulator/MainPage.xaml.h
@@ -22,11 +22,6 @@ namespace muxc
     using namespace winrt::Microsoft::UI::Xaml::Controls;
 };
 
-namespace wuxc
-{
-    using namespace winrt::Windows::UI::Xaml::Controls;
-};
-
 namespace winrt::OobSimulator::implementation
 {
 struct MainPage : MainPageT<MainPage>
@@ -54,15 +49,6 @@ struct MainPage : MainPageT<MainPage>
     void
     ContentFrame_Navigated(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Navigation::NavigationEventArgs const& e);
 
-    void
-    CoreDispatcher_AcceleratorKeyActivated(Windows::UI::Core::CoreDispatcher const& /* sender */, Windows::UI::Core::AcceleratorKeyEventArgs const& args);
-    
-    void
-    CoreWindow_PointerPressed(Windows::UI::Core::CoreWindow const& /* sender */, Windows::UI::Core::PointerEventArgs const& args);
-    
-    void 
-    System_BackRequested(Windows::Foundation::IInspectable const& /* sender */, Windows::UI::Core::BackRequestedEventArgs const& args);
-    
     bool
     TryGoBack();
 

--- a/windows/tools/OobSimulator/MainPage.xaml.h
+++ b/windows/tools/OobSimulator/MainPage.xaml.h
@@ -1,25 +1,25 @@
 // Copyright (c) Microsoft Corporation and Contributors.
 // Licensed under the MIT License.
 
-#ifndef MAIN_PAGE_H
-#define MAIN_PAGE_H
+#ifndef MAIN_PAGE_XAML_H
+#define MAIN_PAGE_XAML_H
 
 #include <string>
 #include <utility>
 #include <vector>
 
-#include "winrt/Windows.UI.Xaml.Input.h"
-#include "winrt/Windows.UI.Xaml.Media.Animation.h"
 #include "winrt/Microsoft.UI.Xaml.Controls.h"
 #include "winrt/Microsoft.UI.Xaml.XamlTypeInfo.h"
-#include <winrt/Windows.UI.Core.h>
 #include "winrt/Windows.UI.Input.h"
+#include "winrt/Windows.UI.Xaml.Input.h"
+#include "winrt/Windows.UI.Xaml.Media.Animation.h"
+#include <winrt/Windows.UI.Core.h>
 
 #include "MainPage.g.h"
 
 namespace muxc
 {
-    using namespace winrt::Microsoft::UI::Xaml::Controls;
+using namespace winrt::Microsoft::UI::Xaml::Controls;
 };
 
 namespace winrt::OobSimulator::implementation
@@ -28,18 +28,18 @@ struct MainPage : MainPageT<MainPage>
 {
     MainPage();
 
-    double 
+    double
     NavViewCompactModeThresholdWidth();
 
-    void 
+    void
     NavView_Loaded(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);
-    
+
     void
     NavView_ItemInvoked(Windows::Foundation::IInspectable const& /* sender */, muxc::NavigationViewItemInvokedEventArgs const& args);
 
     void
     NavView_BackRequested(winrt::Microsoft::UI::Xaml::Controls::NavigationView const& sender, winrt::Microsoft::UI::Xaml::Controls::NavigationViewBackRequestedEventArgs const& args);
-    
+
     void
     NavView_Navigate(std::wstring navItemTag, Microsoft::UI::Xaml::Media::Animation::NavigationTransitionInfo const& transitionInfo);
 
@@ -56,13 +56,13 @@ private:
     // Vector of std::pair holding the Navigation Tag and the relative Navigation Page.
     std::vector<std::pair<std::wstring, Windows::UI::Xaml::Interop::TypeName>> m_pages;
 };
-} // winrt::OobSimulator::implementation
+} // namespace winrt::OobSimulator::implementation
 
 namespace winrt::OobSimulator::factory_implementation
 {
 struct MainPage : MainPageT<MainPage, implementation::MainPage>
 {
 };
-} // winrt::OobSimulator::factory_implementation
+} // namespace winrt::OobSimulator::factory_implementation
 
-#endif // MAIN_PAGE_H
+#endif // MAIN_PAGE_XAML_H

--- a/windows/tools/OobSimulator/MainPage.xaml.h
+++ b/windows/tools/OobSimulator/MainPage.xaml.h
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation and Contributors.
+// Licensed under the MIT License.
+
+#ifndef MAIN_PAGE_H
+#define MAIN_PAGE_H
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "winrt/Windows.UI.Xaml.Input.h"
+#include "winrt/Windows.UI.Xaml.Media.Animation.h"
+#include "winrt/Microsoft.UI.Xaml.Controls.h"
+#include "winrt/Microsoft.UI.Xaml.XamlTypeInfo.h"
+#include <winrt/Windows.UI.Core.h>
+#include "winrt/Windows.UI.Input.h"
+
+#include "MainPage.g.h"
+
+namespace muxc
+{
+    using namespace winrt::Microsoft::UI::Xaml::Controls;
+};
+
+namespace wuxc
+{
+    using namespace winrt::Windows::UI::Xaml::Controls;
+};
+
+namespace winrt::OobSimulator::implementation
+{
+struct MainPage : MainPageT<MainPage>
+{
+    MainPage();
+
+    double 
+    NavViewCompactModeThresholdWidth();
+
+    void 
+    NavView_Loaded(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);
+    
+    void
+    NavView_ItemInvoked(Windows::Foundation::IInspectable const& /* sender */, muxc::NavigationViewItemInvokedEventArgs const& args);
+
+    void
+    NavView_BackRequested(winrt::Microsoft::UI::Xaml::Controls::NavigationView const& sender, winrt::Microsoft::UI::Xaml::Controls::NavigationViewBackRequestedEventArgs const& args);
+    
+    void
+    NavView_Navigate(std::wstring navItemTag, Microsoft::UI::Xaml::Media::Animation::NavigationTransitionInfo const& transitionInfo);
+
+    void
+    ContentFrame_NavigationFailed(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Navigation::NavigationFailedEventArgs const& args);
+
+    void
+    ContentFrame_Navigated(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Navigation::NavigationEventArgs const& e);
+
+    void
+    CoreDispatcher_AcceleratorKeyActivated(Windows::UI::Core::CoreDispatcher const& /* sender */, Windows::UI::Core::AcceleratorKeyEventArgs const& args);
+    
+    void
+    CoreWindow_PointerPressed(Windows::UI::Core::CoreWindow const& /* sender */, Windows::UI::Core::PointerEventArgs const& args);
+    
+    void 
+    System_BackRequested(Windows::Foundation::IInspectable const& /* sender */, Windows::UI::Core::BackRequestedEventArgs const& args);
+    
+    bool
+    TryGoBack();
+
+private:
+    // Vector of std::pair holding the Navigation Tag and the relative Navigation Page.
+    std::vector<std::pair<std::wstring, Windows::UI::Xaml::Interop::TypeName>> m_pages;
+};
+} // winrt::OobSimulator::implementation
+
+namespace winrt::OobSimulator::factory_implementation
+{
+struct MainPage : MainPageT<MainPage, implementation::MainPage>
+{
+};
+} // winrt::OobSimulator::factory_implementation
+
+#endif // MAIN_PAGE_H

--- a/windows/tools/OobSimulator/OobSimulator.vcxproj
+++ b/windows/tools/OobSimulator/OobSimulator.vcxproj
@@ -111,6 +111,10 @@
     <ClInclude Include="BindableBase.h" />
     <ClInclude Include="DelegateCommand.h" />
     <ClInclude Include="Globals.h" />
+    <ClInclude Include="MainPage.xaml.h">
+      <DependentUpon>MainPage.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </ClInclude>
     <ClInclude Include="UwbSessionData.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="App.xaml.h">
@@ -131,6 +135,9 @@
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml" />
+    <Page Include="MainPage.xaml">
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="MainWindow.xaml" />
     <Page Include="UwbSessionDataPage.xaml">
       <SubType>Designer</SubType>
@@ -140,6 +147,10 @@
     <ClCompile Include="BindableBase.cpp" />
     <ClCompile Include="DelegateCommand.cpp" />
     <ClCompile Include="Globals.cpp" />
+    <ClCompile Include="MainPage.xaml.cpp">
+      <DependentUpon>MainPage.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </ClCompile>
     <ClCompile Include="UwbSessionData.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
@@ -168,6 +179,10 @@
     </Midl>
     <Midl Include="BindableBase.idl" />
     <Midl Include="DelegateCommand.idl" />
+    <Midl Include="MainPage.idl">
+      <DependentUpon>MainPage.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Midl>
     <Midl Include="MainWindow.idl">
       <SubType>Code</SubType>
       <DependentUpon>MainWindow.xaml</DependentUpon>


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Allow navigation of multiple pages and/or features.

### Technical Details

* Add a primary `Page` control called `MainPage` to be the content of the primary window, `MainWindow`.
* Add a `NavigationView` control to organize pages within the application.
* Add `UWB` section to navigation view with `UWB Session Data Generator` item (default).

### Test Results

* Launched the app, changed some UI values, clicked `Set UWB Session Data` and verified it produced the expected output file.

### Reviewer Focus

None

### Screenshots
<img width="635" alt="image" src="https://user-images.githubusercontent.com/2082148/236956502-c2c33d68-82ed-433e-b681-da7d0796b404.png">

### Future Work

* A dedicated settings page needs to be added.
* The `UwbSessionDataPage` UI elements could be laid out a bit more neatly.

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
