### PR TITLE
Always send at least sizeof(UWB_NOTIFICATION_DATA) bytes for notifications

### DIFF
--- a/windows/devices/uwb/UwbConnector.cxx
+++ b/windows/devices/uwb/UwbConnector.cxx
@@ -685,7 +685,7 @@ UwbConnector::HandleNotifications(std::stop_token stopToken)
     auto handleDriver = m_notificationHandleDriver;
 
     while (!stopToken.stop_requested()) {
-        DWORD minimumNotificationSize = sizeof(UWB_NOTIFICATION_DATA);
+        static constexpr DWORD minimumNotificationSize = sizeof(UWB_NOTIFICATION_DATA);
         DWORD bytesRequired = minimumNotificationSize;
         std::vector<uint8_t> uwbNotificationDataBuffer{};
         m_notificationOverlapped = {};


### PR DESCRIPTION
### Type

- [x] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Currently, the handling of notifications is failing the UWB CX validation test. This happens because the CX requires a buffer of at least `sizeof(UWB_NOTIFICATION_DATA)` (0x50) bytes, but `lpBytesReturned` of `DeviceIoControl` returns fewer bytes. The reason for this is because `UWB_NOTIFICATION_DATA` has a union member, which causes `sizeof` to account for the _largest_ member in the union. A specific notification of the non-largest type may actually use fewer bytes than what `sizeof` calculates for the union.

Therefore, the notification handling should always send at least `sizeof(UWB_NOTIFICATION_DATA)` bytes, not just the number of bytes actually used for a specific notification.

### Technical Details

- Changed the notification handling to resize the buffer to the maximum of `bytesRequired` and `sizeof(UWB_NOTIFICATION_DATA)`.

### Test Results

nocli output displays expected values, eliminating the unexpected "insufficient buffer" messages from before.

### Reviewer Focus

None.

### Future Work

None.

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
