### PR TITLE
Enable TLV-BER in OobSimulator

### DIFF
--- a/windows/tools/OobSimulator/UwbSessionData.cpp
+++ b/windows/tools/OobSimulator/UwbSessionData.cpp
@@ -71,6 +71,19 @@ UwbSessionData::ControleeShortMacAddress(hstring const& value)
         m_propertyChanged(*this, winrt::Microsoft::UI::Xaml::Data::PropertyChangedEventArgs{ L"Controlee Short MAC Address" });
     }
 }
+winrt::OobSimulator::SessionDataEncoding
+UwbSessionData::SessionDataEncoding()
+{
+    return m_sessionDataEncoding;
+}
+void
+UwbSessionData::SessionDataEncoding(winrt::OobSimulator::SessionDataEncoding const& value)
+{
+    if (m_sessionDataEncoding != value) {
+        m_sessionDataEncoding = value;
+        m_propertyChanged(*this, winrt::Microsoft::UI::Xaml::Data::PropertyChangedEventArgs{ L"Session Data Encoding" });
+    }
+}
 winrt::event_token
 UwbSessionData::PropertyChanged(winrt::Microsoft::UI::Xaml::Data::PropertyChangedEventHandler const& handler)
 {

--- a/windows/tools/OobSimulator/UwbSessionData.h
+++ b/windows/tools/OobSimulator/UwbSessionData.h
@@ -29,6 +29,10 @@ struct UwbSessionData : UwbSessionDataT<UwbSessionData>
     ControleeShortMacAddress();
     void
     ControleeShortMacAddress(hstring const& value);
+    winrt::OobSimulator::SessionDataEncoding
+    SessionDataEncoding();
+    void
+    SessionDataEncoding(winrt::OobSimulator::SessionDataEncoding const& value);
     winrt::event_token
     PropertyChanged(winrt::Microsoft::UI::Xaml::Data::PropertyChangedEventHandler const& handler);
     void
@@ -40,6 +44,7 @@ private:
     winrt::OobSimulator::MultiNodeMode m_multiNodeMode;
     winrt::hstring m_controllerMacAddress;
     winrt::hstring m_controleeShortMacAddress;
+    winrt::OobSimulator::SessionDataEncoding m_sessionDataEncoding;
 
     winrt::event<winrt::Microsoft::UI::Xaml::Data::PropertyChangedEventHandler> m_propertyChanged;
 };

--- a/windows/tools/OobSimulator/UwbSessionData.idl
+++ b/windows/tools/OobSimulator/UwbSessionData.idl
@@ -12,6 +12,11 @@ enum MultiNodeMode {
     ManyToMany,
 };
 
+enum SessionDataEncoding {
+    TlvBer,
+    MessagePack,
+};
+
 runtimeclass UwbSessionData : Microsoft.UI.Xaml.Data.INotifyPropertyChanged
 {
     UwbSessionData();
@@ -21,5 +26,6 @@ runtimeclass UwbSessionData : Microsoft.UI.Xaml.Data.INotifyPropertyChanged
     MultiNodeMode MultiNodeMode;
     String ControllerMacAddress;
     String ControleeShortMacAddress;
+    SessionDataEncoding SessionDataEncoding;
 }
 } // namespace OobSimulator

--- a/windows/tools/OobSimulator/UwbSessionDataPage.xaml
+++ b/windows/tools/OobSimulator/UwbSessionDataPage.xaml
@@ -58,6 +58,14 @@
             <TextBox Margin="10" VerticalAlignment="Center" Text="{x:Bind ViewModel.UwbSessionData.ControleeShortMacAddress, Mode=TwoWay}" />
         </StackPanel>
 
-        <Button Grid.Row="6" Content="Set UWB Session Data" FontSize="16" FontWeight="Bold" Margin="10" Command="{x:Bind ViewModel.SetUwbSessionDataCommand}"/>
+        <StackPanel Grid.Row="6" Orientation="Horizontal" Margin="10">
+            <TextBlock Text="Encoding: " VerticalAlignment="Center" />
+            <StackPanel Margin="10" Orientation="Horizontal">
+                <RadioButton x:Name="TlvBerRadioButton" Content="TLV-BER" GroupName="EncodingGroup" IsChecked="True" Checked="OnSelectSessionDataEncoding" VerticalAlignment="Center" />
+                <RadioButton x:Name="MsgpackRadioButton" Content="MessagePack" GroupName="EncodingGroup" Checked="OnSelectSessionDataEncoding" VerticalAlignment="Center" />
+            </StackPanel>
+        </StackPanel>
+
+        <Button Grid.Row="7" Content="Set UWB Session Data" FontSize="16" FontWeight="Bold" Margin="10" Command="{x:Bind ViewModel.SetUwbSessionDataCommand}"/>
     </Grid>
 </Page>

--- a/windows/tools/OobSimulator/UwbSessionDataPage.xaml.cpp
+++ b/windows/tools/OobSimulator/UwbSessionDataPage.xaml.cpp
@@ -23,4 +23,16 @@ UwbSessionDataPage::ViewModel()
 {
     return m_viewModel;
 }
+
+// TODO: Move to IValueConverter for radio buttons to conform to MVVM principles
+void
+UwbSessionDataPage::OnSelectSessionDataEncoding(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const&)
+{
+    auto radioButton = sender.as<Controls::RadioButton>();
+    if (radioButton == TlvBerRadioButton()) {
+        ViewModel().UwbSessionData().SessionDataEncoding(winrt::OobSimulator::SessionDataEncoding::TlvBer);
+    } else if (radioButton == MsgpackRadioButton()) {
+        ViewModel().UwbSessionData().SessionDataEncoding(winrt::OobSimulator::SessionDataEncoding::MessagePack);
+    }
+}
 } // namespace winrt::OobSimulator::implementation

--- a/windows/tools/OobSimulator/UwbSessionDataPage.xaml.h
+++ b/windows/tools/OobSimulator/UwbSessionDataPage.xaml.h
@@ -14,6 +14,9 @@ struct UwbSessionDataPage : UwbSessionDataPageT<UwbSessionDataPage>
     winrt::OobSimulator::UwbSessionDataPageViewModel
     ViewModel();
 
+    void
+    OnSelectSessionDataEncoding(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const&);
+
 private:
     winrt::OobSimulator::UwbSessionDataPageViewModel m_viewModel;
 };


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [x] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

This PR enables the TLV-BER encoding of UwbSessionData in the OobSimulator app. Users of this app can choose to save the encoding as TLV-BER or as MessagePack.

### Technical Details

- Added SessionDataEncoding enum and property to View (UwbSessionData).
- Added radio button options for the session data encoding.
- Added code to save the TLV-BER encoded session data as a ".tlvber" file.

### Test Results

Verified the ability to choose between TLV-BER and MessagePack options, as well as the ability to save the encodings as their respective file types.

### Reviewer Focus

None.

### Future Work

I used a simple event handler in the XAML code-behind file to handle the radio button selection, but this should eventually be replaced to use IValueConverter (along with the other radio buttons). I was previously unsuccessful with using the converters, so this new feature takes the simpler, non-MVVM approach.

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
