### PR TITLE
Prevent starting the notification listener more than once

### DIFF
--- a/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
@@ -2,9 +2,11 @@
 #ifndef UWB_DEVICE_CONNECTOR_HXX
 #define UWB_DEVICE_CONNECTOR_HXX
 
+#include <atomic>
 #include <cstdint>
 #include <future>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <shared_mutex>
 #include <string>
@@ -225,6 +227,8 @@ private:
 private:
     std::string m_deviceName{};
     std::jthread m_notificationThread;
+    std::mutex m_notificationThreadGate;
+    std::atomic<bool> m_notificationThreadStartPending{ false };
     wil::shared_hfile m_notificationHandleDriver;
     OVERLAPPED m_notificationOverlapped;
 


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Ensure the `UwbConnector` only ever opens a single handle to the driver notification namespace.

### Technical Details

* Add code to ensure the handler thread is only started once.

### Test Results

* NOT tested yet, compile tested only.

### Reviewer Focus

Consider whether a race can occur and whether the current code to stop the handler thread is correct.

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
