### PR TITLE
Fix build workflow to configure the project for ARM64 properly

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -118,7 +118,7 @@ jobs:
       run: cmake --build --preset ${{ inputs.preset-name }} --config ${{ matrix.build-type }}
 
     - name: CMake Test (ctest)
-      if: ${{ matrix.config.arch != 'ARM64' }}
+      if: ${{ ! matrix.config.arch }}
       run: ctest --preset ${{ inputs.preset-name }} -C ${{ matrix.build-type }}
 
     - name: CMake Install

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -107,14 +107,14 @@ jobs:
         languages: 'cpp'
 
     - name: CMake Configure
+      if: ${{ ! matrix.config.arch }}
       run: cmake --preset ${{ inputs.preset-name }} --fresh -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -G"${{ matrix.config.generator }}"
 
-    - name: CMake Cross-Compile Build ${{ matrix.config.arch }}
+    - name: CMake Configure Cross-Compile ${{ matrix.config.arch }}
       if: ${{ matrix.config.arch }}
-      run: cmake --build --preset ${{ inputs.preset-name }} --config ${{ matrix.build-type }} -A ${{ matrix.config.arch }}
+      run: cmake --preset ${{ inputs.preset-name }} --fresh -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -G"${{ matrix.config.generator }}" -A ${{ matrix.config.arch }}
 
     - name: CMake Build
-      if: ${{ ! matrix.config.arch }}
       run: cmake --build --preset ${{ inputs.preset-name }} --config ${{ matrix.build-type }}
 
     - name: CMake Test (ctest)


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [X] Infrastructure

### Goals

Ensure the build workflows configure the CMake project correctly for ARM64.

### Technical Details

* Move architecture argument and conditionals from `build` to `configure` step.

### Test Results

* Ran the corresponding build commands locally and verified the project is configured and cross-compiles for ARM64:

```Shell
cmake --preset dev --fresh -DCMAKE_BUILD_TYPE=Debug -G "Visual Studio 17 2022" -A ARM64
cmake --build --preset dev --config Debug
```

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
