### PR TITLE
we don't need to support size_t for tags

### DIFF
--- a/lib/shared/tlv/TlvBer.cxx
+++ b/lib/shared/tlv/TlvBer.cxx
@@ -252,25 +252,6 @@ TlvBer::Builder::SetTag(uint16_t tag)
     }
 }
 
-TlvBer::Builder&
-TlvBer::Builder::SetTag(size_t tag)
-{
-    std::array<uint8_t, sizeof tag> tagData;
-    std::memcpy(&tagData, &tag, sizeof tag);
-
-    if (std::endian::native == std::endian::big) {
-        TlvBer::Builder::SetTag(tagData);
-        return *this;
-    } else {
-        std::array<uint8_t, sizeof tag> tagDataRev;
-        std::transform(std::rbegin(tagData), std::rend(tagData), std::begin(tagDataRev), [](auto&& b) {
-            return b;
-        });
-        TlvBer::Builder::SetTag(tagDataRev);
-        return *this;
-    }
-}
-
 std::vector<uint8_t>
 TlvBer::GetLengthEncoding(std::size_t length)
 {

--- a/lib/shared/tlv/include/tlv/TlvBer.hxx
+++ b/lib/shared/tlv/include/tlv/TlvBer.hxx
@@ -506,15 +506,6 @@ public:
          */
         Builder&
         SetTag(uint16_t tag);
-
-        /**
-         * @brief Set the tag of the top-level/parent BerTlv.
-         * 
-         * @param tag 
-         * @return Builder& 
-         */
-        Builder&
-        SetTag(size_t tag);
         
         /**
          * @brief Set the tag of the top-level/parent BerTlv.

--- a/lib/uwb/protocols/fira/UwbCapability.cxx
+++ b/lib/uwb/protocols/fira/UwbCapability.cxx
@@ -175,7 +175,7 @@ UwbCapability::ToOobDataObject() const
     {
         auto macRange = GetBytesBigEndianFromBitMap(FiraMacVersionRange, 4);
         auto macRangeTlv = childbuilder.Reset()
-                               .SetTag(std::size_t(ParameterTag::FiraMacVersionRange))
+                               .SetTag(notstd::to_underlying(ParameterTag::FiraMacVersionRange))
                                .SetValue(macRange)
                                .Build();
         builder.AddTlv(macRangeTlv);


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

* Remove convenience function to set a size_t tag (we don't need it)

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
