### PR TITLE
Add DeviceType parameter to CreateSession

### DIFF
--- a/lib/uwb/UwbDevice.cxx
+++ b/lib/uwb/UwbDevice.cxx
@@ -124,9 +124,9 @@ UwbDevice::OnSessionStatusChanged(UwbSessionStatus statusSession)
 }
 
 std::shared_ptr<UwbSession>
-UwbDevice::CreateSession(uint32_t sessionId, std::weak_ptr<UwbSessionEventCallbacks> callbacks)
+UwbDevice::CreateSession(uint32_t sessionId, std::weak_ptr<UwbSessionEventCallbacks> callbacks, DeviceType deviceType)
 {
-    auto session = CreateSessionImpl(sessionId, std::move(callbacks));
+    auto session = CreateSessionImpl(sessionId, std::move(callbacks), deviceType);
     {
         std::unique_lock sessionExclusiveLock{ m_sessionsGate };
         m_sessions[session->GetId()] = std::weak_ptr<UwbSession>(session);

--- a/lib/uwb/include/uwb/UwbDevice.hxx
+++ b/lib/uwb/include/uwb/UwbDevice.hxx
@@ -31,10 +31,11 @@ public:
      * @brief Creates a new UWB session with no configuration nor peers.
      *
      * @param callbacks
+     * @param deviceType
      * @return std::shared_ptr<UwbSession>
      */
     std::shared_ptr<UwbSession>
-    CreateSession(uint32_t sessionId, std::weak_ptr<UwbSessionEventCallbacks> callbacks);
+    CreateSession(uint32_t sessionId, std::weak_ptr<UwbSessionEventCallbacks> callbacks, uwb::protocol::fira::DeviceType deviceType);
 
     /**
      * @brief Obtains a shared reference to a pre-existing session.
@@ -104,10 +105,11 @@ private:
      *
      * @param sessionId
      * @param callbacks
+     * @param deviceType
      * @return std::shared_ptr<UwbSession>
      */
     virtual std::shared_ptr<UwbSession>
-    CreateSessionImpl(uint32_t sessionId, std::weak_ptr<UwbSessionEventCallbacks> callbacks) = 0;
+    CreateSessionImpl(uint32_t sessionId, std::weak_ptr<UwbSessionEventCallbacks> callbacks, uwb::protocol::fira::DeviceType deviceType = uwb::protocol::fira::DeviceType::Controller) = 0;
 
     /**
      * @brief Attempt to resolve a session from the underlying UWB device.

--- a/linux/devices/uwb/UwbDevice.cxx
+++ b/linux/devices/uwb/UwbDevice.cxx
@@ -5,7 +5,7 @@ using namespace linux::devices;
 using namespace uwb::protocol::fira;
 
 std::shared_ptr<uwb::UwbSession>
-UwbDevice::CreateSessionImpl(uint32_t sessionId, std::weak_ptr<uwb::UwbSessionEventCallbacks> /* callbacks */)
+UwbDevice::CreateSessionImpl(uint32_t sessionId, std::weak_ptr<uwb::UwbSessionEventCallbacks> /* callbacks */, DeviceType /* deviceType */)
 {
     // TODO
     return nullptr;

--- a/linux/devices/uwb/include/linux/uwb/UwbDevice.hxx
+++ b/linux/devices/uwb/include/linux/uwb/UwbDevice.hxx
@@ -37,10 +37,11 @@ private:
      *
      * @param sessionId
      * @param callbacks
+     * @param deviceType
      * @return std::shared_ptr<uwb::UwbSession>
      */
     std::shared_ptr<uwb::UwbSession>
-    CreateSessionImpl(uint32_t sessionId, std::weak_ptr<uwb::UwbSessionEventCallbacks> callbacks) override;
+    CreateSessionImpl(uint32_t sessionId, std::weak_ptr<uwb::UwbSessionEventCallbacks> callbacks, uwb::protocol::fira::DeviceType deviceType) override;
 
     /**
      * @brief Get the capabilities of the device.

--- a/tests/unit/uwb/TestUwbDevice.cxx
+++ b/tests/unit/uwb/TestUwbDevice.cxx
@@ -21,7 +21,7 @@ struct UwbDeviceTestBase : public uwb::UwbDevice
     uint16_t Id;
 
     std::shared_ptr<UwbSession>
-    CreateSessionImpl(uint32_t /* sessionId */, std::weak_ptr<UwbSessionEventCallbacks> /* callbacks */) override
+    CreateSessionImpl(uint32_t /* sessionId */, std::weak_ptr<UwbSessionEventCallbacks> /* callbacks */, uwb::protocol::fira::DeviceType /* deviceType */) override
     {
         return nullptr;
     }

--- a/tools/cli/NearObjectCliHandler.cxx
+++ b/tools/cli/NearObjectCliHandler.cxx
@@ -44,7 +44,7 @@ try {
         return std::get_if<uwb::protocol::fira::DeviceType>(&parameter.Value) != nullptr;
     });
     if (it != std::cend(parameters)) {
-        deviceType = *(std::get_if<uwb::protocol::fira::DeviceType>(&it->Value));
+        deviceType = std::get<uwb::protocol::fira::DeviceType>(it->Value);
     }
 
     auto session = uwbDevice->CreateSession(rangingParameters.SessionId, m_sessionEventCallbacks, deviceType);

--- a/windows/devices/uwb/UwbDevice.cxx
+++ b/windows/devices/uwb/UwbDevice.cxx
@@ -50,9 +50,9 @@ UwbDevice::DeviceName() const noexcept
 }
 
 std::shared_ptr<::uwb::UwbSession>
-UwbDevice::CreateSessionImpl(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks)
+UwbDevice::CreateSessionImpl(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, DeviceType deviceType)
 {
-    return std::make_shared<UwbSession>(sessionId, shared_from_this(), m_uwbSessionConnector, std::move(callbacks));
+    return std::make_shared<UwbSession>(sessionId, shared_from_this(), m_uwbSessionConnector, std::move(callbacks), deviceType);
 }
 
 std::shared_ptr<::uwb::UwbSession>

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
@@ -79,10 +79,11 @@ private:
      *
      * @param sessionId
      * @param callbacks The event callback instance.
+     * @param deviceType
      * @return std::shared_ptr<uwb::UwbSession>
      */
     virtual std::shared_ptr<::uwb::UwbSession>
-    CreateSessionImpl(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks) override;
+    CreateSessionImpl(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, ::uwb::protocol::fira::DeviceType deviceType = ::uwb::protocol::fira::DeviceType::Controller) override;
 
     /**
      * @brief Attempt to resolve a session from the underlying UWB device.

--- a/windows/devices/uwbsimulator/UwbDeviceSimulator.cxx
+++ b/windows/devices/uwbsimulator/UwbDeviceSimulator.cxx
@@ -37,7 +37,7 @@ UwbDeviceSimulator::Initialize()
 }
 
 std::shared_ptr<::uwb::UwbSession>
-UwbDeviceSimulator::CreateSessionImpl(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks)
+UwbDeviceSimulator::CreateSessionImpl(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, DeviceType deviceType)
 {
     return std::make_shared<UwbSessionSimulator>(sessionId, shared_from_this(), GetSessionDdiConnector(), std::move(callbacks), m_uwbDeviceSimulatorConnector);
 }

--- a/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbDeviceSimulator.hxx
+++ b/windows/devices/uwbsimulator/include/windows/devices/uwb/simulator/UwbDeviceSimulator.hxx
@@ -12,6 +12,7 @@
 #include <UwbSimulatorDdiGlue.h>
 
 #include <cfgmgr32.h>
+#include <uwb/protocols/fira/FiraDevice.hxx>
 #include <wil/resource.h>
 #include <windows/devices/DeviceResource.hxx>
 #include <windows/devices/uwb/IUwbDeviceDdi.hxx>
@@ -60,17 +61,17 @@ public:
     GetSimulatorCapabilities();
 
     /**
-     * @brief Trigger an event for a session. 
-     * 
-     * @param triggerSessionEventArgs 
-     * @return UwbSimulatorTriggerSessionEventResult 
+     * @brief Trigger an event for a session.
+     *
+     * @param triggerSessionEventArgs
+     * @return UwbSimulatorTriggerSessionEventResult
      */
     UwbSimulatorTriggerSessionEventResult
     TriggerSessionEvent(const UwbSimulatorTriggerSessionEventArgs& triggerSessionEventArgs);
 
 private:
     virtual std::shared_ptr<::uwb::UwbSession>
-    CreateSessionImpl(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks) override;
+    CreateSessionImpl(uint32_t sessionId, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, ::uwb::protocol::fira::DeviceType deviceType = ::uwb::protocol::fira::DeviceType::Controller) override;
 
 private:
     const std::string m_deviceName;


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [x] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

The `DeviceType` parameter is determined by the application utilizing UWB (e.g. `HandleStartRanging()` in nocli takes a `DeviceType` as an argument) and is currently never set in `UwbSession`. Because it is accessed by the WinRT service APIs through `GetDeviceType()`, this parameter must be set, otherwise `GetDeviceType()` will always return the default value. It makes most sense to me to set the `DeviceType` when constructing a session rather than setting it after a session is already constructed.

### Technical Details

- Added `DeviceType` as a parameter to `CreateSession` and `CreateSessionImpl`.

### Test Results

Compile-tested only.

### Reviewer Focus

None.

### Future Work

The WinRT API code that calls `CreateSession` will need to be updated to pass in the `DeviceType`, which comes from the application.

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
