### PR TITLE
Expand magic_enum range to include all of uint8_t

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,6 +240,8 @@ elseif (BUILD_FOR_WINDOWS)
       UNICODE
       NOMINMAX
       WIN32_LEAN_AND_MEAN
+      MAGIC_ENUM_RANGE_MIN=0
+      MAGIC_ENUM_RANGE_MAX=255
   )
 
   # Allow more than default number of sections in object files.


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Ensure magic_enum works for all the enum values defined in this library.

### Technical Details

* Set magic enum range to that of `uint8_t` limits, [0, 255].

### Test Results

None

### Reviewer Focus

None

### Future Work

* We may later consider providing local overrides for each enum outside the range of the defaults set by the library. This would improve compile times.

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
