### PR TITLE
Implement TLV serialization for UwbConfiguration

### DIFF
--- a/lib/uwb/protocols/fira/UwbConfiguration.cxx
+++ b/lib/uwb/protocols/fira/UwbConfiguration.cxx
@@ -1,4 +1,5 @@
 
+#include <cstring>
 #include <functional>
 #include <ranges>
 #include <stdexcept>

--- a/lib/uwb/protocols/fira/UwbConfiguration.cxx
+++ b/lib/uwb/protocols/fira/UwbConfiguration.cxx
@@ -164,14 +164,16 @@ UwbConfiguration::FromDataObject(const encoding::TlvBer& tlvBer)
         case ParameterTag::SlotDuration:
         case ParameterTag::RangingInterval:
         case ParameterTag::MaxRrRetry:
-            uint16_t value = 0; // TODO: convert
+            uint16_t value = 0; // assumes endianness matches host
+            std::memcpy(&value, std::data(parameterValue), std::size(parameterValue));
             setters16.at(*parameterTag)(value);
             break;
         }
 
         // 32-bit values
         case ParameterTag::UwbInitiationTime: {
-            uint32_t value = 0; // TODO: convert
+            uint32_t value = 0; // assumes endianness matches host
+            std::memcpy(&value, std::data(parameterValue), std::size(parameterValue));
             builder.SetUwbInitiationTime(value);
             break;
         }

--- a/lib/uwb/protocols/fira/UwbConfiguration.cxx
+++ b/lib/uwb/protocols/fira/UwbConfiguration.cxx
@@ -292,8 +292,28 @@ UwbConfiguration::FromDataObject(const encoding::TlvBer& tlvBer)
             builder.SetMacAddressControleeShort(uwbMacAddressShort);
             break;
         }
-        case ParameterTag::ControllerMacAddress:
-            break; // TODO
+        case ParameterTag::ControllerMacAddress: {
+            std::optional<uwb::UwbMacAddress> uwbMacAddress;
+            switch (std::size(parameterValue)) {
+            case uwb::UwbMacAddress::ShortLength: {
+                std::array<uint8_t, uwb::UwbMacAddress::ShortLength> addressData{ parameterValue[0], parameterValue[1] };
+                uwbMacAddress = UwbMacAddress(addressData);
+            }
+            case uwb::UwbMacAddress::ExtendedLength: {
+                std::array<uint8_t, uwb::UwbMacAddress::ExtendedLength> addressData{ 
+                    parameterValue[0], parameterValue[1], parameterValue[2], parameterValue[3], 
+                    parameterValue[4], parameterValue[5], parameterValue[6], parameterValue[7] };
+                uwbMacAddress = UwbMacAddress(addressData);
+            }
+            default: {
+                break;
+            }
+            }
+            if (uwbMacAddress.has_value()) {
+                builder.SetMacAddressController(uwbMacAddress.value());
+            }
+            break;
+        }
         default:
             break;
         } // switch (parameterTag)

--- a/lib/uwb/protocols/fira/UwbConfiguration.cxx
+++ b/lib/uwb/protocols/fira/UwbConfiguration.cxx
@@ -245,6 +245,8 @@ UwbConfiguration::FromDataObject(const encoding::TlvBer& tlvBer)
             });
             break;
         }
+
+        // special cases
         case ParameterTag::RangingMethod: {
             uint8_t value = parameterValue.front();
             RangingDirection rangingDirection;
@@ -278,7 +280,6 @@ UwbConfiguration::FromDataObject(const encoding::TlvBer& tlvBer)
             break;
         }
 
-        // special cases
         case ParameterTag::ResultReportConfig: {
             uint8_t value = parameterValue.front();
             for (const auto resultReportConfiguration : magic_enum::enum_values<ResultReportConfiguration>()) {


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Ensure `UwbConfiguration` can be serialized for OOB.

### Technical Details

* Implement `UwbConfiguration::ToDataObject()` and  `UwbConfiguration::FromDataObject(...)`

### Test Results

TBD

### Reviewer Focus

* There was some copy+pasting done here, so I'd appreciate a keen eye for typos.

### Future Work

Implement TLV serialization for `UwbSessionData`.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
