### PR TITLE
add explicit set tag functionfor uint16_t and size_t to handle endianness

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,18 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "nearobject-test",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/out/build/dev/tests/unit/Debug/nearobject-test.exe",
+            "args": [
+            ],
+            "stopAtEntry": false,
+            "cwd": "${fileDirname}",
+            "environment": [],
+            "console": "externalTerminal"
+        },
+        {
             "name": "cli start ranging probe",
             "type": "cppvsdbg",
             "request": "launch",

--- a/lib/shared/tlv/TlvBer.cxx
+++ b/lib/shared/tlv/TlvBer.cxx
@@ -1,6 +1,7 @@
 
 #include <algorithm>
 #include <bit>
+#include <cstring>
 #include <iterator>
 #include <optional>
 #include <utility>

--- a/lib/shared/tlv/TlvBer.cxx
+++ b/lib/shared/tlv/TlvBer.cxx
@@ -232,6 +232,44 @@ TlvBer::Builder::SetTag(uint8_t tag)
     return *this;
 }
 
+TlvBer::Builder&
+TlvBer::Builder::SetTag(uint16_t tag)
+{
+    std::array<uint8_t, sizeof tag> tagData;
+    std::memcpy(&tagData, &tag, sizeof tag);
+
+    if (std::endian::native == std::endian::big) {
+        TlvBer::Builder::SetTag(tagData);
+        return *this;
+    } else {
+        std::array<uint8_t, sizeof tag> tagDataRev;
+        std::transform(std::rbegin(tagData), std::rend(tagData), std::begin(tagDataRev), [](auto&& b) {
+            return b;
+        });
+        TlvBer::Builder::SetTag(tagDataRev);
+        return *this;
+    }
+}
+
+TlvBer::Builder&
+TlvBer::Builder::SetTag(size_t tag)
+{
+    std::array<uint8_t, sizeof tag> tagData;
+    std::memcpy(&tagData, &tag, sizeof tag);
+
+    if (std::endian::native == std::endian::big) {
+        TlvBer::Builder::SetTag(tagData);
+        return *this;
+    } else {
+        std::array<uint8_t, sizeof tag> tagDataRev;
+        std::transform(std::rbegin(tagData), std::rend(tagData), std::begin(tagDataRev), [](auto&& b) {
+            return b;
+        });
+        TlvBer::Builder::SetTag(tagDataRev);
+        return *this;
+    }
+}
+
 std::vector<uint8_t>
 TlvBer::GetLengthEncoding(std::size_t length)
 {

--- a/lib/shared/tlv/include/tlv/TlvBer.hxx
+++ b/lib/shared/tlv/include/tlv/TlvBer.hxx
@@ -519,7 +519,7 @@ public:
         /**
          * @brief Set the tag of the top-level/parent BerTlv.
          * 
-         * @tparam Iterable 
+         * @tparam Iterable This NEEDS to be in Big-Endian
          * @param tag 
          * @return Builder& 
          */

--- a/lib/shared/tlv/include/tlv/TlvBer.hxx
+++ b/lib/shared/tlv/include/tlv/TlvBer.hxx
@@ -501,6 +501,24 @@ public:
         /**
          * @brief Set the tag of the top-level/parent BerTlv.
          * 
+         * @param tag 
+         * @return Builder& 
+         */
+        Builder&
+        SetTag(uint16_t tag);
+
+        /**
+         * @brief Set the tag of the top-level/parent BerTlv.
+         * 
+         * @param tag 
+         * @return Builder& 
+         */
+        Builder&
+        SetTag(size_t tag);
+        
+        /**
+         * @brief Set the tag of the top-level/parent BerTlv.
+         * 
          * @tparam Iterable 
          * @param tag 
          * @return Builder& 

--- a/lib/uwb/protocols/fira/UwbSessionData.cxx
+++ b/lib/uwb/protocols/fira/UwbSessionData.cxx
@@ -19,12 +19,8 @@ UwbSessionData::ToDataObject() const
 {
     using encoding::TlvBer, encoding::GetBytesBigEndianFromBitMap;
 
-    // Construct the tag data.
-    std::array<uint8_t, sizeof Tag> tagData;
-    std::memcpy(&tagData, &Tag, sizeof Tag);
-
     auto builder = TlvBer::Builder()
-                       .SetTag(tagData)
+                       .SetTag(Tag)
                        // UWB_SESSION_DATA_VERSION
                        .AddTlv(
                            TlvBer::Builder()

--- a/tests/unit/uwb/protocols/fira/TestUwbFiraUwbCapability.cxx
+++ b/tests/unit/uwb/protocols/fira/TestUwbFiraUwbCapability.cxx
@@ -225,7 +225,7 @@ TEST_CASE("Parsing from TlvBer", "[basic][protocol]")
 
         encoding::TlvBer::Builder builder;
         auto invalidTlv = builder.SetAsCopyOfTlv(*tlv)
-                              .SetTag(0xFF)
+                              .SetTag(uint8_t(0xFF))
                               .Build();
         REQUIRE_THROWS(UwbCapability::FromOobDataObject(invalidTlv));
     }


### PR DESCRIPTION
### Type

- [x] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

* add a function to set the tag for uint16_t and size_t to handle endianness, since the TlvBer needs a big endian tag
* add a high level round trip test for tlvber that uses the uwbsessiondata

### Test Results

tests pass locally 

### Reviewer Focus

This requires the user to explicitly tell the compiler which SetTag function to use.

### Future Work

Maybe put the test somewhere else since it uses components outside of TlvBer

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
