### PR TITLE
Fire SessionEnded event only when the session enters the de-initialized state

### DIFF
--- a/windows/devices/uwb/UwbConnector.cxx
+++ b/windows/devices/uwb/UwbConnector.cxx
@@ -915,7 +915,7 @@ UwbConnector::DispatchCallbacks(::uwb::protocol::fira::UwbNotificationData uwbNo
             InvokeCallbacks(m_onDeviceStatusChangedCallbacks, arg);
         } else if constexpr (std::is_same_v<ValueType, UwbSessionStatus>) {
             InvokeCallbacks(m_onSessionStatusChangedCallbacks, arg);
-            if (arg.State == UwbSessionState::Idle) {
+            if (arg.State == UwbSessionState::Deinitialized) {
                 OnSessionEnded(arg.SessionId, ::uwb::UwbSessionEndReason::Stopped);
             }
         } else if constexpr (std::is_same_v<ValueType, UwbSessionUpdateMulticastListStatus>) {


### PR DESCRIPTION
…lized state.

### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

* Ensure the `SessionEnded` event fires at the correct time.

### Technical Details

* Change the event dispatch logic to fire the `SessionEnded` event only when the session enters the `Deinitialized` state instead of the `Idle` state.

### Test Results

None (TBD)

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
