### PR TITLE
Fix Q97 to double conversion

### DIFF
--- a/lib/uwb/UwbPeer.cxx
+++ b/lib/uwb/UwbPeer.cxx
@@ -57,10 +57,14 @@ ConvertQ97FormatToIEEE(uint16_t q97)
     static const uint16_t fractionMask = ~(signMask | unsignedIntegerMask);
 
     bool sign = q97 & signMask;
-    int unsignedIntegerPart = (q97 & unsignedIntegerMask) >> 7U;
-    int fractionPart = q97 & fractionMask;
+    uint16_t unsignedIntegerPart = (q97 & unsignedIntegerMask) >> 7U;
+    uint16_t fractionPart = q97 & fractionMask;
 
-    double unsignedNumber = ((double)unsignedIntegerPart) + (((double)fractionPart) * pow2);
+    if (sign) {
+        unsignedIntegerPart = (~unsignedIntegerPart + 1U) & 0x00FF;
+    }
+
+    double unsignedNumber = static_cast<double>(unsignedIntegerPart + (fractionPart * pow2));
 
     return (sign ? -1 : 1) * unsignedNumber;
 }


### PR DESCRIPTION
### Type

- [x] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

This PR fixes the conversion from ARM Q9.7 format to IEEE 754 double precision format. Fixes #294

### Technical Details

- Added twos complement conversion of "integer" part if the "sign" bit is set.
- Minor syntax improvements.

### Test Results

Verified expected conversion results using TestClient driver.

### Reviewer Focus

None.

### Future Work

Unit tests still need to be added.

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
