### PR TITLE
Move encoding helpers to separate file in Tlv lib

### DIFF
--- a/lib/shared/tlv/CMakeLists.txt
+++ b/lib/shared/tlv/CMakeLists.txt
@@ -8,10 +8,12 @@ target_sources(tlv
     PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/TlvBer.cxx
         ${CMAKE_CURRENT_LIST_DIR}/TlvSimple.cxx
+        ${CMAKE_CURRENT_LIST_DIR}/TlvSerialize.cxx
     PUBLIC
         ${TLV_DIR_PUBLIC_INCLUDE_PREFIX}/Tlv.hxx
         ${TLV_DIR_PUBLIC_INCLUDE_PREFIX}/TlvBer.hxx
         ${TLV_DIR_PUBLIC_INCLUDE_PREFIX}/TlvSimple.hxx
+        ${TLV_DIR_PUBLIC_INCLUDE_PREFIX}/TlvSerialize.hxx
 )
 
 target_include_directories(tlv
@@ -23,6 +25,7 @@ list(APPEND TLV_PUBLIC_HEADERS
     ${TLV_DIR_PUBLIC_INCLUDE_PREFIX}/Tlv.hxx
     ${TLV_DIR_PUBLIC_INCLUDE_PREFIX}/TlvBer.hxx
     ${TLV_DIR_PUBLIC_INCLUDE_PREFIX}/TlvSimple.hxx
+    ${TLV_DIR_PUBLIC_INCLUDE_PREFIX}/TlvSerialize.hxx
 )
 
 set_target_properties(tlv PROPERTIES FOLDER lib/shared/tlv)

--- a/lib/shared/tlv/TlvSerialize.cxx
+++ b/lib/shared/tlv/TlvSerialize.cxx
@@ -1,0 +1,51 @@
+
+#include <iterator>
+#include <stdexcept>
+
+#include <tlv/TlvSerialize.hxx>
+
+std::size_t
+encoding::GetBitMaskFromBitIndex(std::size_t bitIndex)
+{
+    if (bitIndex >= sizeof(std::size_t) * CHAR_BIT) {
+        return 0; // TODO throw error? this isn't really part of an interface so may not be necessary
+    }
+    return static_cast<std::size_t>(1UL) << bitIndex;
+}
+
+std::size_t
+encoding::GetBitIndexFromBitMask(std::size_t bitMask)
+{
+    for (std::size_t index = 0; index < (sizeof bitMask) * CHAR_BIT; index++) {
+        if (bitMask == GetBitMaskFromBitIndex(index)) {
+            return index;
+        }
+    }
+    throw std::runtime_error("bit index not found");
+}
+
+std::vector<uint8_t>
+encoding::GetBytesBigEndianFromBitMap(std::size_t value, std::size_t desiredLength)
+{
+    if (desiredLength > sizeof value) {
+        throw std::runtime_error("desired length exceeds std::size_t width, this is a bug!");
+    }
+
+    std::vector<uint8_t> bytes;
+    bytes.reserve(desiredLength);
+
+    for (std::size_t i = 0; i < desiredLength; i++) {
+        const auto b = static_cast<uint8_t>(value & 0xFFU);
+        bytes.push_back(b);
+        value >>= 8U;
+    }
+
+    if constexpr (std::endian::native != std::endian::big) {
+        return {
+            std::make_move_iterator(std::rbegin(bytes)),
+            std::make_move_iterator(std::rend(bytes))
+        };
+    }
+
+    return bytes;
+}

--- a/lib/shared/tlv/TlvSerialize.cxx
+++ b/lib/shared/tlv/TlvSerialize.cxx
@@ -1,4 +1,6 @@
 
+#include <bit>
+#include <climits>
 #include <iterator>
 #include <stdexcept>
 

--- a/lib/shared/tlv/include/tlv/TlvSerialize.hxx
+++ b/lib/shared/tlv/include/tlv/TlvSerialize.hxx
@@ -1,0 +1,114 @@
+
+#ifndef TLV_SERIALIZE_HXX
+#define TLV_SERIALIZE_HXX
+
+#include <cstdint>
+#include <span>
+#include <type_traits>
+#include <unordered_map>
+#include <vector>
+
+namespace encoding
+{
+/**
+ * @brief Get the Bit Mask From Bit Index object
+ *
+ * @param bitIndex
+ * @return std::size_t
+ */
+std::size_t
+GetBitMaskFromBitIndex(std::size_t bitIndex);
+
+/**
+ * @brief Get the Bit Index From Bit Mask object.
+ *
+ * @param bitMask
+ * @return std::size_t
+ */
+std::size_t
+GetBitIndexFromBitMask(std::size_t bitMask);
+
+/**
+ * @brief Get the Bytes Big Endian From std::size_t
+ *
+ * @param value the bitmap to encode
+ * @param desiredLength the desired number of bytes in the encoding, padding with zeros if necessary.
+ *                      If the value is too large, this will only encode the lowest desiredLength bytes
+ * @return std::vector<uint8_t>
+ */
+std::vector<uint8_t>
+GetBytesBigEndianFromBitMap(std::size_t value, std::size_t desiredLength);
+
+/**
+ * @brief Parses a span of bytes as a std::size_t number encoded in big endian.
+ *
+ * @tparam IntegerT The type of output integer.
+ * @param bytes The buffer to parse.
+ * @return
+ */
+template <typename IntegerT = std::size_t>
+// clang-format off
+requires std::is_unsigned_v<IntegerT>
+IntegerT
+// clang-format on
+ReadSizeTFromBytesBigEndian(std::span<const uint8_t> bytes)
+{
+    std::size_t rvalue = 0;
+
+    if (bytes.size() >= sizeof rvalue) {
+        return 0; // TODO throw error? this isn't really part of an interface so may not be necessary
+    }
+
+    for (std::size_t i = 0; i < bytes.size(); i++) {
+        rvalue *= 0x100;
+        rvalue += bytes[i];
+    }
+    return static_cast<IntegerT>(rvalue);
+}
+
+/**
+ * @brief helper function that writes the bitset for a given valueSet according to bitIndexMap, using desiredLength bytes
+ *
+ * @tparam T
+ * @param assignee the destination of the bitset
+ * @param bitIndexMap
+ * @param bytes
+ */
+template <class T>
+std::vector<T>
+AssignValuesFromBytes(const std::unordered_map<T, std::size_t>& bitIndexMap, std::span<const uint8_t> bytes)
+{
+    std::vector<T> assignee;
+    auto bitmasks = ReadSizeTFromBytesBigEndian(bytes);
+    for (const auto& [key, value] : bitIndexMap) {
+        if (bitmasks & GetBitMaskFromBitIndex(value)) {
+            assignee.push_back(key);
+        }
+    }
+    return assignee;
+}
+
+/**
+ * @brief helper function to encode a given valueSet into a bitset according to bitIndexMap, using desiredLength bytes
+ *
+ * @tparam T
+ * @param valueSet
+ * @param bitIndexMap
+ * @param desiredLength
+ * @return std::vector<uint8_t>
+ */
+template <class T>
+std::vector<uint8_t>
+EncodeValuesAsBytes(const std::vector<T>& valueSet, const std::unordered_map<T, std::size_t>& bitIndexMap, std::size_t desiredLength)
+{
+    std::size_t valueSetEncoded = 0;
+    for (const auto& value : valueSet) {
+        auto bitIndex = bitIndexMap.at(value);
+        valueSetEncoded |= GetBitMaskFromBitIndex(bitIndex);
+    }
+    return encoding::GetBytesBigEndianFromBitMap(valueSetEncoded, desiredLength);
+}
+
+} // namespace encoding
+
+#endif // TLV_SERIALIZE_HXX

--- a/lib/uwb/protocols/fira/UwbCapability.cxx
+++ b/lib/uwb/protocols/fira/UwbCapability.cxx
@@ -1,7 +1,5 @@
 
 #include <algorithm>
-#include <bit>
-#include <climits>
 #include <iterator>
 #include <sstream>
 #include <stdexcept>


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [X] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Allow the encoding helpers to be used in other OOB-related code.

### Technical Details

* Move all of the encoding helpers written by @forwardpointer as-is to `TlvSerialize.hxx` in the Tlv library.

### Test Results

* All unit tests pass on Windows and Linux.

### Reviewer Focus

None

### Future Work

* These new helpers will be used to serialize/deserialize `UwbConfiguration`, `UwbSessionData` et al in a future PR.

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
