### PR TITLE
Disable building tests for cross-compile in GitHub cmake action

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -112,7 +112,7 @@ jobs:
 
     - name: CMake Configure Cross-Compile ${{ matrix.config.arch }}
       if: ${{ matrix.config.arch }}
-      run: cmake --preset ${{ inputs.preset-name }} --fresh -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -G"${{ matrix.config.generator }}" -A ${{ matrix.config.arch }}
+      run: cmake --preset ${{ inputs.preset-name }} --fresh -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DNOF_DISABLE_TESTS=TRUE -G"${{ matrix.config.generator }}" -A ${{ matrix.config.arch }}
 
     - name: CMake Build
       run: cmake --build --preset ${{ inputs.preset-name }} --config ${{ matrix.build-type }}


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [X] Infrastructure

### Goals

Ensure cross-compile builds (eg. ARM64) are built successfully. Tests must be disabled on cross-compile builds since they can't be executed on the compiler host due to mismatching processor architecture.

### Technical Details

* Disable tests during configure step when cross-compiling.

### Test Results

* Ran cmake action steps locally and validated the build completed.

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
