### PR TITLE
Expose OOB data bytes through UwbSession

### DIFF
--- a/lib/uwb/UwbSession.cxx
+++ b/lib/uwb/UwbSession.cxx
@@ -15,10 +15,10 @@ using namespace uwb::protocol::fira;
 const std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameterType> UwbSession::AllParameters = {};
 
 UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<UwbDevice> device, std::weak_ptr<UwbSessionEventCallbacks> callbacks, DeviceType deviceType) :
-    m_uwbMacAddressSelf(UwbMacAddress::Random<UwbMacAddressType::Extended>()),
-    m_callbacks(std::move(callbacks)),
     m_deviceType{ deviceType },
     m_sessionId(sessionId),
+    m_uwbMacAddressSelf(UwbMacAddress::Random<UwbMacAddressType::Extended>()),
+    m_callbacks(std::move(callbacks)),
     m_device(std::move(device))
 {}
 

--- a/lib/uwb/UwbSession.cxx
+++ b/lib/uwb/UwbSession.cxx
@@ -157,3 +157,10 @@ UwbSession::Destroy()
     PLOG_VERBOSE << "destroy session with id " << m_sessionId;
     DestroyImpl();
 }
+
+std::vector<uint8_t>
+UwbSession::GetOobDataObject()
+{
+    PLOG_VERBOSE << "get OOB data object";
+    return GetOobDataObjectImpl();
+}

--- a/lib/uwb/UwbSession.cxx
+++ b/lib/uwb/UwbSession.cxx
@@ -11,6 +11,9 @@
 using namespace uwb;
 using namespace uwb::protocol::fira;
 
+/* static */
+const std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameterType> UwbSession::AllParameters = {};
+
 UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<UwbDevice> device, std::weak_ptr<UwbSessionEventCallbacks> callbacks, DeviceType deviceType) :
     m_uwbMacAddressSelf(UwbMacAddress::Random<UwbMacAddressType::Extended>()),
     m_callbacks(std::move(callbacks)),

--- a/lib/uwb/include/uwb/UwbSession.hxx
+++ b/lib/uwb/include/uwb/UwbSession.hxx
@@ -166,6 +166,14 @@ public:
     void
     Destroy();
 
+    /**
+     * @brief Get the OOB data object representing the session data for this UwbSession.
+     * 
+     * @return std::vector<uint8_t>
+    */
+   std::vector<uint8_t>
+   GetOobDataObject();
+
 protected:
     /**
      * @brief Attempt to resolve the event callbacks from a weak to a shared
@@ -270,6 +278,14 @@ private:
      */
     virtual void
     DestroyImpl() = 0;
+
+    /**
+     * @brief Get the OOB data object representing the session data for this UwbSession.
+     * 
+     * @return std::vector<uint8_t>
+    */
+   virtual std::vector<uint8_t>
+   GetOobDataObjectImpl() = 0;
 
 protected:
     uwb::protocol::fira::DeviceType m_deviceType{ uwb::protocol::fira::DeviceType::Controller };

--- a/lib/uwb/include/uwb/UwbSession.hxx
+++ b/lib/uwb/include/uwb/UwbSession.hxx
@@ -135,6 +135,8 @@ public:
     void
     SetSessionStatus(const uwb::protocol::fira::UwbSessionStatus& status);
 
+    static constexpr std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameterType> AllParameters = {};
+
     /**
      * @brief Get the application configuration parameters for this session.
      *

--- a/lib/uwb/include/uwb/UwbSession.hxx
+++ b/lib/uwb/include/uwb/UwbSession.hxx
@@ -135,7 +135,11 @@ public:
     void
     SetSessionStatus(const uwb::protocol::fira::UwbSessionStatus& status);
 
-    static constexpr std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameterType> AllParameters = {};
+    /**
+     * @brief Sentinel value indicating that all supported application
+     * configuration parameters should be requested.
+     */
+    static const std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameterType> AllParameters;
 
     /**
      * @brief Get the application configuration parameters for this session.

--- a/lib/uwb/include/uwb/UwbSession.hxx
+++ b/lib/uwb/include/uwb/UwbSession.hxx
@@ -168,11 +168,11 @@ public:
 
     /**
      * @brief Get the OOB data object representing the session data for this UwbSession.
-     * 
+     *
      * @return std::vector<uint8_t>
-    */
-   std::vector<uint8_t>
-   GetOobDataObject();
+     */
+    std::vector<uint8_t>
+    GetOobDataObject();
 
 protected:
     /**
@@ -281,11 +281,11 @@ private:
 
     /**
      * @brief Get the OOB data object representing the session data for this UwbSession.
-     * 
+     *
      * @return std::vector<uint8_t>
-    */
-   virtual std::vector<uint8_t>
-   GetOobDataObjectImpl() = 0;
+     */
+    virtual std::vector<uint8_t>
+    GetOobDataObjectImpl() = 0;
 
 protected:
     uwb::protocol::fira::DeviceType m_deviceType{ uwb::protocol::fira::DeviceType::Controller };

--- a/lib/uwb/include/uwb/protocols/fira/UwbOobConversions.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/UwbOobConversions.hxx
@@ -3,7 +3,7 @@
 #define UWB_OOB_CONVERSIONS_HXX
 
 #include <uwb/protocols/fira/FiraDevice.hxx>
-#include <uwb/protocols/fira/UwbConfiguration.hxx>
+#include <uwb/protocols/fira/UwbSessionData.hxx>
 
 namespace uwb::protocol::fira
 {
@@ -14,6 +14,14 @@ namespace uwb::protocol::fira
  */
 std::vector<UwbApplicationConfigurationParameter>
 GetUciConfigParams(const UwbConfiguration& uwbConfiguration, DeviceType deviceType);
+
+/**
+ * @brief Converts the given UCI application configuration parameters to the OOB UwbSessionData equivalent
+ * 
+ * @return UwbSessionData
+*/
+UwbSessionData
+GetUwbSessionData(std::vector<UwbApplicationConfigurationParameter> applicationConfigurationParameters);
 
 } // namespace uwb::protocol::fira
 

--- a/lib/uwb/include/uwb/protocols/fira/UwbOobConversions.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/UwbOobConversions.hxx
@@ -17,9 +17,9 @@ GetUciConfigParams(const UwbConfiguration& uwbConfiguration, DeviceType deviceTy
 
 /**
  * @brief Converts the given UCI application configuration parameters to the OOB UwbSessionData equivalent
- * 
+ *
  * @return UwbSessionData
-*/
+ */
 UwbSessionData
 GetUwbSessionData(std::vector<UwbApplicationConfigurationParameter> applicationConfigurationParameters);
 

--- a/lib/uwb/include/uwb/protocols/fira/UwbOobConversions.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/UwbOobConversions.hxx
@@ -10,6 +10,8 @@ namespace uwb::protocol::fira
 /**
  * @brief Converts the config params given by OOB to config params that UCI needs
  *
+ * @param uwbConfiguration The UWB configuration data used to generate the UCI configuration parameter list
+ * @param deviceType The type of device (Controller/Controlee)
  * @return std::vector<UwbApplicationConfigurationParameter>
  */
 std::vector<UwbApplicationConfigurationParameter>
@@ -18,6 +20,7 @@ GetUciConfigParams(const UwbConfiguration& uwbConfiguration, DeviceType deviceTy
 /**
  * @brief Converts the given UCI application configuration parameters to the OOB UwbSessionData equivalent
  *
+ * @param applicationConfigurationParameters The UCI application configuration parameters used to construct UwbSessionData
  * @return UwbSessionData
  */
 UwbSessionData

--- a/lib/uwb/include/uwb/protocols/fira/UwbSessionData.hxx
+++ b/lib/uwb/include/uwb/protocols/fira/UwbSessionData.hxx
@@ -78,7 +78,15 @@ struct UwbSessionData
     static UwbSessionData
     FromMsgPack(std::span<uint8_t> msgpack);
 
-    uint16_t sessionDataVersion{ 0 };
+    /**
+     * @brief Session data version v1.1 taken from example in FiRa Consortium
+     * Common Service Management Layer Technical Specification v1.0.0, Section
+     * 7.5.3.2, 'UWB Session Data structure',
+     * Table 53, page 103.
+     */
+    static constexpr uint16_t Version_1_1 = 0x0101;
+
+    uint16_t sessionDataVersion{ Version_1_1 };
     uint32_t sessionId{ 0 };
     uint32_t subSessionId{ 0 };
     UwbConfiguration uwbConfiguration{};

--- a/lib/uwb/protocols/fira/UwbOobConversions.cxx
+++ b/lib/uwb/protocols/fira/UwbOobConversions.cxx
@@ -1,4 +1,6 @@
 
+#include <magic_enum.hpp>
+#include <plog/Log.h>
 #include <uwb/protocols/fira/UwbConfigurationBuilder.hxx>
 #include <uwb/protocols/fira/UwbOobConversions.hxx>
 #include <uwb/protocols/fira/UwbSessionData.hxx>
@@ -164,9 +166,6 @@ uwb::protocol::fira::GetUwbSessionData(std::vector<UwbApplicationConfigurationPa
         case UwbApplicationConfigurationParameterType::DeviceType:
             deviceType = std::get<DeviceType>(parameterValue);
             break;
-        case UwbApplicationConfigurationParameterType::RangingRoundUsage:
-            // TODO
-            break;
         case UwbApplicationConfigurationParameterType::StsConfiguration:
             builder.SetStsConfiguration(std::get<StsConfiguration>(parameterValue));
             break;
@@ -175,9 +174,6 @@ uwb::protocol::fira::GetUwbSessionData(std::vector<UwbApplicationConfigurationPa
             break;
         case UwbApplicationConfigurationParameterType::ChannelNumber:
             builder.SetChannel(std::get<Channel>(parameterValue));
-            break;
-        case UwbApplicationConfigurationParameterType::NumberOfControlees:
-            // TODO
             break;
         case UwbApplicationConfigurationParameterType::DeviceMacAddress:
             // In case this parameter comes before DeviceType, store and set correct parameter later
@@ -188,7 +184,7 @@ uwb::protocol::fira::GetUwbSessionData(std::vector<UwbApplicationConfigurationPa
             // In case this parameter comes before DeviceType, store and set correct parameter later
             destinationMacAddresses = std::get<std::unordered_set<UwbMacAddress>>(parameterValue);
             // TODO: Do this correctly
-            builder.SetMacAddressControleeShort(*destinationMacAddresses.begin());
+            builder.SetMacAddressControleeShort(*std::begin(destinationMacAddresses));
             break;
         case UwbApplicationConfigurationParameterType::SlotDuration:
             builder.SetSlotDuration(std::get<uint16_t>(parameterValue));
@@ -196,26 +192,8 @@ uwb::protocol::fira::GetUwbSessionData(std::vector<UwbApplicationConfigurationPa
         case UwbApplicationConfigurationParameterType::RangingInterval:
             builder.SetRangingInterval(std::get<uint32_t>(parameterValue));
             break;
-        case UwbApplicationConfigurationParameterType::StsIndex:
-            // TODO
-            break;
         case UwbApplicationConfigurationParameterType::MacFcsType:
             builder.SetMacAddressFcsType(std::get<UwbMacAddressFcsType>(parameterValue));
-            break;
-        case UwbApplicationConfigurationParameterType::RangingRoundControl:
-            // TODO
-            break;
-        case UwbApplicationConfigurationParameterType::AoAResultRequest:
-            // TODO
-            break;
-        case UwbApplicationConfigurationParameterType::RangeDataNotificationConfig:
-            // TODO
-            break;
-        case UwbApplicationConfigurationParameterType::RangeDataNotificationProximityNear:
-            // TODO
-            break;
-        case UwbApplicationConfigurationParameterType::RangeDataNotificationProximityFar:
-            // TODO
             break;
         case UwbApplicationConfigurationParameterType::DeviceRole:
             builder.SetDeviceRole(std::get<DeviceRole>(parameterValue));
@@ -226,45 +204,28 @@ uwb::protocol::fira::GetUwbSessionData(std::vector<UwbApplicationConfigurationPa
         case UwbApplicationConfigurationParameterType::PreambleCodeIndex:
             builder.SetPreambleCodeIndex(std::get<uint8_t>(parameterValue));
             break;
-        case UwbApplicationConfigurationParameterType::SfdId:
-            // TODO
-            break;
-        case UwbApplicationConfigurationParameterType::PsduDataRate:
-            // TODO
-            break;
-        case UwbApplicationConfigurationParameterType::PreambleDuration:
-            // TODO
-            break;
         case UwbApplicationConfigurationParameterType::RangingTimeStruct:
             builder.SetRangingTimeStruct(std::get<RangingMode>(parameterValue));
             break;
         case UwbApplicationConfigurationParameterType::SlotsPerRangingRound:
             builder.SetMaxSlotsPerRangingRound(std::get<uint8_t>(parameterValue));
             break;
-        case UwbApplicationConfigurationParameterType::TxAdaptivePayloadPower:
-            // TODO
-            break;
-        case UwbApplicationConfigurationParameterType::ResponderSlotIndex:
-            // TODO
-            break;
         case UwbApplicationConfigurationParameterType::PrfMode:
-            if (std::get<PrfModeDetailed>(parameterValue) == PrfModeDetailed::Bprf62MHz) {
+            switch (std::get<PrfModeDetailed>(parameterValue)) {
+            case PrfModeDetailed::Bprf62MHz:
                 builder.SetPrfMode(PrfMode::Bprf);
-            } else { // PrfModeDetailed::Hprf124MHz || PrfModeDetailed::Hprf249MHz
+                break;
+            case PrfModeDetailed::Hprf124MHz:
+                [[fallthrough]];
+            case PrfModeDetailed::Hprf249MHz:
                 builder.SetPrfMode(PrfMode::Hprf);
+                break;
             }
-            break;
         case UwbApplicationConfigurationParameterType::ScheduledMode:
             builder.SetSchedulingMode(std::get<SchedulingMode>(parameterValue));
             break;
-        case UwbApplicationConfigurationParameterType::KeyRotation:
-            // TODO
-            break;
         case UwbApplicationConfigurationParameterType::KeyRotationRate:
             builder.SetKeyRotationRate(std::get<uint8_t>(parameterValue));
-            break;
-        case UwbApplicationConfigurationParameterType::SessionPriority:
-            // TODO
             break;
         case UwbApplicationConfigurationParameterType::MacAddressMode:
             builder.SetMacAddressType(std::get<UwbMacAddressType>(parameterValue));
@@ -275,20 +236,11 @@ uwb::protocol::fira::GetUwbSessionData(std::vector<UwbApplicationConfigurationPa
         case UwbApplicationConfigurationParameterType::StaticStsIv:
             sessionData.staticRangingInfo->InitializationVector = std::get<StaticStsInitializationVector>(parameterValue);
             break;
-        case UwbApplicationConfigurationParameterType::NumberOfStsSegments:
-            // TODO
-            break;
         case UwbApplicationConfigurationParameterType::MaxRangingRoundRetry:
             builder.SetMaxRangingRoundRetry(std::get<uint16_t>(parameterValue));
             break;
         case UwbApplicationConfigurationParameterType::UwbInitiationTime:
             builder.SetUwbInitiationTime(std::get<uint32_t>(parameterValue));
-            break;
-        case UwbApplicationConfigurationParameterType::HoppingMode:
-            // TODO
-            break;
-        case UwbApplicationConfigurationParameterType::BlockStrideLength:
-            // TODO
             break;
         case UwbApplicationConfigurationParameterType::ResultReportConfig: {
             auto resultReportConfigurations = std::get<std::unordered_set<ResultReportConfiguration>>(parameterValue);
@@ -297,23 +249,57 @@ uwb::protocol::fira::GetUwbSessionData(std::vector<UwbApplicationConfigurationPa
             }
             break;
         }
-        case UwbApplicationConfigurationParameterType::InBandTerminationAttemptCount:
-            // TODO
-            break;
         case UwbApplicationConfigurationParameterType::SubSessionId:
             sessionData.subSessionId = std::get<uint32_t>(parameterValue);
             break;
+        case UwbApplicationConfigurationParameterType::RangingRoundUsage:
+            [[fallthrough]];
+        case UwbApplicationConfigurationParameterType::NumberOfControlees:
+            [[fallthrough]];
+        case UwbApplicationConfigurationParameterType::StsIndex:
+            [[fallthrough]];
+        case UwbApplicationConfigurationParameterType::RangingRoundControl:
+            [[fallthrough]];
+        case UwbApplicationConfigurationParameterType::AoAResultRequest:
+            [[fallthrough]];
+        case UwbApplicationConfigurationParameterType::RangeDataNotificationConfig:
+            [[fallthrough]];
+        case UwbApplicationConfigurationParameterType::RangeDataNotificationProximityNear:
+            [[fallthrough]];
+        case UwbApplicationConfigurationParameterType::RangeDataNotificationProximityFar:
+            [[fallthrough]];
+        case UwbApplicationConfigurationParameterType::SfdId:
+            [[fallthrough]];
+        case UwbApplicationConfigurationParameterType::PsduDataRate:
+            [[fallthrough]];
+        case UwbApplicationConfigurationParameterType::PreambleDuration:
+            [[fallthrough]];
+        case UwbApplicationConfigurationParameterType::TxAdaptivePayloadPower:
+            [[fallthrough]];
+        case UwbApplicationConfigurationParameterType::ResponderSlotIndex:
+            [[fallthrough]];
+        case UwbApplicationConfigurationParameterType::KeyRotation:
+            [[fallthrough]];
+        case UwbApplicationConfigurationParameterType::SessionPriority:
+            [[fallthrough]];
+        case UwbApplicationConfigurationParameterType::NumberOfStsSegments:
+            [[fallthrough]];
+        case UwbApplicationConfigurationParameterType::HoppingMode:
+            [[fallthrough]];
+        case UwbApplicationConfigurationParameterType::BlockStrideLength:
+            [[fallthrough]];
+        case UwbApplicationConfigurationParameterType::InBandTerminationAttemptCount:
+            [[fallthrough]];
         case UwbApplicationConfigurationParameterType::BprfPhrDataRate:
-            // TODO
-            break;
+            [[fallthrough]];
         case UwbApplicationConfigurationParameterType::MaxNumberOfMeasurements:
-            // TODO
-            break;
+            [[fallthrough]];
         case UwbApplicationConfigurationParameterType::StsLength:
-            // TODO
+            [[fallthrough]];
+            PLOG_WARNING << "parameter type " << magic_enum::enum_name(parameterType) << " not implemented. Ignoring.";
             break;
         default:
-            // TODO: Log error
+            PLOG_ERROR << "Unknown parameter type: " << magic_enum::enum_name(parameterType);
             break;
         }
     }
@@ -322,9 +308,9 @@ uwb::protocol::fira::GetUwbSessionData(std::vector<UwbApplicationConfigurationPa
     //       Need to figure out how to do this correctly
     if (deviceType == DeviceType::Controller) {
         builder.SetMacAddressController(deviceMacAddress);
-        builder.SetMacAddressControleeShort(*destinationMacAddresses.begin());
+        builder.SetMacAddressControleeShort(*std::begin(destinationMacAddresses));
     } else { // DeviceType::Controlee
-        builder.SetMacAddressController(*destinationMacAddresses.begin());
+        builder.SetMacAddressController(*std::begin(destinationMacAddresses));
         builder.SetMacAddressControleeShort(deviceMacAddress);
     }
 

--- a/lib/uwb/protocols/fira/UwbOobConversions.cxx
+++ b/lib/uwb/protocols/fira/UwbOobConversions.cxx
@@ -1,5 +1,7 @@
 
+#include <uwb/protocols/fira/UwbConfigurationBuilder.hxx>
 #include <uwb/protocols/fira/UwbOobConversions.hxx>
+#include <uwb/protocols/fira/UwbSessionData.hxx>
 
 using namespace uwb::protocol::fira;
 /**
@@ -142,4 +144,192 @@ uwb::protocol::fira::GetUciConfigParams(const UwbConfiguration& uwbConfiguration
             .Value = uciValue.value() });
     }
     return result;
+}
+
+UwbSessionData
+uwb::protocol::fira::GetUwbSessionData(std::vector<UwbApplicationConfigurationParameter> applicationConfigurationParameters)
+{
+    UwbSessionData sessionData{};
+    UwbConfiguration::Builder builder{};
+
+    DeviceType deviceType;
+    UwbMacAddress deviceMacAddress;
+    std::unordered_set<UwbMacAddress> destinationMacAddresses;
+
+    for (const auto& applicationConfigurationParameter : applicationConfigurationParameters) {
+        const auto& parameterType = applicationConfigurationParameter.Type;
+        const auto& parameterValue = applicationConfigurationParameter.Value;
+
+        switch (parameterType) {
+        case UwbApplicationConfigurationParameterType::DeviceType:
+            deviceType = std::get<DeviceType>(parameterValue);
+            break;
+        case UwbApplicationConfigurationParameterType::RangingRoundUsage:
+            // TODO
+            break;
+        case UwbApplicationConfigurationParameterType::StsConfiguration:
+            builder.SetStsConfiguration(std::get<StsConfiguration>(parameterValue));
+            break;
+        case UwbApplicationConfigurationParameterType::MultiNodeMode:
+            builder.SetMultiNodeMode(std::get<MultiNodeMode>(parameterValue));
+            break;
+        case UwbApplicationConfigurationParameterType::ChannelNumber:
+            builder.SetChannel(std::get<Channel>(parameterValue));
+            break;
+        case UwbApplicationConfigurationParameterType::NumberOfControlees:
+            // TODO
+            break;
+        case UwbApplicationConfigurationParameterType::DeviceMacAddress:
+            // In case this parameter comes before DeviceType, store and set correct parameter later
+            deviceMacAddress = std::get<UwbMacAddress>(parameterValue);
+            builder.SetMacAddressController(deviceMacAddress);
+            break;
+        case UwbApplicationConfigurationParameterType::DestinationMacAddresses:
+            // In case this parameter comes before DeviceType, store and set correct parameter later
+            destinationMacAddresses = std::get<std::unordered_set<UwbMacAddress>>(parameterValue);
+            // TODO: Do this correctly
+            builder.SetMacAddressControleeShort(*destinationMacAddresses.begin());
+            break;
+        case UwbApplicationConfigurationParameterType::SlotDuration:
+            builder.SetSlotDuration(std::get<uint16_t>(parameterValue));
+            break;
+        case UwbApplicationConfigurationParameterType::RangingInterval:
+            builder.SetRangingInterval(std::get<uint32_t>(parameterValue));
+            break;
+        case UwbApplicationConfigurationParameterType::StsIndex:
+            // TODO
+            break;
+        case UwbApplicationConfigurationParameterType::MacFcsType:
+            builder.SetMacAddressFcsType(std::get<UwbMacAddressFcsType>(parameterValue));
+            break;
+        case UwbApplicationConfigurationParameterType::RangingRoundControl:
+            // TODO
+            break;
+        case UwbApplicationConfigurationParameterType::AoAResultRequest:
+            // TODO
+            break;
+        case UwbApplicationConfigurationParameterType::RangeDataNotificationConfig:
+            // TODO
+            break;
+        case UwbApplicationConfigurationParameterType::RangeDataNotificationProximityNear:
+            // TODO
+            break;
+        case UwbApplicationConfigurationParameterType::RangeDataNotificationProximityFar:
+            // TODO
+            break;
+        case UwbApplicationConfigurationParameterType::DeviceRole:
+            builder.SetDeviceRole(std::get<DeviceRole>(parameterValue));
+            break;
+        case UwbApplicationConfigurationParameterType::RFrameConfiguration:
+            builder.SetStsPacketConfiguration(std::get<RFrameConfiguration>(parameterValue));
+            break;
+        case UwbApplicationConfigurationParameterType::PreambleCodeIndex:
+            builder.SetPreambleCodeIndex(std::get<uint8_t>(parameterValue));
+            break;
+        case UwbApplicationConfigurationParameterType::SfdId:
+            // TODO
+            break;
+        case UwbApplicationConfigurationParameterType::PsduDataRate:
+            // TODO
+            break;
+        case UwbApplicationConfigurationParameterType::PreambleDuration:
+            // TODO
+            break;
+        case UwbApplicationConfigurationParameterType::RangingTimeStruct:
+            builder.SetRangingTimeStruct(std::get<RangingMode>(parameterValue));
+            break;
+        case UwbApplicationConfigurationParameterType::SlotsPerRangingRound:
+            builder.SetMaxSlotsPerRangingRound(std::get<uint8_t>(parameterValue));
+            break;
+        case UwbApplicationConfigurationParameterType::TxAdaptivePayloadPower:
+            // TODO
+            break;
+        case UwbApplicationConfigurationParameterType::ResponderSlotIndex:
+            // TODO
+            break;
+        case UwbApplicationConfigurationParameterType::PrfMode:
+            if (std::get<PrfModeDetailed>(parameterValue) == PrfModeDetailed::Bprf62MHz) {
+                builder.SetPrfMode(PrfMode::Bprf);
+            } else { // PrfModeDetailed::Hprf124MHz || PrfModeDetailed::Hprf249MHz
+                builder.SetPrfMode(PrfMode::Hprf);
+            }
+            break;
+        case UwbApplicationConfigurationParameterType::ScheduledMode:
+            builder.SetSchedulingMode(std::get<SchedulingMode>(parameterValue));
+            break;
+        case UwbApplicationConfigurationParameterType::KeyRotation:
+            // TODO
+            break;
+        case UwbApplicationConfigurationParameterType::KeyRotationRate:
+            builder.SetKeyRotationRate(std::get<uint8_t>(parameterValue));
+            break;
+        case UwbApplicationConfigurationParameterType::SessionPriority:
+            // TODO
+            break;
+        case UwbApplicationConfigurationParameterType::MacAddressMode:
+            builder.SetMacAddressType(std::get<UwbMacAddressType>(parameterValue));
+            break;
+        case UwbApplicationConfigurationParameterType::VendorId:
+            sessionData.staticRangingInfo->VendorId = std::get<uint16_t>(parameterValue);
+            break;
+        case UwbApplicationConfigurationParameterType::StaticStsIv:
+            sessionData.staticRangingInfo->InitializationVector = std::get<StaticStsInitializationVector>(parameterValue);
+            break;
+        case UwbApplicationConfigurationParameterType::NumberOfStsSegments:
+            // TODO
+            break;
+        case UwbApplicationConfigurationParameterType::MaxRangingRoundRetry:
+            builder.SetMaxRangingRoundRetry(std::get<uint16_t>(parameterValue));
+            break;
+        case UwbApplicationConfigurationParameterType::UwbInitiationTime:
+            builder.SetUwbInitiationTime(std::get<uint32_t>(parameterValue));
+            break;
+        case UwbApplicationConfigurationParameterType::HoppingMode:
+            // TODO
+            break;
+        case UwbApplicationConfigurationParameterType::BlockStrideLength:
+            // TODO
+            break;
+        case UwbApplicationConfigurationParameterType::ResultReportConfig: {
+            auto resultReportConfigurations = std::get<std::unordered_set<ResultReportConfiguration>>(parameterValue);
+            for (const auto& resultReportConfiguration : resultReportConfigurations) {
+                builder.AddResultReportConfiguration(resultReportConfiguration);
+            }
+            break;
+        }
+        case UwbApplicationConfigurationParameterType::InBandTerminationAttemptCount:
+            // TODO
+            break;
+        case UwbApplicationConfigurationParameterType::SubSessionId:
+            sessionData.subSessionId = std::get<uint32_t>(parameterValue);
+            break;
+        case UwbApplicationConfigurationParameterType::BprfPhrDataRate:
+            // TODO
+            break;
+        case UwbApplicationConfigurationParameterType::MaxNumberOfMeasurements:
+            // TODO
+            break;
+        case UwbApplicationConfigurationParameterType::StsLength:
+            // TODO
+            break;
+        default:
+            // TODO: Log error
+            break;
+        }
+    }
+
+    // TODO: This assumes short mac addresses and only 1 address in the destination set.
+    //       Need to figure out how to do this correctly
+    if (deviceType == DeviceType::Controller) {
+        builder.SetMacAddressController(deviceMacAddress);
+        builder.SetMacAddressControleeShort(*destinationMacAddresses.begin());
+    } else { // DeviceType::Controlee
+        builder.SetMacAddressController(*destinationMacAddresses.begin());
+        builder.SetMacAddressControleeShort(deviceMacAddress);
+    }
+
+    sessionData.uwbConfiguration = std::move(builder);
+    sessionData.uwbConfigurationAvailable = true;
+
+    return sessionData;
 }

--- a/tools/cli/NearObjectCliHandler.cxx
+++ b/tools/cli/NearObjectCliHandler.cxx
@@ -49,7 +49,7 @@ try {
 
     auto session = uwbDevice->CreateSession(rangingParameters.SessionId, deviceType, m_sessionEventCallbacks);
     session->Configure(rangingParameters.ApplicationConfigurationParameters);
-    auto applicationConfigurationParameters = session->GetApplicationConfigurationParameters({});
+    auto applicationConfigurationParameters = session->GetApplicationConfigurationParameters(uwb::UwbSession::AllParameters);
     PLOG_DEBUG << "Session Application Configuration Parameters: ";
     for (const auto& applicationConfigurationParameter : applicationConfigurationParameters) {
         PLOG_DEBUG << " > " << applicationConfigurationParameter.ToString();

--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -300,7 +300,7 @@ UwbSession::DestroyImpl()
 std::vector<uint8_t>
 UwbSession::GetOobDataObjectImpl()
 {
-    auto applicationConfigurationParameters = GetApplicationConfigurationParameters({});
+    auto applicationConfigurationParameters = GetApplicationConfigurationParameters(AllParameters);
     auto uwbSessionData = GetUwbSessionData(applicationConfigurationParameters);
 
     uwbSessionData.sessionId = GetId();

--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -305,6 +305,6 @@ UwbSession::GetOobDataObjectImpl()
 
     uwbSessionData.sessionId = GetId();
     auto dataObject = uwbSessionData.ToDataObject();
-    
+
     return dataObject->ToBytes();
 }

--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -9,6 +9,7 @@
 #include <wil/result.h>
 
 #include <uwb/protocols/fira/UwbException.hxx>
+#include <uwb/protocols/fira/UwbOobConversions.hxx>
 #include <windows/devices/uwb/UwbConnector.hxx>
 #include <windows/devices/uwb/UwbCxDdiLrp.hxx>
 #include <windows/devices/uwb/UwbDevice.hxx>
@@ -294,4 +295,16 @@ UwbSession::DestroyImpl()
         PLOG_ERROR << "caught unexpected exception attempting to deinitialize for session id " << sessionId << " (" << e.what() << ")";
         throw e;
     }
+}
+
+std::vector<uint8_t>
+UwbSession::GetOobDataObjectImpl()
+{
+    auto applicationConfigurationParameters = GetApplicationConfigurationParameters({});
+    auto uwbSessionData = GetUwbSessionData(applicationConfigurationParameters);
+
+    uwbSessionData.sessionId = GetId();
+    auto dataObject = uwbSessionData.ToDataObject();
+    
+    return dataObject->ToBytes();
 }

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
@@ -108,6 +108,14 @@ private:
     void
     DestroyImpl() override;
 
+    /**
+     * @brief Get the OOB data object representing the session data for this UwbSession.
+     * 
+     * @return std::vector<uint8_t>
+    */
+   virtual std::vector<uint8_t>
+   GetOobDataObjectImpl() override;
+
 protected:
     /**
      * @brief Obtain a shared instance of the device driver connector.

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
@@ -110,11 +110,11 @@ private:
 
     /**
      * @brief Get the OOB data object representing the session data for this UwbSession.
-     * 
+     *
      * @return std::vector<uint8_t>
-    */
-   virtual std::vector<uint8_t>
-   GetOobDataObjectImpl() override;
+     */
+    virtual std::vector<uint8_t>
+    GetOobDataObjectImpl() override;
 
 protected:
     /**


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [x] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

`UwbSession` currently does not have a way of exposing `UwbSessionData` from it. This PR exposes that data in its Data Object format as a byte buffer.

### Technical Details

- Added OOB conversion function: `GetUwbSessionData`.
- Added public `GetOobDataObject` function in `UwbSession`.

### Test Results

Compile-tested only.

### Reviewer Focus

None.

### Future Work

The UCI parameters and the OOB parameters do not match up 1:1, so there are quite a few TODOs in the code for these situations.

The classic "controlee short mac address" problem shows up here in the conversion function, so the code currently assumes short mac addresses and only 1 destination mac address.

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
