### PR TITLE
Add json serializers for UwbPeer and UwbPeerSpatialProperties

### DIFF
--- a/lib/uwb/CMakeLists.txt
+++ b/lib/uwb/CMakeLists.txt
@@ -33,11 +33,11 @@ target_include_directories(uwb
 
 target_link_libraries(uwb
     PRIVATE
-        jsonify
         magic_enum::magic_enum
         tlv
         plog::plog
     PUBLIC
+        jsonify
         notstd
         uwb-proto-fira
 )

--- a/lib/uwb/CMakeLists.txt
+++ b/lib/uwb/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(uwb
         ${CMAKE_CURRENT_LIST_DIR}/UwbMacAddress.cxx
         ${CMAKE_CURRENT_LIST_DIR}/UwbMacAddressJsonSerializer.cxx
         ${CMAKE_CURRENT_LIST_DIR}/UwbPeer.cxx
+        ${CMAKE_CURRENT_LIST_DIR}/UwbPeerJsonSerializer.cxx
         ${CMAKE_CURRENT_LIST_DIR}/UwbSession.cxx
         ${CMAKE_CURRENT_LIST_DIR}/UwbVersion.cxx
     PUBLIC
@@ -18,6 +19,7 @@ target_sources(uwb
         ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbMacAddress.hxx
         ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbMacAddressJsonSerializer.hxx
         ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbPeer.hxx
+        ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbPeerJsonSerializer.hxx
         ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbSession.hxx
         ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbSessionEventCallbacks.hxx
         ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbRegisteredCallbacks.hxx
@@ -46,6 +48,7 @@ list(APPEND UWB_PUBLIC_HEADERS
     ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbMacAddress.hxx
     ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbMacAddressJsonSerializer.hxx
     ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbPeer.hxx
+    ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbPeerJsonSerializer.hxx
     ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbSession.hxx
     ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbSessionEventCallbacks.hxx
     ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbRegisteredCallbacks.hxx

--- a/lib/uwb/CMakeLists.txt
+++ b/lib/uwb/CMakeLists.txt
@@ -16,13 +16,14 @@ target_sources(uwb
     PUBLIC
         ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbDevice.hxx
         ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbDeviceEventCallbacks.hxx
+        ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbJsonSerializers.hxx
         ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbMacAddress.hxx
         ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbMacAddressJsonSerializer.hxx
         ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbPeer.hxx
         ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbPeerJsonSerializer.hxx
+        ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbRegisteredCallbacks.hxx
         ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbSession.hxx
         ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbSessionEventCallbacks.hxx
-        ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbRegisteredCallbacks.hxx
         ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbVersion.hxx
 )
 
@@ -45,6 +46,7 @@ target_link_libraries(uwb
 list(APPEND UWB_PUBLIC_HEADERS
     ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbDevice.hxx
     ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbDeviceEventCallbacks.hxx
+    ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbJsonSerializers.hxx
     ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbMacAddress.hxx
     ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbMacAddressJsonSerializer.hxx
     ${UWB_DIR_PUBLIC_INCLUDE_PREFIX}/UwbPeer.hxx

--- a/lib/uwb/UwbPeer.cxx
+++ b/lib/uwb/UwbPeer.cxx
@@ -37,6 +37,11 @@ UwbPeer::UwbPeer(UwbMacAddress address) :
     m_address(std::move(address))
 {}
 
+UwbPeer::UwbPeer(UwbMacAddress address, UwbPeerSpatialProperties spatialProperties) :
+    m_address(std::move(address)),
+    m_spatialProperties(std::move(spatialProperties))
+{}
+
 UwbPeer::UwbPeer(const uwb::protocol::fira::UwbRangingMeasurement& data) :
     m_address{ data.PeerMacAddress },
     m_spatialProperties{

--- a/lib/uwb/UwbPeerJsonSerializer.cxx
+++ b/lib/uwb/UwbPeerJsonSerializer.cxx
@@ -1,71 +1,32 @@
 
 #include <stdexcept>
 
+#include <uwb/UwbMacAddress.hxx>
+#include <uwb/UwbMacAddressJsonSerializer.hxx>
 #include <uwb/UwbPeer.hxx>
 #include <uwb/UwbPeerJsonSerializer.hxx>
 
 using namespace uwb;
 
 void
-uwb::to_json(nlohmann::json& json, [[maybe_unused]] const UwbPeer& uwbPeer)
+uwb::to_json(nlohmann::json& json, const UwbPeer& uwbPeer)
 {
-    json = nlohmann::json {
-
+    json = nlohmann::json{
+        { "MacAddress", uwbPeer.GetAddress() },
+        { "SpatialProperties", uwbPeer.GetSpatialProperties() },
     };
 }
 
-
 void
-uwb::from_json([[maybe_unused]] const nlohmann::json& json, [[maybe_unused]] UwbPeer& uwbPeer)
+uwb::from_json(const nlohmann::json& json, UwbPeer& uwbPeer)
 {
+    UwbMacAddress uwbMacAddress{};
+    UwbPeerSpatialProperties uwbPeerSpatialProperties{};
+    json.at("MacAddress").get_to(uwbMacAddress);
+    json.at("SpatialProperties").get_to(uwbPeerSpatialProperties);
 
-}
-
-void
-uwb::to_json(nlohmann::json& json, [[maybe_unused]] const UwbPeerSpatialProperties& uwbPeerSpatialProperties)
-{
-    json = nlohmann::json {
-
+    uwbPeer = UwbPeer{
+        std::move(uwbMacAddress),
+        std::move(uwbPeerSpatialProperties)
     };
 }
-
-
-void
-uwb::from_json([[maybe_unused]] const nlohmann::json& json, [[maybe_unused]] UwbPeerSpatialProperties& uwbPeerSpatialProperties)
-{
-}
-
-// void
-// uwb::to_json(nlohmann::json& json, const UwbMacAddress& uwbMacAddress)
-// {
-//     json = nlohmann::json {
-//         { "Type", uwbMacAddress.GetType() },
-//         { "Value", uwbMacAddress.GetValue() },
-//     };
-// }
-
-// void
-// uwb::from_json(const nlohmann::json& json, UwbMacAddress& uwbMacAddress)
-// {
-//     UwbMacAddressType uwbMacAddressType{ UwbMacAddressType::Short }; 
-//     json.at("Type").get_to(uwbMacAddressType);
-
-//     switch (uwbMacAddressType) {
-//     case UwbMacAddressType::Short: {
-//         UwbMacAddress::ShortType value{};
-//         json.at("Value").get_to(value);
-//         uwbMacAddress = UwbMacAddress{ value };
-//         break;
-//     }
-//     case UwbMacAddressType::Extended: {
-//         UwbMacAddress::ExtendedType value{};
-//         json.at("Value").get_to(value);
-//         uwbMacAddress = UwbMacAddress{ value };
-//         break;
-//     }
-//     default: {
-//         throw std::invalid_argument("invalid UwbMacAddressType specified");
-//     }
-//     }
-// }
-

--- a/lib/uwb/UwbPeerJsonSerializer.cxx
+++ b/lib/uwb/UwbPeerJsonSerializer.cxx
@@ -1,6 +1,4 @@
 
-#include <stdexcept>
-
 #include <uwb/UwbMacAddress.hxx>
 #include <uwb/UwbMacAddressJsonSerializer.hxx>
 #include <uwb/UwbPeer.hxx>

--- a/lib/uwb/UwbPeerJsonSerializer.cxx
+++ b/lib/uwb/UwbPeerJsonSerializer.cxx
@@ -1,0 +1,71 @@
+
+#include <stdexcept>
+
+#include <uwb/UwbPeer.hxx>
+#include <uwb/UwbPeerJsonSerializer.hxx>
+
+using namespace uwb;
+
+void
+uwb::to_json(nlohmann::json& json, [[maybe_unused]] const UwbPeer& uwbPeer)
+{
+    json = nlohmann::json {
+
+    };
+}
+
+
+void
+uwb::from_json([[maybe_unused]] const nlohmann::json& json, [[maybe_unused]] UwbPeer& uwbPeer)
+{
+
+}
+
+void
+uwb::to_json(nlohmann::json& json, [[maybe_unused]] const UwbPeerSpatialProperties& uwbPeerSpatialProperties)
+{
+    json = nlohmann::json {
+
+    };
+}
+
+
+void
+uwb::from_json([[maybe_unused]] const nlohmann::json& json, [[maybe_unused]] UwbPeerSpatialProperties& uwbPeerSpatialProperties)
+{
+}
+
+// void
+// uwb::to_json(nlohmann::json& json, const UwbMacAddress& uwbMacAddress)
+// {
+//     json = nlohmann::json {
+//         { "Type", uwbMacAddress.GetType() },
+//         { "Value", uwbMacAddress.GetValue() },
+//     };
+// }
+
+// void
+// uwb::from_json(const nlohmann::json& json, UwbMacAddress& uwbMacAddress)
+// {
+//     UwbMacAddressType uwbMacAddressType{ UwbMacAddressType::Short }; 
+//     json.at("Type").get_to(uwbMacAddressType);
+
+//     switch (uwbMacAddressType) {
+//     case UwbMacAddressType::Short: {
+//         UwbMacAddress::ShortType value{};
+//         json.at("Value").get_to(value);
+//         uwbMacAddress = UwbMacAddress{ value };
+//         break;
+//     }
+//     case UwbMacAddressType::Extended: {
+//         UwbMacAddress::ExtendedType value{};
+//         json.at("Value").get_to(value);
+//         uwbMacAddress = UwbMacAddress{ value };
+//         break;
+//     }
+//     default: {
+//         throw std::invalid_argument("invalid UwbMacAddressType specified");
+//     }
+//     }
+// }
+

--- a/lib/uwb/include/uwb/UwbJsonSerializers.hxx
+++ b/lib/uwb/include/uwb/UwbJsonSerializers.hxx
@@ -1,0 +1,24 @@
+
+#ifndef UWB_JSON_SERIALIZERS_HXX
+#define UWB_JSON_SERIALIZERS_HXX
+
+#include <nlohmann/json.hpp>
+#include <uwb/UwbSessionEventCallbacks.hxx>
+
+namespace uwb
+{
+/**
+ * @brief Specialize enum serialization to avoid any potential issues with
+ * changes or re-ordering of the underlying values.
+ */
+// clang-format off
+NLOHMANN_JSON_SERIALIZE_ENUM(UwbSessionEndReason, { // NOLINT(*-avoid-c-arrays)
+    { UwbSessionEndReason::Stopped, "Stopped" },
+    { UwbSessionEndReason::Canceled, "Canceled" },
+    { UwbSessionEndReason::Timeout, "Timeout" },
+    { UwbSessionEndReason::Unspecified, "Unspecified" },
+})
+// clang-format on
+} // namespace uwb
+
+#endif // UWB_JSON_SERIALIZERS_HXX

--- a/lib/uwb/include/uwb/UwbPeer.hxx
+++ b/lib/uwb/include/uwb/UwbPeer.hxx
@@ -51,16 +51,16 @@ public:
 
     /**
      * @brief Construct a new UwbPeer object.
-     * 
-     * @param address 
-     * @param spatialProperties 
+     *
+     * @param address
+     * @param spatialProperties
      */
     explicit UwbPeer(UwbMacAddress address, UwbPeerSpatialProperties spatialProperties);
 
     /**
      * @brief Construct a new Uwb Peer object from UwbRangingMeasurement data
-     * 
-     * @param data 
+     *
+     * @param data
      */
     explicit UwbPeer(const uwb::protocol::fira::UwbRangingMeasurement& data);
 
@@ -104,9 +104,9 @@ public:
     GetSpatialProperties() const noexcept;
 
     /**
-     * @brief Returns a string representation of the object. 
-     * 
-     * @return std::string 
+     * @brief Returns a string representation of the object.
+     *
+     * @return std::string
      */
     std::string
     ToString() const;

--- a/lib/uwb/include/uwb/UwbPeer.hxx
+++ b/lib/uwb/include/uwb/UwbPeer.hxx
@@ -103,6 +103,11 @@ public:
     UwbPeerSpatialProperties
     GetSpatialProperties() const noexcept;
 
+    /**
+     * @brief Returns a string representation of the object. 
+     * 
+     * @return std::string 
+     */
     std::string
     ToString() const;
 

--- a/lib/uwb/include/uwb/UwbPeer.hxx
+++ b/lib/uwb/include/uwb/UwbPeer.hxx
@@ -39,6 +39,11 @@ class UwbPeer
 public:
     /**
      * @brief Construct a new UwbPeer object.
+     */
+    UwbPeer() = default;
+
+    /**
+     * @brief Construct a new UwbPeer object.
      *
      * @param address
      */

--- a/lib/uwb/include/uwb/UwbPeer.hxx
+++ b/lib/uwb/include/uwb/UwbPeer.hxx
@@ -45,6 +45,14 @@ public:
     explicit UwbPeer(UwbMacAddress address);
 
     /**
+     * @brief Construct a new UwbPeer object.
+     * 
+     * @param address 
+     * @param spatialProperties 
+     */
+    explicit UwbPeer(UwbMacAddress address, UwbPeerSpatialProperties spatialProperties);
+
+    /**
      * @brief Construct a new Uwb Peer object from UwbRangingMeasurement data
      * 
      * @param data 

--- a/lib/uwb/include/uwb/UwbPeerJsonSerializer.hxx
+++ b/lib/uwb/include/uwb/UwbPeerJsonSerializer.hxx
@@ -1,0 +1,50 @@
+
+#ifndef UWB_PEER_JSON_SERIALIZER_HXX
+#define UWB_PEER_JSON_SERIALIZER_HXX
+
+#include <nlohmann/json.hpp>
+
+namespace uwb
+{
+class UwbPeer;
+struct UwbPeerSpatialProperties;
+
+/**
+ * @brief 
+ * 
+ * @param json 
+ * @param uwbPeer 
+ */
+void
+to_json(nlohmann::json& json, const UwbPeer& uwbPeer);
+
+/**
+ * @brief 
+ * 
+ * @param json 
+ * @param uwbPeer 
+ */
+void
+from_json(const nlohmann::json& json, UwbPeer& uwbPeer);
+
+/**
+ * @brief 
+ * 
+ * @param json 
+ * @param uwbPeerSpatialProperties 
+ */
+void
+to_json(nlohmann::json& json, const UwbPeerSpatialProperties& uwbPeerSpatialProperties);
+
+/**
+ * @brief 
+ * 
+ * @param json 
+ * @param uwbPeerSpatialProperties 
+ */
+void
+from_json(const nlohmann::json& json, UwbPeerSpatialProperties& uwbPeerSpatialProperties);
+
+} // namespace uwb
+
+#endif // UWB_PEER_JSON_SERIALIZER_HXX

--- a/lib/uwb/include/uwb/UwbPeerJsonSerializer.hxx
+++ b/lib/uwb/include/uwb/UwbPeerJsonSerializer.hxx
@@ -2,8 +2,8 @@
 #ifndef UWB_PEER_JSON_SERIALIZER_HXX
 #define UWB_PEER_JSON_SERIALIZER_HXX
 
-#include <nlohmann/json.hpp>
 #include <jsonify/nlohmann/std_optional_serializer.hxx>
+#include <nlohmann/json.hpp>
 
 namespace uwb
 {
@@ -11,19 +11,19 @@ class UwbPeer;
 struct UwbPeerSpatialProperties;
 
 /**
- * @brief 
- * 
- * @param json 
- * @param uwbPeer 
+ * @brief
+ *
+ * @param json
+ * @param uwbPeer
  */
 void
 to_json(nlohmann::json& json, const UwbPeer& uwbPeer);
 
 /**
- * @brief 
- * 
- * @param json 
- * @param uwbPeer 
+ * @brief
+ *
+ * @param json
+ * @param uwbPeer
  */
 void
 from_json(const nlohmann::json& json, UwbPeer& uwbPeer);

--- a/lib/uwb/include/uwb/UwbPeerJsonSerializer.hxx
+++ b/lib/uwb/include/uwb/UwbPeerJsonSerializer.hxx
@@ -30,24 +30,6 @@ from_json(const nlohmann::json& json, UwbPeer& uwbPeer);
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(UwbPeerSpatialProperties, Distance, AngleAzimuth, AngleElevation, Elevation, AngleAzimuthFom, AngleElevationFom, ElevationFom)
 
-// /**
-//  * @brief 
-//  * 
-//  * @param json 
-//  * @param uwbPeerSpatialProperties 
-//  */
-// void
-// to_json(nlohmann::json& json, const UwbPeerSpatialProperties& uwbPeerSpatialProperties);
-
-// /**
-//  * @brief 
-//  * 
-//  * @param json 
-//  * @param uwbPeerSpatialProperties 
-//  */
-// void
-// from_json(const nlohmann::json& json, UwbPeerSpatialProperties& uwbPeerSpatialProperties);
-
 } // namespace uwb
 
 #endif // UWB_PEER_JSON_SERIALIZER_HXX

--- a/lib/uwb/include/uwb/UwbPeerJsonSerializer.hxx
+++ b/lib/uwb/include/uwb/UwbPeerJsonSerializer.hxx
@@ -3,6 +3,7 @@
 #define UWB_PEER_JSON_SERIALIZER_HXX
 
 #include <nlohmann/json.hpp>
+#include <jsonify/nlohmann/std_optional_serializer.hxx>
 
 namespace uwb
 {
@@ -27,23 +28,25 @@ to_json(nlohmann::json& json, const UwbPeer& uwbPeer);
 void
 from_json(const nlohmann::json& json, UwbPeer& uwbPeer);
 
-/**
- * @brief 
- * 
- * @param json 
- * @param uwbPeerSpatialProperties 
- */
-void
-to_json(nlohmann::json& json, const UwbPeerSpatialProperties& uwbPeerSpatialProperties);
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(UwbPeerSpatialProperties, Distance, AngleAzimuth, AngleElevation, Elevation, AngleAzimuthFom, AngleElevationFom, ElevationFom)
 
-/**
- * @brief 
- * 
- * @param json 
- * @param uwbPeerSpatialProperties 
- */
-void
-from_json(const nlohmann::json& json, UwbPeerSpatialProperties& uwbPeerSpatialProperties);
+// /**
+//  * @brief 
+//  * 
+//  * @param json 
+//  * @param uwbPeerSpatialProperties 
+//  */
+// void
+// to_json(nlohmann::json& json, const UwbPeerSpatialProperties& uwbPeerSpatialProperties);
+
+// /**
+//  * @brief 
+//  * 
+//  * @param json 
+//  * @param uwbPeerSpatialProperties 
+//  */
+// void
+// from_json(const nlohmann::json& json, UwbPeerSpatialProperties& uwbPeerSpatialProperties);
 
 } // namespace uwb
 

--- a/lib/uwb/protocols/fira/CMakeLists.txt
+++ b/lib/uwb/protocols/fira/CMakeLists.txt
@@ -43,10 +43,10 @@ target_include_directories(uwb-proto-fira
 
 target_link_libraries(uwb-proto-fira
     PRIVATE
-        jsonify
         uwb-proto-fira-uci
         magic_enum::magic_enum
     PUBLIC
+        jsonify
         notstd
         smartcard
         tlv

--- a/tests/unit/uwb/CMakeLists.txt
+++ b/tests/unit/uwb/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(uwb-test
         ${CMAKE_CURRENT_LIST_DIR}/protocols/fira/TestUwbFiraUwbConfigurationBuilder.cxx
         ${CMAKE_CURRENT_LIST_DIR}/TestUwbDevice.cxx
         ${CMAKE_CURRENT_LIST_DIR}/TestUwbDeviceCallbacks.cxx
+        ${CMAKE_CURRENT_LIST_DIR}/TestUwbJsonSerializers.cxx
         ${CMAKE_CURRENT_LIST_DIR}/TestUwbMacAddress.cxx
         ${CMAKE_CURRENT_LIST_DIR}/TestUwbPeer.cxx
 )

--- a/tests/unit/uwb/TestUwbJsonSerializers.cxx
+++ b/tests/unit/uwb/TestUwbJsonSerializers.cxx
@@ -1,0 +1,19 @@
+
+#include <catch2/catch_test_macros.hpp>
+#include <magic_enum.hpp>
+#include <nlohmann/json.hpp>
+#include <uwb/UwbJsonSerializers.hxx>
+
+TEST_CASE("UwbSessionEndReason enumeration serialization is stable", "[basic][uwb][serialize]")
+{
+    using namespace uwb;
+
+    SECTION("serialization is stable")
+    {
+        for (const auto uwbSessionEndReason : magic_enum::enum_values<UwbSessionEndReason>()) {
+            const auto json = nlohmann::json(uwbSessionEndReason);
+            const auto uwbSessionEndReasonDeserialized = json.get<UwbSessionEndReason>();
+            REQUIRE(uwbSessionEndReason == uwbSessionEndReasonDeserialized);
+        }
+    }
+}

--- a/tests/unit/uwb/TestUwbPeer.cxx
+++ b/tests/unit/uwb/TestUwbPeer.cxx
@@ -5,8 +5,11 @@
 #include <type_traits>
 
 #include <uwb/UwbPeer.hxx>
+#include <uwb/UwbPeerJsonSerializer.hxx>
 
 #include <catch2/catch_test_macros.hpp>
+
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers)
 
 namespace uwb::test
 {
@@ -127,3 +130,48 @@ TEST_CASE("uwb peer spatial properties can be created", "[basic]")
         });
     }
 }
+
+TEST_CASE("uwb peer spatial properties serialization is stable", "[basic][uwb][serialize]")
+{
+    using namespace uwb;
+
+    constexpr UwbPeerSpatialProperties UwbPeerSpatialPropertiesAllEmpty {
+        .Distance = std::nullopt,
+        .AngleAzimuth = std::nullopt,
+        .AngleElevation = std::nullopt,
+        .Elevation = std::nullopt,
+        .AngleAzimuthFom = std::nullopt,
+        .AngleElevationFom = std::nullopt,
+        .ElevationFom = std::nullopt,
+    };
+
+    constexpr UwbPeerSpatialProperties UwbPeerSpatialPropertiesAllPopulated {
+        .Distance = 1.0,
+        .AngleAzimuth = 2.0,
+        .AngleElevation = 3.0,
+        .Elevation = 4.0,
+        .AngleAzimuthFom = 0xAA,
+        .AngleElevationFom = 0xBB,
+        .ElevationFom = 0xCC,
+    };
+
+    SECTION("all values empty is stable")
+    {
+        const auto json = nlohmann::json(UwbPeerSpatialPropertiesAllEmpty);
+        const auto uwbPeerSpatialPropertiesAllEmptylDeserialized = json.get<UwbPeerSpatialProperties>();
+        REQUIRE(uwbPeerSpatialPropertiesAllEmptylDeserialized == UwbPeerSpatialPropertiesAllEmpty);
+    }
+
+    SECTION("all values populated is stable")
+    {
+        const auto json = nlohmann::json(UwbPeerSpatialPropertiesAllPopulated);
+        const auto uwbPeerSpatialPropertiesAllPopulatedDeserialized = json.get<UwbPeerSpatialProperties>();
+        REQUIRE(uwbPeerSpatialPropertiesAllPopulatedDeserialized == UwbPeerSpatialPropertiesAllPopulated);
+    }
+}
+
+TEST_CASE("uwb peer serialization is stable", "[basic][uwb][serialize]")
+{
+}
+
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers)

--- a/tests/unit/uwb/TestUwbPeer.cxx
+++ b/tests/unit/uwb/TestUwbPeer.cxx
@@ -13,7 +13,7 @@
 
 namespace uwb::test
 {
-constexpr UwbPeerSpatialProperties UwbPeerSpatialPropertiesAllEmpty {
+constexpr UwbPeerSpatialProperties UwbPeerSpatialPropertiesAllEmpty{
     .Distance = std::nullopt,
     .AngleAzimuth = std::nullopt,
     .AngleElevation = std::nullopt,
@@ -22,7 +22,7 @@ constexpr UwbPeerSpatialProperties UwbPeerSpatialPropertiesAllEmpty {
     .AngleElevationFom = std::nullopt,
     .ElevationFom = std::nullopt,
 };
-constexpr UwbPeerSpatialProperties UwbPeerSpatialPropertiesAllPopulated {
+constexpr UwbPeerSpatialProperties UwbPeerSpatialPropertiesAllPopulated{
     .Distance = 1.1,
     .AngleAzimuth = 2.22,
     .AngleElevation = 3.333,
@@ -42,11 +42,11 @@ const std::array<UwbPeer, 2> PeersRandom = {
     UwbPeer{ UwbMacAddressesRandom[0] },
     UwbPeer{ UwbMacAddressesRandom[1] },
 };
-const std::array<UwbPeer, 2> PeersWithFullyPopulatedSpatialProperties {
+const std::array<UwbPeer, 2> PeersWithFullyPopulatedSpatialProperties{
     UwbPeer{ UwbMacAddressesRandom[0], UwbPeerSpatialPropertiesAllPopulated },
     UwbPeer{ UwbMacAddressesRandom[1], UwbPeerSpatialPropertiesAllPopulated },
 };
-const std::array<UwbPeer, 2> PeersWithFullyEmptySpatialProperties {
+const std::array<UwbPeer, 2> PeersWithFullyEmptySpatialProperties{
     UwbPeer{ UwbMacAddressesRandom[0], UwbPeerSpatialPropertiesAllEmpty },
     UwbPeer{ UwbMacAddressesRandom[1], UwbPeerSpatialPropertiesAllEmpty },
 };

--- a/tests/unit/uwb/TestUwbPeer.cxx
+++ b/tests/unit/uwb/TestUwbPeer.cxx
@@ -21,6 +21,24 @@ const std::array<UwbPeer, 2> PeersRandom = {
     UwbPeer{ UwbMacAddressesRandom[0] },
     UwbPeer{ UwbMacAddressesRandom[1] },
 };
+constexpr UwbPeerSpatialProperties UwbPeerSpatialPropertiesAllEmpty {
+    .Distance = std::nullopt,
+    .AngleAzimuth = std::nullopt,
+    .AngleElevation = std::nullopt,
+    .Elevation = std::nullopt,
+    .AngleAzimuthFom = std::nullopt,
+    .AngleElevationFom = std::nullopt,
+    .ElevationFom = std::nullopt,
+};
+constexpr UwbPeerSpatialProperties UwbPeerSpatialPropertiesAllPopulated {
+    .Distance = 1.0,
+    .AngleAzimuth = 2.0,
+    .AngleElevation = 3.0,
+    .Elevation = 4.0,
+    .AngleAzimuthFom = 0xAA,
+    .AngleElevationFom = 0xBB,
+    .ElevationFom = 0xCC,
+};
 } // namespace uwb::test
 
 TEST_CASE("uwb peer objects can be created", "[basic]")
@@ -135,38 +153,18 @@ TEST_CASE("uwb peer spatial properties serialization is stable", "[basic][uwb][s
 {
     using namespace uwb;
 
-    constexpr UwbPeerSpatialProperties UwbPeerSpatialPropertiesAllEmpty {
-        .Distance = std::nullopt,
-        .AngleAzimuth = std::nullopt,
-        .AngleElevation = std::nullopt,
-        .Elevation = std::nullopt,
-        .AngleAzimuthFom = std::nullopt,
-        .AngleElevationFom = std::nullopt,
-        .ElevationFom = std::nullopt,
-    };
-
-    constexpr UwbPeerSpatialProperties UwbPeerSpatialPropertiesAllPopulated {
-        .Distance = 1.0,
-        .AngleAzimuth = 2.0,
-        .AngleElevation = 3.0,
-        .Elevation = 4.0,
-        .AngleAzimuthFom = 0xAA,
-        .AngleElevationFom = 0xBB,
-        .ElevationFom = 0xCC,
-    };
-
     SECTION("all values empty is stable")
     {
-        const auto json = nlohmann::json(UwbPeerSpatialPropertiesAllEmpty);
+        const auto json = nlohmann::json(test::UwbPeerSpatialPropertiesAllEmpty);
         const auto uwbPeerSpatialPropertiesAllEmptylDeserialized = json.get<UwbPeerSpatialProperties>();
-        REQUIRE(uwbPeerSpatialPropertiesAllEmptylDeserialized == UwbPeerSpatialPropertiesAllEmpty);
+        REQUIRE(uwbPeerSpatialPropertiesAllEmptylDeserialized == test::UwbPeerSpatialPropertiesAllEmpty);
     }
 
     SECTION("all values populated is stable")
     {
-        const auto json = nlohmann::json(UwbPeerSpatialPropertiesAllPopulated);
+        const auto json = nlohmann::json(test::UwbPeerSpatialPropertiesAllPopulated);
         const auto uwbPeerSpatialPropertiesAllPopulatedDeserialized = json.get<UwbPeerSpatialProperties>();
-        REQUIRE(uwbPeerSpatialPropertiesAllPopulatedDeserialized == UwbPeerSpatialPropertiesAllPopulated);
+        REQUIRE(uwbPeerSpatialPropertiesAllPopulatedDeserialized == test::UwbPeerSpatialPropertiesAllPopulated);
     }
 }
 

--- a/tests/unit/uwb/TestUwbPeer.cxx
+++ b/tests/unit/uwb/TestUwbPeer.cxx
@@ -13,14 +13,6 @@
 
 namespace uwb::test
 {
-const std::array<UwbMacAddress, 2> UwbMacAddressesRandom = {
-    UwbMacAddress::Random<UwbMacAddressType::Short>(),
-    UwbMacAddress::Random<UwbMacAddressType::Extended>(),
-};
-const std::array<UwbPeer, 2> PeersRandom = {
-    UwbPeer{ UwbMacAddressesRandom[0] },
-    UwbPeer{ UwbMacAddressesRandom[1] },
-};
 constexpr UwbPeerSpatialProperties UwbPeerSpatialPropertiesAllEmpty {
     .Distance = std::nullopt,
     .AngleAzimuth = std::nullopt,
@@ -31,14 +23,34 @@ constexpr UwbPeerSpatialProperties UwbPeerSpatialPropertiesAllEmpty {
     .ElevationFom = std::nullopt,
 };
 constexpr UwbPeerSpatialProperties UwbPeerSpatialPropertiesAllPopulated {
-    .Distance = 1.0,
-    .AngleAzimuth = 2.0,
-    .AngleElevation = 3.0,
-    .Elevation = 4.0,
+    .Distance = 1.1,
+    .AngleAzimuth = 2.22,
+    .AngleElevation = 3.333,
+    .Elevation = 4.4444,
     .AngleAzimuthFom = 0xAA,
     .AngleElevationFom = 0xBB,
     .ElevationFom = 0xCC,
 };
+const std::array<UwbMacAddress, 2> UwbMacAddressesRandom = {
+    UwbMacAddress::Random<UwbMacAddressType::Short>(),
+    UwbMacAddress::Random<UwbMacAddressType::Extended>(),
+};
+const auto UwbMacAddressRandomShort = UwbMacAddressesRandom[0];
+const auto UwbMacAddressRandomExtended = UwbMacAddressesRandom[1];
+
+const std::array<UwbPeer, 2> PeersRandom = {
+    UwbPeer{ UwbMacAddressesRandom[0] },
+    UwbPeer{ UwbMacAddressesRandom[1] },
+};
+const std::array<UwbPeer, 2> PeersWithFullyPopulatedSpatialProperties {
+    UwbPeer{ UwbMacAddressesRandom[0], UwbPeerSpatialPropertiesAllPopulated },
+    UwbPeer{ UwbMacAddressesRandom[1], UwbPeerSpatialPropertiesAllPopulated },
+};
+const std::array<UwbPeer, 2> PeersWithFullyEmptySpatialProperties {
+    UwbPeer{ UwbMacAddressesRandom[0], UwbPeerSpatialPropertiesAllEmpty },
+    UwbPeer{ UwbMacAddressesRandom[1], UwbPeerSpatialPropertiesAllEmpty },
+};
+
 } // namespace uwb::test
 
 TEST_CASE("uwb peer objects can be created", "[basic]")
@@ -170,6 +182,39 @@ TEST_CASE("uwb peer spatial properties serialization is stable", "[basic][uwb][s
 
 TEST_CASE("uwb peer serialization is stable", "[basic][uwb][serialize]")
 {
+    using namespace uwb;
+
+    SECTION("peer with short mac address and fully populated spatial properties is stable")
+    {
+        const UwbPeer uwbPeerOriginal{ test::UwbMacAddressRandomShort, test::UwbPeerSpatialPropertiesAllPopulated };
+        const auto json = nlohmann::json(uwbPeerOriginal);
+        const auto uwbPeerDeserialized = json.get<UwbPeer>();
+        REQUIRE(uwbPeerOriginal == uwbPeerDeserialized);
+    }
+
+    SECTION("peer with short mac address and fully empty spatial properties is stable")
+    {
+        const UwbPeer uwbPeerOriginal{ test::UwbMacAddressRandomShort, test::UwbPeerSpatialPropertiesAllEmpty };
+        const auto json = nlohmann::json(uwbPeerOriginal);
+        const auto uwbPeerDeserialized = json.get<UwbPeer>();
+        REQUIRE(uwbPeerOriginal == uwbPeerDeserialized);
+    }
+
+    SECTION("peer with extended mac address and fully populated spatial properties is stable")
+    {
+        const UwbPeer uwbPeerOriginal{ test::UwbMacAddressRandomExtended, test::UwbPeerSpatialPropertiesAllPopulated };
+        const auto json = nlohmann::json(uwbPeerOriginal);
+        const auto uwbPeerDeserialized = json.get<UwbPeer>();
+        REQUIRE(uwbPeerOriginal == uwbPeerDeserialized);
+    }
+
+    SECTION("peer with extended mac address and fully empty spatial properties is stable")
+    {
+        const UwbPeer uwbPeerOriginal{ test::UwbMacAddressRandomExtended, test::UwbPeerSpatialPropertiesAllEmpty };
+        const auto json = nlohmann::json(uwbPeerOriginal);
+        const auto uwbPeerDeserialized = json.get<UwbPeer>();
+        REQUIRE(uwbPeerOriginal == uwbPeerDeserialized);
+    }
 }
 
 // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Allow `UwbPeer` and `UwbPeerSpatialProperties` to be exchanged cross-process.

### Technical Details

* Implement json serialization and deserialization functions for use with nlohmann.
* Add unit tests validating serialization works.
* Move `jsonify` target to a public dependency for the `uwb` and `uwb-proto-fira` targets (this was previously a bug, but other dependencies satisfied the requirement indirectly).

### Test Results

* All unit tests pass on both Linux and Windows.

### Reviewer Focus

None

### Future Work

* Additional types used in session events will have similar json serializers added.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
