### PR TITLE
Allow not providing callbacks to UwbDevice::CreateSession()

### DIFF
--- a/lib/uwb/UwbDevice.cxx
+++ b/lib/uwb/UwbDevice.cxx
@@ -124,7 +124,7 @@ UwbDevice::OnSessionStatusChanged(UwbSessionStatus statusSession)
 }
 
 std::shared_ptr<UwbSession>
-UwbDevice::CreateSession(uint32_t sessionId, std::weak_ptr<UwbSessionEventCallbacks> callbacks, DeviceType deviceType)
+UwbDevice::CreateSession(uint32_t sessionId, uwb::protocol::fira::DeviceType deviceType, std::weak_ptr<UwbSessionEventCallbacks> callbacks)
 {
     auto session = CreateSessionImpl(sessionId, std::move(callbacks), deviceType);
     {

--- a/lib/uwb/include/uwb/UwbDevice.hxx
+++ b/lib/uwb/include/uwb/UwbDevice.hxx
@@ -30,12 +30,13 @@ public:
     /**
      * @brief Creates a new UWB session with no configuration nor peers.
      *
-     * @param callbacks
+     * @param sessionId
      * @param deviceType
+     * @param callbacks
      * @return std::shared_ptr<UwbSession>
      */
     std::shared_ptr<UwbSession>
-    CreateSession(uint32_t sessionId, std::weak_ptr<UwbSessionEventCallbacks> callbacks, uwb::protocol::fira::DeviceType deviceType);
+    CreateSession(uint32_t sessionId, uwb::protocol::fira::DeviceType deviceType, std::weak_ptr<UwbSessionEventCallbacks> callbacks = {});
 
     /**
      * @brief Obtains a shared reference to a pre-existing session.

--- a/tools/cli/NearObjectCliHandler.cxx
+++ b/tools/cli/NearObjectCliHandler.cxx
@@ -47,7 +47,7 @@ try {
         deviceType = std::get<uwb::protocol::fira::DeviceType>(it->Value);
     }
 
-    auto session = uwbDevice->CreateSession(rangingParameters.SessionId, m_sessionEventCallbacks, deviceType);
+    auto session = uwbDevice->CreateSession(rangingParameters.SessionId, deviceType, m_sessionEventCallbacks);
     session->Configure(rangingParameters.ApplicationConfigurationParameters);
     auto applicationConfigurationParameters = session->GetApplicationConfigurationParameters({});
     PLOG_DEBUG << "Session Application Configuration Parameters: ";


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [x] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

This PR provides a default value for the callbacks argument in UwbDevice::CreateSession(), allowing callers to not provide any if desired.

### Technical Details

- Added default empty value `{}` for `std::weak_ptr<UwbSessionEventCallbacks>`.
- Added missing parameter in doxygen comment.

### Test Results

Compile-tested only.

### Reviewer Focus

None.

### Future Work

None.

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
