### PR TITLE
Allow canceling nocli with control signal (Ctrl-C, Ctrl-Break) on Windows

### DIFF
--- a/tools/cli/include/nearobject/cli/NearObjectCliControlFlowContext.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliControlFlowContext.hxx
@@ -4,6 +4,7 @@
 
 #include <functional>
 #include <latch>
+#include <mutex>
 #include <stop_token>
 #include <vector>
 
@@ -81,6 +82,7 @@ private:
     std::latch m_operationCompleteLatch;
     std::stop_source m_stopSource;
     std::stop_callback<std::function<void()>> m_stopCallback;
+    std::mutex m_stopCallbacksGate;
     std::vector<std::function<void()>> m_stopCallbacks;
 };
 } // namespace nearobject::cli

--- a/windows/devices/uwb/UwbConnector.cxx
+++ b/windows/devices/uwb/UwbConnector.cxx
@@ -915,7 +915,7 @@ UwbConnector::DispatchCallbacks(::uwb::protocol::fira::UwbNotificationData uwbNo
             InvokeCallbacks(m_onDeviceStatusChangedCallbacks, arg);
         } else if constexpr (std::is_same_v<ValueType, UwbSessionStatus>) {
             InvokeCallbacks(m_onSessionStatusChangedCallbacks, arg);
-            if (arg.State == UwbSessionState::Deinitialized) {
+            if (arg.State == UwbSessionState::Idle) {
                 OnSessionEnded(arg.SessionId, ::uwb::UwbSessionEndReason::Stopped);
             }
         } else if constexpr (std::is_same_v<ValueType, UwbSessionUpdateMulticastListStatus>) {

--- a/windows/tools/nocli/Main.cxx
+++ b/windows/tools/nocli/Main.cxx
@@ -30,14 +30,14 @@
 /**
  * @brief Function that will be executed by the control sequence handler on a
  * stop request (eg. Ctrl-C, Ctrl-Break, etc.). Populated by the main() function
- * once parsing is complete 
+ * once parsing is complete
  */
 static std::function<void(void)>
-OnApplicationStopRequest{ nullptr };
+    OnApplicationStopRequest{ nullptr };
 
 /**
  * @brief Control sequence handler.
- * 
+ *
  * @param controlType The type of control signal sent.
  * @return BOOL Whether the control signal was handled.
  */
@@ -75,7 +75,7 @@ try {
     nearobject::cli::NearObjectCli cli{ cliData, cliHandler };
 
     // Configure stop handler to cancel and wait for execution to complete.
-    OnApplicationStopRequest = [&]{
+    OnApplicationStopRequest = [&] {
         PLOG_VERBOSE << "handling stop request sent via control signal";
         cli.CancelExecution();
         cli.WaitForExecutionComplete();

--- a/windows/tools/nocli/Main.cxx
+++ b/windows/tools/nocli/Main.cxx
@@ -1,5 +1,6 @@
 
 #include <cstdint>
+#include <functional>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -26,6 +27,38 @@
 
 #include <winrt/windows.devices.nearobject.h>
 
+/**
+ * @brief Function that will be executed by the control sequence handler on a
+ * stop request (eg. Ctrl-C, Ctrl-Break, etc.). Populated by the main() function
+ * once parsing is complete 
+ */
+static std::function<void(void)>
+OnApplicationStopRequest{ nullptr };
+
+/**
+ * @brief Control sequence handler.
+ * 
+ * @param controlType The type of control signal sent.
+ * @return BOOL Whether the control signal was handled.
+ */
+BOOL WINAPI
+CtrlHandler(DWORD controlType)
+{
+    switch (controlType) {
+    case CTRL_C_EVENT:
+    case CTRL_CLOSE_EVENT:
+    case CTRL_BREAK_EVENT:
+    case CTRL_LOGOFF_EVENT:
+    case CTRL_SHUTDOWN_EVENT:
+        if (OnApplicationStopRequest != nullptr) {
+            OnApplicationStopRequest();
+        }
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
 int
 main(int argc, char* argv[])
 try {
@@ -40,6 +73,20 @@ try {
     auto cliHandler = std::make_shared<nearobject::cli::NearObjectCliHandlerWindows>();
 
     nearobject::cli::NearObjectCli cli{ cliData, cliHandler };
+
+    // Configure stop handler to cancel and wait for execution to complete.
+    OnApplicationStopRequest = [&]{
+        PLOG_VERBOSE << "handling stop request sent via control signal";
+        cli.CancelExecution();
+        cli.WaitForExecutionComplete();
+        PLOG_INFO << "exiting";
+    };
+
+    // Register console control signal handler.
+    {
+        static constexpr auto AddHandler = TRUE;
+        SetConsoleCtrlHandler(CtrlHandler, AddHandler);
+    }
 
     // Configure the cli parsing app with Windows-specific options.
     auto& uwbApp = cli.GetDriverUwbApp();


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Allow the app to be canceled via console control sequences like Ctrl-C and Ctrl-Break.

### Technical Details

* Add a control sequence handler and use it to request canceling CLI operation.
* Wait for operations to complete after requesting cancelation to ensure teardown code is executed.

### Test Results

* Observed that control sequence is received and requests to cancel execution.

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
