### PR TITLE
Move session status changed callback from device to session callbacks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ MESSAGE(STATUS "using build environment '${NOF_BUILD_ENVIRONMENT}'")
 
 project(nearobject-framework 
   LANGUAGES CXX
-  VERSION 0.5.1
+  VERSION 0.5.2
 )
 
 # Conditional inclusion of OS-dependent source trees.

--- a/lib/uwb/UwbDevice.cxx
+++ b/lib/uwb/UwbDevice.cxx
@@ -110,19 +110,6 @@ UwbDevice::OnDeviceStatusChanged(UwbStatusDevice statusDevice)
     }
 }
 
-void
-UwbDevice::OnSessionStatusChanged(UwbSessionStatus statusSession)
-{
-    // TODO should this be something that the session handles itself?
-    auto session = FindSession(statusSession.SessionId);
-    if (!session) {
-        PLOG_WARNING << "Ignoring StatusChanged event due to missing session";
-        return;
-    }
-
-    session->SetSessionStatus(statusSession);
-}
-
 std::shared_ptr<UwbSession>
 UwbDevice::CreateSession(uint32_t sessionId, uwb::protocol::fira::DeviceType deviceType, std::weak_ptr<UwbSessionEventCallbacks> callbacks)
 {

--- a/lib/uwb/include/uwb/UwbDevice.hxx
+++ b/lib/uwb/include/uwb/UwbDevice.hxx
@@ -200,14 +200,6 @@ protected:
     void
     OnDeviceStatusChanged(::uwb::protocol::fira::UwbStatusDevice statusDevice);
 
-    /**
-     * @brief Invoked when the status of a session changes.
-     *
-     * @param statusSession The new status of the session.
-     */
-    void
-    OnSessionStatusChanged(::uwb::protocol::fira::UwbSessionStatus statusSession);
-
 private:
     ::uwb::protocol::fira::UwbStatusDevice m_status{ .State = ::uwb::protocol::fira::UwbDeviceState::Uninitialized };
     ::uwb::protocol::fira::UwbStatus m_lastError{ ::uwb::protocol::fira::UwbStatusGeneric::Ok };

--- a/lib/uwb/include/uwb/UwbDeviceEventCallbacks.hxx
+++ b/lib/uwb/include/uwb/UwbDeviceEventCallbacks.hxx
@@ -33,14 +33,6 @@ struct UwbDeviceEventCallbacks
      */
     virtual void
     OnDeviceStatusChanged(::uwb::protocol::fira::UwbStatusDevice statusDevice) = 0;
-
-    /**
-     * @brief Invoked when the status of a session changes.
-     *
-     * @param statusSession The new status of the session.
-     */
-    virtual void
-    OnSessionStatusChanged(::uwb::protocol::fira::UwbSessionStatus statusSession) = 0;
 };
 } // namespace uwb
 

--- a/lib/uwb/include/uwb/UwbRegisteredCallbacks.hxx
+++ b/lib/uwb/include/uwb/UwbRegisteredCallbacks.hxx
@@ -22,6 +22,11 @@ namespace UwbRegisteredSessionEventCallbackTypes
 using OnSessionEnded = std::function<bool(::uwb::UwbSessionEndReason reason)>;
 
 /**
+ * @brief Invoked when the session status changes. 
+ */
+using OnSessionStatusChanged = std::function<bool(::uwb::protocol::fira::UwbSessionState, std::optional<::uwb::protocol::fira::UwbSessionReasonCode>)>;
+
+/**
  * @brief Invoked when active ranging starts.
  * @return true if this callback needs to be deregistered
  */
@@ -96,6 +101,11 @@ struct UwbRegisteredSessionEventCallbacks
     std::weak_ptr<UwbRegisteredSessionEventCallbackTypes::OnSessionEnded> OnSessionEnded;
 
     /**
+     * @brief Invoked when the session status changes.
+     */
+    std::weak_ptr<UwbRegisteredSessionEventCallbackTypes::OnSessionStatusChanged> OnStatusChanged;
+
+    /**
      * @brief Invoked when active ranging starts.
      *
      */
@@ -145,13 +155,6 @@ struct UwbRegisteredDeviceEventCallbacks
      * @param statusDevice
      */
     std::weak_ptr<UwbRegisteredDeviceEventCallbackTypes::OnDeviceStatusChanged> OnDeviceStatusChanged;
-
-    /**
-     * @brief Invoked when the status of a session changes.
-     *
-     * @param statusSession The new status of the session.
-     */
-    std::weak_ptr<UwbRegisteredDeviceEventCallbackTypes::OnSessionStatusChanged> OnSessionStatusChanged;
 };
 
 /**
@@ -167,6 +170,7 @@ class RegisteredCallbackToken;
 struct UwbRegisteredSessionEventCallbackTokens
 {
     std::weak_ptr<RegisteredCallbackToken> OnSessionEndedToken;
+    std::weak_ptr<RegisteredCallbackToken> OnSessionStatusChangedToken;
     std::weak_ptr<RegisteredCallbackToken> OnRangingStartedToken;
     std::weak_ptr<RegisteredCallbackToken> OnRangingStoppedToken;
     std::weak_ptr<RegisteredCallbackToken> OnPeerPropertiesChangedToken;
@@ -181,7 +185,6 @@ struct UwbRegisteredDeviceEventCallbackTokens
 {
     std::weak_ptr<RegisteredCallbackToken> OnStatusChangedToken;
     std::weak_ptr<RegisteredCallbackToken> OnDeviceStatusChangedToken;
-    std::weak_ptr<RegisteredCallbackToken> OnSessionStatusChangedToken;
 };
 
 } // namespace uwb

--- a/lib/uwb/include/uwb/UwbSessionEventCallbacks.hxx
+++ b/lib/uwb/include/uwb/UwbSessionEventCallbacks.hxx
@@ -3,9 +3,11 @@
 #define UWB_SESSION_EVENT_CALLBACKS_HXX
 
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include <uwb/UwbPeer.hxx>
+#include <uwb/protocols/fira/FiraDevice.hxx>
 
 namespace uwb
 {
@@ -41,7 +43,7 @@ enum class UwbSessionEndReason {
 /**
  * @brief Interface for receiving events from a UwbSession. This is the primary
  * method to receive information from near peers.
- * 
+ *
  * A pointer to the UwbSession for which the callbacks are bound is provided in
  * each callback. This enables using the same callback object instance with
  * multiple sessions where the pointer value can be used to lookup the
@@ -52,12 +54,22 @@ struct UwbSessionEventCallbacks
 {
     /**
      * @brief Invoked when the session is ended.
-     * 
+     *
      * @param session The session for which the event occurred.
      * @param reason The reason the session ended.
      */
     virtual void
     OnSessionEnded(UwbSession *session, UwbSessionEndReason reason) = 0;
+
+    /**
+     * @brief Invoked when the session changes state.
+     *
+     * @param session The session for which the event occurred.
+     * @param state The new state of the session.
+     * @param reasonCode The reason the session changed state. Optional.
+     */
+    virtual void
+    OnSessionStatusChanged(UwbSession *session, ::uwb::protocol::fira::UwbSessionState state, std::optional<::uwb::protocol::fira::UwbSessionReasonCode> reasonCode) = 0;
 
     /**
      * @brief Invoked when active ranging starts.
@@ -78,7 +90,7 @@ struct UwbSessionEventCallbacks
     /**
      * @brief Invoked when the properties of a peer involved in the session
      * changes. This includes the spatial properties of the peer(s).
-     * 
+     *
      * @param session The session for which the event occurred.
      * @param peersChanged A list of peers whose properties changed.
      */
@@ -89,7 +101,7 @@ struct UwbSessionEventCallbacks
      * @brief Invoked when membership of one or more near peers involved in
      * the session is changed. This can occur when peer members are either
      * added to or removed from the session.
-     * 
+     *
      * @param session The session for which the event occurred.
      * @param peersAdded A list of peers that were added to the session.
      * @param peersRemoved A list of peers that were removed from the session.

--- a/packaging/vcpkg/ports/nearobject-framework/vcpkg.json
+++ b/packaging/vcpkg/ports/nearobject-framework/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "nearobject-framework",
-  "version-string": "0.5.1",
+  "version-string": "0.5.2",
   "dependencies": [
     "catch2",
     {

--- a/tests/unit/uwb/TestUwbDeviceCallbacks.cxx
+++ b/tests/unit/uwb/TestUwbDeviceCallbacks.cxx
@@ -21,11 +21,6 @@ struct UwbDeviceCallbacksTest : public UwbDeviceEventCallbacks
     OnDeviceStatusChanged([[maybe_unused]] ::uwb::protocol::fira::UwbStatusDevice statusDevice) override
     {
     }
-
-    void
-    OnSessionStatusChanged([[maybe_unused]] ::uwb::protocol::fira::UwbSessionStatus statusSession) override
-    {
-    }
 };
 } // namespace uwb::test
 

--- a/tools/cli/NearObjectCliUwbSessionEventCallbacks.cxx
+++ b/tools/cli/NearObjectCliUwbSessionEventCallbacks.cxx
@@ -61,6 +61,13 @@ NearObjectCliUwbSessionEventCallbacks::OnSessionEnded(::uwb::UwbSession* session
 }
 
 void
+NearObjectCliUwbSessionEventCallbacks::OnSessionStatusChanged(::uwb::UwbSession* session, ::uwb::protocol::fira::UwbSessionState state, std::optional<::uwb::protocol::fira::UwbSessionReasonCode> reasonCode)
+{
+    const auto reasonStr = reasonCode.has_value() ? magic_enum::enum_name(reasonCode.value()) : "None";
+    PLOG_VERBOSE << LogPrefix(session->GetId()) << "Session State Changed to '" << magic_enum::enum_name(state) << "' (Reason=" << reasonStr << ")";
+}
+
+void
 NearObjectCliUwbSessionEventCallbacks::OnRangingStarted(::uwb::UwbSession* session)
 {
     PLOG_VERBOSE << LogPrefix(session->GetId()) << "Ranging Started";

--- a/tools/cli/include/nearobject/cli/NearObjectCliUwbSessionEventCallbacks.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliUwbSessionEventCallbacks.hxx
@@ -16,7 +16,7 @@ struct NearObjectCliUwbSessionEventCallbacks :
 {
     /**
      * @brief Construct a new NearObjectCliUwbSessionEventCallbacks object.
-     * 
+     *
      * @param onSessionEndedCallback The callback to invoke when the session ends.
      */
     NearObjectCliUwbSessionEventCallbacks(std::function<void()> onSessionEndedCallback = {});
@@ -28,7 +28,17 @@ struct NearObjectCliUwbSessionEventCallbacks :
      * @param reason The reason the session ended.
      */
     void
-    OnSessionEnded(::uwb::UwbSession *session, ::uwb::UwbSessionEndReason reason);
+    OnSessionEnded(::uwb::UwbSession *session, ::uwb::UwbSessionEndReason reason) override;
+
+    /**
+     * @brief Invoked when the session changes state.
+     *
+     * @param session The session for which the event occurred.
+     * @param state The new state of the session.
+     * @param reasonCode The reason the session changed state. Optional.
+     */
+    void
+    OnSessionStatusChanged(::uwb::UwbSession *session, ::uwb::protocol::fira::UwbSessionState state, std::optional<::uwb::protocol::fira::UwbSessionReasonCode> reasonCode) override;
 
     /**
      * @brief Invoked when active ranging starts.

--- a/windows/devices/uwb/UwbConnector.cxx
+++ b/windows/devices/uwb/UwbConnector.cxx
@@ -919,6 +919,18 @@ UwbConnector::OnSessionRangingData(::uwb::protocol::fira::UwbRangingData ranging
 }
 
 void
+UwbConnector::OnStatusChanged(::uwb::protocol::fira::UwbStatus uwbStatus)
+{
+    InvokeCallbacks(m_onStatusChangedCallbacks, uwbStatus);
+}
+
+void
+UwbConnector::OnDeviceStatusChanged(::uwb::protocol::fira::UwbStatusDevice uwbStatusDevice)
+{
+    InvokeCallbacks(m_onDeviceStatusChangedCallbacks, uwbStatusDevice);
+}
+
+void
 UwbConnector::DispatchCallbacks(::uwb::protocol::fira::UwbNotificationData uwbNotificationData)
 {
     PLOG_INFO << "Received Notification: " << ToString(uwbNotificationData) << "\n";
@@ -929,9 +941,9 @@ UwbConnector::DispatchCallbacks(::uwb::protocol::fira::UwbNotificationData uwbNo
         using ValueType = std::decay_t<decltype(arg)>;
 
         if constexpr (std::is_same_v<ValueType, UwbStatus>) {
-            InvokeCallbacks(m_onStatusChangedCallbacks, arg);
+            OnStatusChanged(arg);
         } else if constexpr (std::is_same_v<ValueType, UwbStatusDevice>) {
-            InvokeCallbacks(m_onDeviceStatusChangedCallbacks, arg);
+            OnDeviceStatusChanged(arg);
         } else if constexpr (std::is_same_v<ValueType, UwbSessionStatus>) {
             OnSessionStatusChanged(arg.SessionId, arg.State, arg.ReasonCode);
         } else if constexpr (std::is_same_v<ValueType, UwbSessionUpdateMulticastListStatus>) {

--- a/windows/devices/uwb/UwbConnector.cxx
+++ b/windows/devices/uwb/UwbConnector.cxx
@@ -35,7 +35,7 @@ struct RegisteredCallbackToken
                 PLOG_WARNING << "empty callback token";
                 return;
             }
-            return deregister(this);
+            deregister(this);
         })
     {}
     virtual ~RegisteredCallbackToken() = default;

--- a/windows/devices/uwb/UwbConnector.cxx
+++ b/windows/devices/uwb/UwbConnector.cxx
@@ -1,10 +1,13 @@
 
+#include <cstdint>
 #include <exception>
+#include <format>
 #include <ios>
 #include <ranges>
 #include <stdexcept>
 #include <typeinfo>
 
+#include <magic_enum.hpp>
 #include <plog/Log.h>
 #include <wil/result.h>
 
@@ -696,72 +699,58 @@ UwbConnector::HandleNotifications(std::stop_token stopToken)
         DWORD bytesRequired = minimumNotificationSize;
         std::vector<uint8_t> uwbNotificationDataBuffer{};
         m_notificationOverlapped = {};
+
         for (const auto i : std::ranges::iota_view{ 0, maxIoctlAttempts }) {
-            const auto logPrefix = std::string("IOCTL_UWB_NOTIFICATION[").append(std::to_string((i + 1))).append("/").append(std::to_string(maxIoctlAttempts)).append("] ");
+            const auto logPrefix = std::string("IOCTL_UWB_NOTIFICATION[").append(std::to_string((i + 1))).append("/").append(std::to_string(maxIoctlAttempts)).append("]");
             // Size the buffer to hold the last known number of bytes required, either from an initial minimum value,
             // or from a prior call to DeviceIoControl indicating ERROR_MORE_DATA or ERROR_INSUFFICIENT_BUFFER.
             uwbNotificationDataBuffer.resize(std::max(bytesRequired, minimumNotificationSize));
-            PLOG_DEBUG << logPrefix << "with " << std::size(uwbNotificationDataBuffer) << "-byte buffer";
+            PLOG_DEBUG << std::format("{} SENT with {}-byte buffer", logPrefix, std::size(uwbNotificationDataBuffer));
             BOOL ioResult = DeviceIoControl(handleDriver.get(), IOCTL_UWB_NOTIFICATION, nullptr, 0, std::data(uwbNotificationDataBuffer), std::size(uwbNotificationDataBuffer), &bytesRequired, &m_notificationOverlapped);
 
             // Get error information from the DeviceIoControl call now before it possibly gets overwritten by other functions that may set it.
             DWORD lastError = GetLastError();
             HRESULT hr = HRESULT_FROM_WIN32(lastError);
-            PLOG_DEBUG << logPrefix << "with " << std::size(uwbNotificationDataBuffer) << "-byte buffer completed " << bytesRequired << " bytes required hr=" << std::showbase << std::hex << hr << " lastError " << std::showbase << std::hex << lastError;
+            PLOG_DEBUG << std::format("{} RESPONSE(SYNC) ioResult={}, hr/err={:#08x}/{:#08x}, buffer size/required {}/{}", logPrefix, static_cast<bool>(ioResult), static_cast<uint32_t>(hr), lastError, std::size(uwbNotificationDataBuffer), bytesRequired);
 
-            // Process the DeviceIoControl result.
-            if (!LOG_IF_WIN32_BOOL_FALSE(ioResult)) {
-                // Check if the I/O has been pended for asynchronous processing.
-                if (lastError == ERROR_IO_PENDING) {
-                    // I/O has been pended, wait for it synchronously, but in an interruptable manner.
-                    PLOG_DEBUG << logPrefix << "result was pended; waiting for result";
-                    if (!LOG_IF_WIN32_BOOL_FALSE(GetOverlappedResult(handleDriver.get(), &m_notificationOverlapped, &bytesRequired, TRUE /* wait */))) {
-                        lastError = GetLastError();
-                        hr = HRESULT_FROM_WIN32(lastError);
-                        if (lastError == ERROR_INSUFFICIENT_BUFFER || lastError == ERROR_MORE_DATA) {
-                            // Driver indicated buffer was too small and put required size in 'bytesRequired'. Retry with new size.
-                            const UWB_NOTIFICATION_DATA& notificationDataPartial = *reinterpret_cast<UWB_NOTIFICATION_DATA*>(std::data(uwbNotificationDataBuffer));
-                            bytesRequired = std::max(notificationDataPartial.size, static_cast<uint32_t>(minimumNotificationSize));
-                            PLOG_VERBOSE << logPrefix << "insufficient buffer (hr=" << std::showbase << std::hex << hr << "), " << std::dec << bytesRequired << " bytes required, current size " << std::size(uwbNotificationDataBuffer) << " bytes";
-                            continue;
-                        } else if (lastError == ERROR_OPERATION_ABORTED) {
-                            PLOG_WARNING << logPrefix << "aborted";
-                            break; // for({0,2})
-                        } else if (lastError == ERROR_DRIVER_PROCESS_TERMINATED) {
-                            PLOG_ERROR << logPrefix << "driver process terminated, hr=" << std::showbase << std::hex << hr;
-                            handleDriver.reset();
-                            break; // for({0,2})
-                        } else {
-                            PLOG_ERROR << logPrefix << "error, hr=" << std::showbase << std::hex << hr;
-                            break; // for({0,2})
-                        }
-                    } else {
-                        PLOG_DEBUG << logPrefix << "completed asynchronously";
-                    }
-                    // Check if the call requires a larger buffer.
-                } else if (lastError == ERROR_MORE_DATA || lastError == ERROR_INSUFFICIENT_BUFFER) {
-                    PLOG_VERBOSE << logPrefix << "insufficient buffer, " << bytesRequired << " bytes required, current size " << std::size(uwbNotificationDataBuffer) << " bytes";
-                    const UWB_NOTIFICATION_DATA& notificationDataPartial = *reinterpret_cast<UWB_NOTIFICATION_DATA*>(std::data(uwbNotificationDataBuffer));
-                    bytesRequired = std::max(notificationDataPartial.size, static_cast<uint32_t>(minimumNotificationSize));
-                    // Attempt to retry the ioctl with the appropriate buffer size, which is now held in bytesRequired.
-                    continue;
-                } else if (lastError == ERROR_DRIVER_PROCESS_TERMINATED) {
-                    PLOG_ERROR << logPrefix << "driver process terminated, hr=" << std::showbase << std::hex << hr;
+            // All responses must be asynchronous, so validate the request was pended.
+            if (ioResult == TRUE || lastError != ERROR_IO_PENDING) {
+                if (lastError == ERROR_DRIVER_PROCESS_TERMINATED || lastError == ERROR_INVALID_HANDLE) {
                     handleDriver.reset();
-                    break; // for({1,2})
-                    // Treat all other errors as fatal.
-                } else {
-                    hr = HRESULT_FROM_WIN32(lastError);
-                    PLOG_ERROR << logPrefix << "error, hr=" << std::showbase << std::hex << hr;
-                    break; // for({1,2})
                 }
-            } else {
-                PLOG_DEBUG << logPrefix << "completed synchronously";
+
+                PLOG_ERROR << std::format("{} RESPONSE with unexpected return value, aborting", logPrefix);
+                break; // for ({ 0, maxIoctlAttempts })
             }
 
-            // Ensure some data was provided by the driver.
+            // I/O has been pended, wait for it synchronously, but in an interruptable manner.
+            PLOG_DEBUG << std::format("{} result was pended; waiting for data to become available", logPrefix);
+
+            static constexpr BOOL WaitSynchronously = TRUE;
+            ioResult = GetOverlappedResult(handleDriver.get(), &m_notificationOverlapped, &bytesRequired, WaitSynchronously);
+            lastError = GetLastError();
+            hr = HRESULT_FROM_WIN32(lastError);
+            PLOG_DEBUG << std::format("{} RESPONSE(ASYNC) completed={}, hr/err={:#08x}/{:#08x}", logPrefix, static_cast<bool>(ioResult), static_cast<uint32_t>(hr), lastError);
+
+            // Check if the request was completed.
+            if (!ioResult) {
+                if (lastError == ERROR_INSUFFICIENT_BUFFER || lastError == ERROR_MORE_DATA) {
+                    // Driver indicated buffer was too small and put required size in 'bytesRequired'. Retry with new size.
+                    const UWB_NOTIFICATION_DATA& notificationDataPartial = *reinterpret_cast<UWB_NOTIFICATION_DATA*>(std::data(uwbNotificationDataBuffer));
+                    bytesRequired = std::max(notificationDataPartial.size, static_cast<uint32_t>(minimumNotificationSize));
+                    PLOG_DEBUG << std::format("{} partial response received, size={}, type={}, buffer size/required={}/{}", logPrefix, notificationDataPartial.size, magic_enum::enum_name(notificationDataPartial.notificationType), std::size(uwbNotificationDataBuffer), bytesRequired);
+                    continue;
+                } else if (ERROR_DRIVER_PROCESS_TERMINATED || ERROR_INVALID_HANDLE) {
+                    handleDriver.reset();
+                }
+
+                PLOG_ERROR << std::format("{} unexpected GetOverlappedResult response received, hr/err={}/{}", logPrefix, static_cast<uint32_t>(hr), lastError);
+                break; // for({ 0, maxIoctlAttempts })
+            }
+
+            // The request was completed. Ensure some data was provided by the driver.
             if (uwbNotificationDataBuffer.empty()) {
-                PLOG_FATAL << logPrefix << "completed but provided an empty buffer";
+                PLOG_FATAL << std::format("{} completed but provided an empty buffer", logPrefix);
                 continue;
             }
 
@@ -784,7 +773,7 @@ UwbConnector::HandleNotifications(std::stop_token stopToken)
         }
     }
 
-    LOG_INFO << "uwb notification listener stopped for device " << DeviceName();
+    LOG_INFO << std::format("uwb notification listener stopped for device {}", DeviceName());
 }
 
 /**

--- a/windows/devices/uwb/UwbDevice.cxx
+++ b/windows/devices/uwb/UwbDevice.cxx
@@ -30,10 +30,6 @@ UwbDevice::UwbDevice(std::string deviceName) :
         OnDeviceStatusChanged(status);
         return false;
     });
-    m_onSessionStatusChangedCallback = std::make_shared<::uwb::UwbRegisteredDeviceEventCallbackTypes::OnSessionStatusChanged>([this](::uwb::protocol::fira::UwbSessionStatus status) {
-        OnSessionStatusChanged(status);
-        return false;
-    });
 }
 
 /* static */
@@ -182,7 +178,8 @@ UwbDevice::InitializeImpl()
     auto uwbConnector = std::make_shared<UwbConnector>(m_deviceName);
     m_uwbDeviceConnector = uwbConnector;
     m_uwbSessionConnector = uwbConnector;
-    m_callbacksToken = m_uwbDeviceConnector->RegisterDeviceEventCallbacks({ m_onStatusChangedCallback, m_onDeviceStatusChangedCallback, m_onSessionStatusChangedCallback });
+    m_callbacksToken = m_uwbDeviceConnector->RegisterDeviceEventCallbacks({ m_onStatusChangedCallback, m_onDeviceStatusChangedCallback });
+
     return true;
 }
 

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
@@ -188,6 +188,24 @@ private:
     DispatchCallbacks(::uwb::protocol::fira::UwbNotificationData uwbNotificationData);
 
     /**
+     * @brief Responsible for calling the relevant registered callbacks for the
+     * status changed event.
+     * 
+     * @param uwbStatus The status value.
+     */
+    void
+    OnStatusChanged(::uwb::protocol::fira::UwbStatus uwbStatus);
+
+    /**
+     * @brief Responsible for calling the relevant registered callbacks for the
+     * device status changed event.
+     * 
+     * @param uwbDeviceStatus The new device status.
+     */
+    void
+    OnDeviceStatusChanged(::uwb::protocol::fira::UwbStatusDevice uwbStatusDevice);
+
+    /**
      * @brief Responsible for calling the relevant registered callbacks for the session ended event.
      * This function assumes the caller is holding the m_eventCallbacksGate
      *

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
@@ -188,7 +188,7 @@ private:
     DispatchCallbacks(::uwb::protocol::fira::UwbNotificationData uwbNotificationData);
 
     /**
-     * @brief Response for calling the relevant registered callbacks for the session ended event.
+     * @brief Responsible for calling the relevant registered callbacks for the session ended event.
      * This function assumes the caller is holding the m_eventCallbacksGate
      *
      * @param sessionId The session identifier of the session that ended.
@@ -196,6 +196,17 @@ private:
      */
     void
     OnSessionEnded(uint32_t sessionId, ::uwb::UwbSessionEndReason sessionEndReason);
+
+    /**
+     * @brief TODO
+     * This function assumes the caller is holding the m_eventCallbacksGate
+     * 
+     * @param sessionId The session identifier of the session that changed status.
+     * @param sessionState The new state of the session.
+     * @param reasonCode The reason the session changed state. May not be present.
+     */
+    void
+    OnSessionStatusChanged(uint32_t sessionId, ::uwb::protocol::fira::UwbSessionState sessionState, std::optional<::uwb::protocol::fira::UwbSessionReasonCode> reasonCode);
 
     /**
      * @brief Internal function that prepares the notification for processing by the m_sessionEventCallbacks
@@ -235,6 +246,7 @@ private:
     // the following shared_mutex is used to protect access to everything regarding the registered callbacks
     mutable std::shared_mutex m_eventCallbacksGate;
     std::unordered_map<uint32_t, std::vector<std::shared_ptr<::uwb::OnSessionEndedToken>>> m_onSessionEndedCallbacks;
+    std::unordered_map<uint32_t, std::vector<std::shared_ptr<::uwb::OnSessionStatusChangedToken>>> m_onSessionStatusChangedCallbacks;
     std::unordered_map<uint32_t, std::vector<std::shared_ptr<::uwb::OnRangingStartedToken>>> m_onRangingStartedCallbacks;
     std::unordered_map<uint32_t, std::vector<std::shared_ptr<::uwb::OnRangingStoppedToken>>> m_onRangingStoppedCallbacks;
     std::unordered_map<uint32_t, std::vector<std::shared_ptr<::uwb::OnPeerPropertiesChangedToken>>> m_onPeerPropertiesChangedCallbacks;
@@ -242,7 +254,6 @@ private:
 
     std::vector<std::shared_ptr<::uwb::OnStatusChangedToken>> m_onStatusChangedCallbacks;
     std::vector<std::shared_ptr<::uwb::OnDeviceStatusChangedToken>> m_onDeviceStatusChangedCallbacks;
-    std::vector<std::shared_ptr<::uwb::OnSessionStatusChangedToken>> m_onSessionStatusChangedCallbacks;
 };
 } // namespace windows::devices::uwb
 

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbDevice.hxx
@@ -158,7 +158,6 @@ private:
     std::shared_ptr<IUwbSessionDdiConnector> m_uwbSessionConnector;
     std::shared_ptr<::uwb::UwbRegisteredDeviceEventCallbackTypes::OnStatusChanged> m_onStatusChangedCallback;
     std::shared_ptr<::uwb::UwbRegisteredDeviceEventCallbackTypes::OnDeviceStatusChanged> m_onDeviceStatusChangedCallback;
-    std::shared_ptr<::uwb::UwbRegisteredDeviceEventCallbackTypes::OnSessionStatusChanged> m_onSessionStatusChangedCallback;
     ::uwb::UwbRegisteredDeviceEventCallbackTokens m_callbacksToken;
 };
 } // namespace windows::devices::uwb

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
@@ -128,6 +128,7 @@ protected:
 private:
     std::shared_ptr<IUwbSessionDdiConnector> m_uwbSessionConnector;
     std::shared_ptr<::uwb::UwbRegisteredSessionEventCallbackTypes::OnSessionEnded> m_onSessionEndedCallback;
+    std::shared_ptr<::uwb::UwbRegisteredSessionEventCallbackTypes::OnSessionStatusChanged> m_onSessionStatusChangedCallback;
     std::shared_ptr<::uwb::UwbRegisteredSessionEventCallbackTypes::OnRangingStarted> m_onRangingStartedCallback;
     std::shared_ptr<::uwb::UwbRegisteredSessionEventCallbackTypes::OnRangingStopped> m_onRangingStoppedCallback;
     std::shared_ptr<::uwb::UwbRegisteredSessionEventCallbackTypes::OnPeerPropertiesChanged> m_onPeerPropertiesChangedCallback;

--- a/windows/tools/nocli/Main.cxx
+++ b/windows/tools/nocli/Main.cxx
@@ -71,13 +71,15 @@ enum class LogInstanceId {
 int
 main(int argc, char* argv[])
 try {
+    static plog::DebugOutputAppender<plog::TxtFormatter> debugAppender{};
     static plog::ColorConsoleAppender<plog::MessageOnlyFormatter> colorConsoleAppender{};
-    plog::init<static_cast<int>(LogInstanceId::Console)>(plog::info, &colorConsoleAppender);
-
     static plog::RollingFileAppender<plog::TxtFormatter> rollingFileAppender(logging::GetLogName("nocli").c_str());
-    plog::init<static_cast<int>(LogInstanceId::File)>(plog::verbose, &rollingFileAppender);
 
-    plog::init(plog::verbose).addAppender(plog::get<static_cast<int>(LogInstanceId::Console)>()).addAppender(plog::get<static_cast<int>(LogInstanceId::File)>());
+    plog::init<static_cast<int>(LogInstanceId::Console)>(plog::verbose, &colorConsoleAppender);
+    plog::init<static_cast<int>(LogInstanceId::File)>(plog::verbose, &rollingFileAppender);
+    plog::init(plog::verbose).addAppender(plog::get<static_cast<int>(LogInstanceId::Console)>())
+        .addAppender(plog::get<static_cast<int>(LogInstanceId::File)>())
+        .addAppender(&debugAppender);
 
     auto cliData = std::make_shared<nearobject::cli::NearObjectCliDataWindows>();
     auto cliHandler = std::make_shared<nearobject::cli::NearObjectCliHandlerWindows>();


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Simplify registering for session callbacks. The existing logic had the session status changed callback in the device event callbacks. The reasoning was that the `UwbDevice` would probably need to manage sessions even if the session clients went away. With the Windows WinRT API implementation, this is not done separately in the service and so isn't needed in the underlying library code.

### Technical Details

* Move `OnSessionStatusChanged` callback from `UwbDeviceEventCallbacks` to `UwbSessionEventCallbacks` and associated connector code handling tokens and registered callbacks.
* Remove code for processing synchronous IOCTL_UWB_NOTIFICATION I/O (both the simulator and UwbCx process everything async, so this was dead code, making notification processing more complex than it needed to be).
* Changed notification logging to use `std::format`, reducing some verbosity in both the code and the log messages.
* Improve and simplify log messages in `UwbConnector::HandleNotifications`.
* Add debug output appender to Windows `nocli` logging configuration, enabling all logs to be forwarded to an attached debugger, if present.

### Test Results

Ran some ad-hoc scenarios with the simulator driver and verified there were no regressions.

### Reviewer Focus

* Consider whether any of these changes could negatively affect the UwbCx.

### Future Work

* Convert all other Windows-specific logging code to use `std::format` and/or `std::vformat`.
* Simplify token registration code where the template-foo is extremely complex and probably at least 1 layer of indirection can be eliminated (this is inspired by some recent logs that show certain evens are not being raised correctly despite them being delivered by the driver).
 
### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
