### PR TITLE
Fix ranging measurement ToString() output

### DIFF
--- a/lib/uwb/UwbPeer.cxx
+++ b/lib/uwb/UwbPeer.cxx
@@ -37,45 +37,13 @@ UwbPeer::UwbPeer(UwbMacAddress address) :
     m_address(std::move(address))
 {}
 
-/**
- * @brief Converts a Q9.7-formatted value to an IEEE 754 double precision floating point formatted value.
- *
- * Assuming the Arm definition of Qm.n formatting, the most significant bit is the sign, the next
- * (m-1) bits are an integer, and the next n bits is the number to be multiplied by pow(2,n)
- * The double equivalent will be the sum of those two results
- * TODO double check this conversion, write tests for it
- *
- * @param q97 a number in Q9.7 format
- * @return double
- */
-double
-ConvertQ97FormatToIEEE(uint16_t q97)
-{
-    static const double pow2 = std::pow(2, -7);
-    static const uint16_t signMask = 0b1000'0000'0000'0000U;
-    static const uint16_t unsignedIntegerMask = 0b0111'1111'1000'0000U;
-    static const uint16_t fractionMask = ~(signMask | unsignedIntegerMask);
-
-    bool sign = q97 & signMask;
-    uint16_t unsignedIntegerPart = (q97 & unsignedIntegerMask) >> 7U;
-    uint16_t fractionPart = q97 & fractionMask;
-
-    if (sign) {
-        unsignedIntegerPart = (~unsignedIntegerPart + 1U) & 0x00FF;
-    }
-
-    double unsignedNumber = static_cast<double>(unsignedIntegerPart + (fractionPart * pow2));
-
-    return (sign ? -1 : 1) * unsignedNumber;
-}
-
 UwbPeer::UwbPeer(const uwb::protocol::fira::UwbRangingMeasurement& data) :
     m_address{ data.PeerMacAddress },
     m_spatialProperties{
-        .Distance{ data.Distance }, // TODO is this also q97
-        .AngleAzimuth{ ConvertQ97FormatToIEEE(data.AoAAzimuth.Result) },
-        .AngleElevation{ ConvertQ97FormatToIEEE(data.AoAElevation.Result) },
-        .Elevation{ ConvertQ97FormatToIEEE(data.AoaDestinationElevation.Result) }, // TODO is this right?
+        .Distance{ data.Distance },
+        .AngleAzimuth{ uwb::protocol::fira::ConvertQ97FormatToIEEE(data.AoAAzimuth.Result) },
+        .AngleElevation{ uwb::protocol::fira::ConvertQ97FormatToIEEE(data.AoAElevation.Result) },
+        .Elevation{ uwb::protocol::fira::ConvertQ97FormatToIEEE(data.AoaDestinationElevation.Result) },
 
         .AngleAzimuthFom{ data.AoAAzimuth.FigureOfMerit },
         .AngleElevationFom{ data.AoAElevation.FigureOfMerit },

--- a/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/FiraDevice.hxx
@@ -43,6 +43,20 @@ std::optional<uint32_t>
 StringToVersion(const std::string& input) noexcept;
 
 /**
+ * @brief Converts a Q9.7-formatted value to an IEEE 754 double precision floating point formatted value.
+ *
+ * Assuming the Arm definition of Qm.n formatting, the most significant bit is the sign, the next
+ * (m-1) bits are an integer, and the next n bits is the number to be multiplied by pow(2,n)
+ * The double equivalent will be the sum of those two results
+ * TODO write unit tests
+ *
+ * @param q97 a number in Q9.7 format
+ * @return double
+ */
+double
+ConvertQ97FormatToIEEE(uint16_t q97);
+
+/**
  * @brief See FiRa Consortium MAC Technical Requirements v1.3.0,
  * Section D.1.8 STS, Figure 19, page 70.
  */


### PR DESCRIPTION
### Type

- [x] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Fixes #293

### Technical Details

- Moved Q9.7 to IEEE conversion function to FiraDevice.
- Used conversion in UwbRangingMeasurementData::ToString().

### Test Results

Verified expected output using TestClient driver.

### Reviewer Focus

None.

### Future Work

None.

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
