### PR TITLE
Ensure magic_enum config limits apply to all platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,6 +203,12 @@ set(NOF_DIR_LIB ${CMAKE_CURRENT_LIST_DIR}/lib)
 set(NOF_DIR_LINUX ${CMAKE_CURRENT_LIST_DIR}/linux)
 set(NOF_DIR_WINDOWS ${CMAKE_CURRENT_LIST_DIR}/windows)
 
+# Add common, global compile definitions.
+add_compile_definitions(
+    MAGIC_ENUM_RANGE_MIN=0
+    MAGIC_ENUM_RANGE_MAX=255
+)
+
 # Conditional inclusion of OS-dependent source trees.
 if (BUILD_FOR_LINUX)
   add_subdirectory(linux)
@@ -240,8 +246,6 @@ elseif (BUILD_FOR_WINDOWS)
       UNICODE
       NOMINMAX
       WIN32_LEAN_AND_MEAN
-      MAGIC_ENUM_RANGE_MIN=0
-      MAGIC_ENUM_RANGE_MAX=255
   )
 
   # Allow more than default number of sections in object files.


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Ensure `UwbSessionData` tests pass on Linux.

### Technical Details

* Move magic num limit configuration from Windows-specific global compile-definitions to shared/common global compile-defintiions.

### Test Results

All unit tests now pass on both Linux and Windows.

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
