### PR TITLE
Improve session logging

### DIFF
--- a/lib/uwb/UwbSession.cxx
+++ b/lib/uwb/UwbSession.cxx
@@ -43,7 +43,7 @@ UwbSession::SetEventCallbacks(std::weak_ptr<UwbSessionEventCallbacks> callbacks)
     }
 
     if (callbacks.lock() != nullptr) {
-        LOG_WARNING << "Session with id " << m_sessionId << " callbacks were replaced";
+        LOG_WARNING << "session " << m_sessionId << " callbacks were replaced";
     }
 }
 
@@ -77,7 +77,7 @@ UwbStatus
 UwbSession::TryAddControlee(UwbMacAddress controleeMacAddress)
 {
     std::scoped_lock peersLock{ m_peerGate };
-    PLOG_VERBOSE << "Session with id " << m_sessionId << " requesting to add controlee with mac address " << controleeMacAddress.ToString();
+    PLOG_VERBOSE << "session " << m_sessionId << " requesting to add controlee with mac address " << controleeMacAddress.ToString();
 
     auto uwbStatus = TryAddControleeImpl(std::move(controleeMacAddress));
     return uwbStatus;
@@ -86,14 +86,14 @@ UwbSession::TryAddControlee(UwbMacAddress controleeMacAddress)
 void
 UwbSession::Configure(const std::vector<protocol::fira::UwbApplicationConfigurationParameter> configParams)
 {
-    PLOG_VERBOSE << "configure session with id " << m_sessionId;
+    PLOG_VERBOSE << "session " << m_sessionId << " configure";
     try {
         ConfigureImpl(configParams);
     } catch (UwbException& uwbException) {
-        PLOG_ERROR << "error configuring session with id " << m_sessionId << ", status=" << ToString(uwbException.Status);
+        PLOG_ERROR << "error configuring session " << m_sessionId << ", status=" << ToString(uwbException.Status);
         throw uwbException;
     } catch (std::exception& e) {
-        PLOG_ERROR << "error configuring session with id " << m_sessionId << ", unexpected exception status=" << e.what();
+        PLOG_ERROR << "error configuring session " << m_sessionId << ", unexpected exception status=" << e.what();
         throw e;
     }
 }
@@ -101,7 +101,7 @@ UwbSession::Configure(const std::vector<protocol::fira::UwbApplicationConfigurat
 void
 UwbSession::StartRanging()
 {
-    PLOG_VERBOSE << "start ranging";
+    PLOG_VERBOSE << "session " << m_sessionId << " start ranging";
     bool rangingActiveExpected = false;
     const bool wasRangingInactive = m_rangingActive.compare_exchange_weak(rangingActiveExpected, true);
     if (wasRangingInactive) {
@@ -112,7 +112,7 @@ UwbSession::StartRanging()
 void
 UwbSession::StopRanging()
 {
-    PLOG_VERBOSE << "stop ranging";
+    PLOG_VERBOSE << "session " << m_sessionId << " stop ranging";
     bool rangingActiveExpected = true;
     const bool wasRangingActive = m_rangingActive.compare_exchange_weak(rangingActiveExpected, false);
     if (wasRangingActive) {
@@ -124,41 +124,41 @@ void
 UwbSession::InsertPeerImpl(const uwb::UwbMacAddress& peerAddress)
 {
     m_peers.insert(peerAddress);
-    PLOG_VERBOSE << "Session with id " << m_sessionId << " added peer via DDI with mac address " << peerAddress.ToString();
+    PLOG_VERBOSE << "session " << m_sessionId << " added peer via DDI with mac address " << peerAddress.ToString();
 }
 
 std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter>
 UwbSession::GetApplicationConfigurationParameters(std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameterType> requestedTypes)
 {
-    PLOG_VERBOSE << "get application configuration parameters";
+    PLOG_VERBOSE << "session " << m_sessionId << " get application configuration parameters";
     return GetApplicationConfigurationParametersImpl(std::move(requestedTypes));
 }
 
 void
 UwbSession::SetApplicationConfigurationParameters(std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> uwbApplicationConfigurationParameters)
 {
-    PLOG_VERBOSE << "set application configuration parameters";
+    PLOG_VERBOSE << "session " << m_sessionId << " set application configuration parameters";
     return SetApplicationConfigurationParametersImpl(std::move(uwbApplicationConfigurationParameters));
 }
 
 UwbSessionState
 UwbSession::GetSessionState()
 {
-    PLOG_VERBOSE << "get session state";
+    PLOG_VERBOSE << "session " << m_sessionId << " get state";
     return GetSessionStateImpl();
 }
 
 void
 UwbSession::Destroy()
 {
-    PLOG_VERBOSE << "destroy session with id " << m_sessionId;
+    PLOG_VERBOSE << "session " << m_sessionId << " destroy";
     DestroyImpl();
 }
 
 std::vector<uint8_t>
 UwbSession::GetOobDataObject()
 {
-    PLOG_VERBOSE << "get OOB data object";
+    PLOG_VERBOSE << "session " << m_sessionId << " get OOB data object";
     return GetOobDataObjectImpl();
 }
 
@@ -181,20 +181,20 @@ UwbSession::OnSessionStateChanged(std::shared_ptr<uwb::UwbSessionEventCallbacks>
 void
 UwbSession::OnSessionEnded(std::shared_ptr<uwb::UwbSessionEventCallbacks> callbacks, ::uwb::UwbSessionEndReason reason)
 {
-    PLOG_VERBOSE << "Session " << m_sessionId << " ended";
+    PLOG_VERBOSE << "session " << m_sessionId << " ended";
     callbacks->OnSessionEnded(this, reason);
 }
 
 void
 UwbSession::OnPeerPropertiesChanged(std::shared_ptr<uwb::UwbSessionEventCallbacks> callbacks, std::vector<::uwb::UwbPeer> peersChanged)
 {
-    PLOG_VERBOSE << "Session " << m_sessionId << " peer properties changed";
+    PLOG_VERBOSE << "session " << m_sessionId << " peer properties changed";
     callbacks->OnPeerPropertiesChanged(this, std::move(peersChanged));
 }
 
 void
 UwbSession::OnSessionMembershipChanged(std::shared_ptr<uwb::UwbSessionEventCallbacks> callbacks, std::vector<::uwb::UwbPeer> peersAdded, std::vector<::uwb::UwbPeer> peersRemoved)
 {
-    PLOG_VERBOSE << "Session " << m_sessionId << " session membership changed";
+    PLOG_VERBOSE << "session " << m_sessionId << " session membership changed";
     callbacks->OnSessionMembershipChanged(this, std::move(peersAdded), std::move(peersRemoved));
 }

--- a/lib/uwb/UwbSession.cxx
+++ b/lib/uwb/UwbSession.cxx
@@ -167,7 +167,7 @@ UwbSession::OnSessionStateChanged(std::shared_ptr<uwb::UwbSessionEventCallbacks>
 {
     const auto stateOld = m_state.exchange(state);
 
-    PLOG_VERBOSE << "Session " << m_sessionId << " changed state: " << magic_enum::enum_name(stateOld) << " --> " << magic_enum::enum_name(state);
+    PLOG_VERBOSE << "session " << m_sessionId << " changed state: " << magic_enum::enum_name(stateOld) << " --> " << magic_enum::enum_name(state);
 
     // Check if the session transitioned into the ranging state.
     if (stateOld != UwbSessionState::Active && state == UwbSessionState::Active) {

--- a/lib/uwb/include/uwb/UwbRegisteredCallbacks.hxx
+++ b/lib/uwb/include/uwb/UwbRegisteredCallbacks.hxx
@@ -27,18 +27,6 @@ using OnSessionEnded = std::function<bool(::uwb::UwbSessionEndReason reason)>;
 using OnSessionStatusChanged = std::function<bool(::uwb::protocol::fira::UwbSessionState, std::optional<::uwb::protocol::fira::UwbSessionReasonCode>)>;
 
 /**
- * @brief Invoked when active ranging starts.
- * @return true if this callback needs to be deregistered
- */
-using OnRangingStarted = std::function<bool()>;
-
-/**
- * @brief Invoked when active ranging stops.
- * @return true if this callback needs to be deregistered
- */
-using OnRangingStopped = std::function<bool()>;
-
-/**
  * @brief Invoked when the properties of a peer involved in the session
  * changes. This includes the spatial properties of the peer(s).
  *
@@ -106,18 +94,6 @@ struct UwbRegisteredSessionEventCallbacks
     std::weak_ptr<UwbRegisteredSessionEventCallbackTypes::OnSessionStatusChanged> OnStatusChanged;
 
     /**
-     * @brief Invoked when active ranging starts.
-     *
-     */
-    std::weak_ptr<UwbRegisteredSessionEventCallbackTypes::OnRangingStarted> OnRangingStarted;
-
-    /**
-     * @brief Invoked when active ranging stops.
-     *
-     */
-    std::weak_ptr<UwbRegisteredSessionEventCallbackTypes::OnRangingStopped> OnRangingStopped;
-
-    /**
      * @brief Invoked when the properties of a peer involved in the session
      * changes. This includes the spatial properties of the peer(s).
      *
@@ -171,8 +147,6 @@ struct UwbRegisteredSessionEventCallbackTokens
 {
     std::weak_ptr<RegisteredCallbackToken> OnSessionEndedToken;
     std::weak_ptr<RegisteredCallbackToken> OnSessionStatusChangedToken;
-    std::weak_ptr<RegisteredCallbackToken> OnRangingStartedToken;
-    std::weak_ptr<RegisteredCallbackToken> OnRangingStoppedToken;
     std::weak_ptr<RegisteredCallbackToken> OnPeerPropertiesChangedToken;
     std::weak_ptr<RegisteredCallbackToken> OnSessionMembershipChangedToken;
 };

--- a/lib/uwb/include/uwb/UwbSession.hxx
+++ b/lib/uwb/include/uwb/UwbSession.hxx
@@ -128,14 +128,6 @@ public:
     StopRanging();
 
     /**
-     * @brief Set the Session Status object. NOTE, this function is NOT thread safe
-     *
-     * @param status the new status
-     */
-    void
-    SetSessionStatus(const uwb::protocol::fira::UwbSessionStatus& status);
-
-    /**
      * @brief Sentinel value indicating that all supported application
      * configuration parameters should be requested.
      */
@@ -213,6 +205,47 @@ protected:
             return std::dynamic_pointer_cast<TDerived>(m_device.lock());
         }
     }
+
+    /**
+     * @brief Invoked when the session ends.
+     * 
+     * @param callbacks A resolved session event callback instance.
+     * @param reason The reason the session ended.
+     */
+    virtual void
+    OnSessionEnded(std::shared_ptr<uwb::UwbSessionEventCallbacks> callbacks, ::uwb::UwbSessionEndReason reason);
+
+    /**
+     * @brief Invoked when the session state changes. 
+     * 
+     * @param callbacks A resolved session event callback instance.
+     * @param state The new state of the session.
+     * @param reasonCode The reason the session changed state. Optional.
+     */
+    virtual void
+    OnSessionStateChanged(std::shared_ptr<uwb::UwbSessionEventCallbacks> callbacks, ::uwb::protocol::fira::UwbSessionState state, std::optional<::uwb::protocol::fira::UwbSessionReasonCode> reasonCode);
+
+    /**
+     * @brief Invoked when the properties of a peer involved in the session
+     * changes. This includes the spatial properties of the peer(s).
+     * 
+     * @param callbacks A resolved session event callback instance.
+     * @param peersChanged A list of peers whose properties changed.
+     */
+    virtual void
+    OnPeerPropertiesChanged(std::shared_ptr<uwb::UwbSessionEventCallbacks> callbacks, std::vector<::uwb::UwbPeer> peersChanged);
+
+    /**
+     * @brief Invoked when membership of one or more near peers involved in
+     * the session is changed. This can occur when peer members are either
+     * added to or removed from the session.
+     * 
+     * @param callbacks A resolved session event callback instance.
+     * @param peersAdded A list of peers that were added to the session.
+     * @param peersRemoved A list of peers that were removed from the session.
+     */
+    virtual void
+    OnSessionMembershipChanged(std::shared_ptr<uwb::UwbSessionEventCallbacks> callbacks, std::vector<::uwb::UwbPeer> peersAdded, std::vector<::uwb::UwbPeer> peersRemoved);
 
 private:
     /**
@@ -296,7 +329,7 @@ private:
 protected:
     uwb::protocol::fira::DeviceType m_deviceType{ uwb::protocol::fira::DeviceType::Controller };
     uint32_t m_sessionId{ 0 };
-    uwb::protocol::fira::UwbSessionStatus m_sessionStatus{};
+    uwb::protocol::fira::UwbSessionState m_state{ uwb::protocol::fira::UwbSessionState::Deinitialized };
     UwbMacAddressType m_uwbMacAddressType{ UwbMacAddressType::Extended };
     UwbMacAddress m_uwbMacAddressSelf;
     std::atomic<bool> m_rangingActive{ false };

--- a/lib/uwb/include/uwb/UwbSession.hxx
+++ b/lib/uwb/include/uwb/UwbSession.hxx
@@ -329,7 +329,7 @@ private:
 protected:
     uwb::protocol::fira::DeviceType m_deviceType{ uwb::protocol::fira::DeviceType::Controller };
     uint32_t m_sessionId{ 0 };
-    uwb::protocol::fira::UwbSessionState m_state{ uwb::protocol::fira::UwbSessionState::Deinitialized };
+    std::atomic<uwb::protocol::fira::UwbSessionState> m_state{ uwb::protocol::fira::UwbSessionState::Deinitialized };
     UwbMacAddressType m_uwbMacAddressType{ UwbMacAddressType::Extended };
     UwbMacAddress m_uwbMacAddressSelf;
     std::atomic<bool> m_rangingActive{ false };

--- a/lib/uwb/include/uwb/UwbSessionEventCallbacks.hxx
+++ b/lib/uwb/include/uwb/UwbSessionEventCallbacks.hxx
@@ -62,16 +62,6 @@ struct UwbSessionEventCallbacks
     OnSessionEnded(UwbSession *session, UwbSessionEndReason reason) = 0;
 
     /**
-     * @brief Invoked when the session changes state.
-     *
-     * @param session The session for which the event occurred.
-     * @param state The new state of the session.
-     * @param reasonCode The reason the session changed state. Optional.
-     */
-    virtual void
-    OnSessionStatusChanged(UwbSession *session, ::uwb::protocol::fira::UwbSessionState state, std::optional<::uwb::protocol::fira::UwbSessionReasonCode> reasonCode) = 0;
-
-    /**
      * @brief Invoked when active ranging starts.
      *
      * @param session The session for which the event occurred.

--- a/tools/cli/NearObjectCliUwbSessionEventCallbacks.cxx
+++ b/tools/cli/NearObjectCliUwbSessionEventCallbacks.cxx
@@ -1,5 +1,4 @@
 
-#include <iomanip>
 #include <iostream>
 #include <nearobject/cli/NearObjectCliUwbSessionEventCallbacks.hxx>
 #include <notstd/tostring.hxx>
@@ -14,46 +13,10 @@ NearObjectCliUwbSessionEventCallbacks::NearObjectCliUwbSessionEventCallbacks(std
     m_onSessionEndedCallback(std::move(onSessionEndedCallback))
 {}
 
-namespace
-{
-/**
- * @brief Helper stream manipulator to add a common log prefix.
- */
-class LogPrefix
-{
-public:
-    LogPrefix(uint32_t sessionId) :
-        m_sessionId(sessionId) {}
-
-    std::ostream&
-    operator()(std::ostream& out) const
-    {
-        return out << "[Session " << std::setw(10) << std::setfill(' ') << std::right << m_sessionId << "]: ";
-    }
-
-private:
-    uint32_t m_sessionId;
-};
-
-/**
- * @brief Stream specialization taking a LogPrefix argument, allowing
- * std::ostream << LogPrefix(value).
- *
- * @param out The stream to manipulate.
- * @param logPrefix The instance to manipulate the stream.
- * @return std::ostream&
- */
-std::ostream&
-operator<<(std::ostream& out, LogPrefix logPrefix)
-{
-    return logPrefix(out);
-}
-} // namespace
-
 void
 NearObjectCliUwbSessionEventCallbacks::OnSessionEnded(::uwb::UwbSession* session, ::uwb::UwbSessionEndReason reason)
 {
-    PLOG_VERBOSE << LogPrefix(session->GetId()) << "Session Ended (" << magic_enum::enum_name(reason) << ")";
+    PLOG_VERBOSE << "Session " << session->GetId() << " ended (" << magic_enum::enum_name(reason) << ")";
 
     if (m_onSessionEndedCallback) {
         m_onSessionEndedCallback();
@@ -63,19 +26,19 @@ NearObjectCliUwbSessionEventCallbacks::OnSessionEnded(::uwb::UwbSession* session
 void
 NearObjectCliUwbSessionEventCallbacks::OnRangingStarted(::uwb::UwbSession* session)
 {
-    PLOG_VERBOSE << LogPrefix(session->GetId()) << "Ranging Started";
+    PLOG_VERBOSE << "Session " << session->GetId() << " ranging started";
 }
 
 void
 NearObjectCliUwbSessionEventCallbacks::OnRangingStopped(::uwb::UwbSession* session)
 {
-    PLOG_VERBOSE << LogPrefix(session->GetId()) << "Ranging Stopped";
+    PLOG_VERBOSE << "Session " << session->GetId() << " ranging stopped";
 }
 
 void
 NearObjectCliUwbSessionEventCallbacks::OnPeerPropertiesChanged(::uwb::UwbSession* session, std::vector<::uwb::UwbPeer> peersChanged)
 {
-    PLOG_VERBOSE << LogPrefix(session->GetId()) << "Peer Properties Changed";
+    PLOG_VERBOSE << "Session " << session->GetId() << " peer properties changed";
 
     for (const auto& peer : peersChanged) {
         PLOG_VERBOSE << " " << peer.ToString();
@@ -85,7 +48,7 @@ NearObjectCliUwbSessionEventCallbacks::OnPeerPropertiesChanged(::uwb::UwbSession
 void
 NearObjectCliUwbSessionEventCallbacks::OnSessionMembershipChanged(::uwb::UwbSession* session, std::vector<::uwb::UwbPeer> peersAdded, std::vector<::uwb::UwbPeer> peersRemoved)
 {
-    PLOG_VERBOSE << LogPrefix(session->GetId()) << "Membership Changed";
+    PLOG_VERBOSE << "Session " << session->GetId() << " session membership changed";
 
     for (const auto& peer : peersAdded) {
         PLOG_VERBOSE << "+" << peer.GetAddress().ToString();

--- a/tools/cli/NearObjectCliUwbSessionEventCallbacks.cxx
+++ b/tools/cli/NearObjectCliUwbSessionEventCallbacks.cxx
@@ -61,13 +61,6 @@ NearObjectCliUwbSessionEventCallbacks::OnSessionEnded(::uwb::UwbSession* session
 }
 
 void
-NearObjectCliUwbSessionEventCallbacks::OnSessionStatusChanged(::uwb::UwbSession* session, ::uwb::protocol::fira::UwbSessionState state, std::optional<::uwb::protocol::fira::UwbSessionReasonCode> reasonCode)
-{
-    const auto reasonStr = reasonCode.has_value() ? magic_enum::enum_name(reasonCode.value()) : "None";
-    PLOG_VERBOSE << LogPrefix(session->GetId()) << "Session State Changed to '" << magic_enum::enum_name(state) << "' (Reason=" << reasonStr << ")";
-}
-
-void
 NearObjectCliUwbSessionEventCallbacks::OnRangingStarted(::uwb::UwbSession* session)
 {
     PLOG_VERBOSE << LogPrefix(session->GetId()) << "Ranging Started";

--- a/tools/cli/include/nearobject/cli/NearObjectCliUwbSessionEventCallbacks.hxx
+++ b/tools/cli/include/nearobject/cli/NearObjectCliUwbSessionEventCallbacks.hxx
@@ -31,16 +31,6 @@ struct NearObjectCliUwbSessionEventCallbacks :
     OnSessionEnded(::uwb::UwbSession *session, ::uwb::UwbSessionEndReason reason) override;
 
     /**
-     * @brief Invoked when the session changes state.
-     *
-     * @param session The session for which the event occurred.
-     * @param state The new state of the session.
-     * @param reasonCode The reason the session changed state. Optional.
-     */
-    void
-    OnSessionStatusChanged(::uwb::UwbSession *session, ::uwb::protocol::fira::UwbSessionState state, std::optional<::uwb::protocol::fira::UwbSessionReasonCode> reasonCode) override;
-
-    /**
      * @brief Invoked when active ranging starts.
      *
      * @param session The session for which the event occurred.

--- a/windows/devices/uwb/UwbConnector.cxx
+++ b/windows/devices/uwb/UwbConnector.cxx
@@ -1228,13 +1228,14 @@ UwbConnector::DeregisterEventCallback(std::weak_ptr<::uwb::RegisteredCallbackTok
     if (!tokenShared) {
         return;
     }
+
     std::lock_guard eventCallbacksLockExclusive{ m_eventCallbacksGate };
 
     auto callbacksPresentPrior = CallbacksPresent();
 
     tokenShared->Deregister();
 
-    if ((!CallbacksPresent()) && callbacksPresentPrior) {
+    if (!CallbacksPresent() && callbacksPresentPrior) {
         NotificationListenerStop();
     }
 }

--- a/windows/devices/uwb/UwbConnector.cxx
+++ b/windows/devices/uwb/UwbConnector.cxx
@@ -34,7 +34,7 @@ struct RegisteredCallbackToken
      */
     RegisteredCallbackToken(std::function<void(RegisteredCallbackToken*)> deregister) :
         Deregister([this, deregister = std::move(deregister)]() {
-            if (not deregister) {
+            if (!deregister) {
                 PLOG_WARNING << "empty callback token";
                 return;
             }
@@ -795,11 +795,11 @@ InvokeCallbacks(std::vector<std::shared_ptr<TokenT>>& tokens, ArgTs&&... args)
         auto token = *it;
         auto callbackWeak = token->Callback;
         auto callbackShared = callbackWeak.lock();
-        if (not callbackShared) {
+        if (!callbackShared) {
             it = tokens.erase(it);
         } else {
             auto callback = *callbackShared;
-            if (not callback) {
+            if (!callback) {
                 it = tokens.erase(it);
             } else {
                 auto remove = callback(std::forward<ArgTs>(args)...);
@@ -833,7 +833,7 @@ InvokeSessionCallbacks(std::unordered_map<uint32_t, std::vector<std::shared_ptr<
     }
     auto& tokens = node.mapped();
     InvokeCallbacks(tokens, std::forward<ArgTs>(args)...);
-    if (not tokens.empty()) {
+    if (!tokens.empty()) {
         sessionMap.insert(std::move(node));
     }
 }
@@ -995,7 +995,7 @@ bool
 DeregisterSessionEventCallback(::uwb::RegisteredCallbackToken* token, std::unordered_map<uint32_t, std::vector<std::shared_ptr<T>>>& tokensMap)
 {
     auto callback = dynamic_cast<T*>(token);
-    if (not callback) {
+    if (!callback) {
         return false;
     }
     auto sessionId = callback->SessionId;
@@ -1031,7 +1031,7 @@ bool
 DeregisterDeviceEventCallback(::uwb::RegisteredCallbackToken* token, std::vector<std::shared_ptr<T>>& tokens)
 {
     auto callback = dynamic_cast<T*>(token);
-    if (not callback) {
+    if (!callback) {
         return false;
     }
 
@@ -1060,11 +1060,11 @@ GetToken(::uwb::UwbRegisteredDeviceEventCallbacks callbacks, std::function<std::
 {
     auto callbackWeak = accessor(callbacks);
     auto callbackShared = callbackWeak.lock();
-    if (not callbackShared) {
+    if (!callbackShared) {
         return std::shared_ptr<::uwb::RegisteredDeviceCallbackToken>();
     }
     auto callback = *callbackShared;
-    if (not callback) {
+    if (!callback) {
         return std::shared_ptr<::uwb::RegisteredDeviceCallbackToken>();
     }
     return tokenize(callbackWeak);
@@ -1074,7 +1074,7 @@ GetToken(::uwb::UwbRegisteredDeviceEventCallbacks callbacks, std::function<std::
 UwbConnector::RegisterDeviceEventCallbacks(::uwb::UwbRegisteredDeviceEventCallbacks callbacks)
 {
     std::lock_guard eventCallbacksLockExclusive{ m_eventCallbacksGate };
-    bool noCallbacksPrior = not CallbacksPresent();
+    bool noCallbacksPrior = !CallbacksPresent();
 
     auto OnStatusChangedToken = GetToken<::uwb::UwbRegisteredDeviceEventCallbackTypes::OnStatusChanged>(
         callbacks, [](auto&& callbackStruct) {
@@ -1100,7 +1100,7 @@ UwbConnector::RegisterDeviceEventCallbacks(::uwb::UwbRegisteredDeviceEventCallba
             return token;
         });
 
-    if (noCallbacksPrior and CallbacksPresent()) {
+    if (noCallbacksPrior && CallbacksPresent()) {
         NotificationListenerStart();
     }
 
@@ -1148,11 +1148,11 @@ GetToken(uint32_t sessionId, ::uwb::UwbRegisteredSessionEventCallbacks callbacks
 {
     auto callbackWeak = accessor(callbacks);
     auto callbackShared = callbackWeak.lock();
-    if (not callbackShared) {
+    if (!callbackShared) {
         return std::shared_ptr<::uwb::RegisteredSessionCallbackToken>();
     }
     auto callback = *callbackShared;
-    if (not callback) {
+    if (!callback) {
         return std::shared_ptr<::uwb::RegisteredSessionCallbackToken>();
     }
     return tokenize(sessionId, callbackWeak);
@@ -1162,7 +1162,7 @@ GetToken(uint32_t sessionId, ::uwb::UwbRegisteredSessionEventCallbacks callbacks
 UwbConnector::RegisterSessionEventCallbacks(uint32_t sessionId, ::uwb::UwbRegisteredSessionEventCallbacks callbacks)
 {
     std::lock_guard eventCallbacksLockExclusive{ m_eventCallbacksGate };
-    bool noCallbacksPrior = not CallbacksPresent();
+    bool noCallbacksPrior = !CallbacksPresent();
 
     auto OnSessionEndedToken = GetToken<::uwb::UwbRegisteredSessionEventCallbackTypes::OnSessionEnded>(
         sessionId, callbacks, [](auto&& callbackStruct) {

--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -29,7 +29,8 @@ UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<::uwb::UwbDevice> devic
                 PLOG_WARNING << "missing session event callback for UwbSessionEndReason, skipping";
                 return true;
             }
-            callbacks->OnSessionEnded(this, reason);
+
+            ::uwb::UwbSession::OnSessionEnded(callbacks, reason);
             return false;
         });
     m_onSessionStatusChangedCallback =
@@ -39,7 +40,8 @@ UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<::uwb::UwbDevice> devic
                 PLOG_WARNING << "missing session event callback for session status changed, skipping";
                 return true;
             }
-            callbacks->OnSessionStatusChanged(this, state, reasonCode);
+
+            ::uwb::UwbSession::OnSessionStateChanged(callbacks, state, reasonCode);
             return false;
         });
     m_onPeerPropertiesChangedCallback =
@@ -49,7 +51,8 @@ UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<::uwb::UwbDevice> devic
                 PLOG_WARNING << "missing session event callback for ranging data, skipping";
                 return true;
             }
-            callbacks->OnPeerPropertiesChanged(this, peersChanged);
+            
+            ::uwb::UwbSession::OnPeerPropertiesChanged(callbacks, std::move(peersChanged));
             return false;
         });
     m_onSessionMembershipChangedCallback =
@@ -59,7 +62,8 @@ UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<::uwb::UwbDevice> devic
                 PLOG_WARNING << "missing session event callback for peer list changes, skipping";
                 return true;
             }
-            callbacks->OnSessionMembershipChanged(this, peersAdded, peersRemoved);
+
+            ::uwb::UwbSession::OnSessionMembershipChanged(callbacks, std::move(peersAdded), std::move(peersRemoved));
             return false;
         });
 

--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -42,25 +42,6 @@ UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<::uwb::UwbDevice> devic
             callbacks->OnSessionStatusChanged(this, state, reasonCode);
             return false;
         });
-    m_onRangingStartedCallback = std::make_shared<::uwb::UwbRegisteredSessionEventCallbackTypes::OnRangingStarted>([this]() {
-        auto callbacks = ResolveEventCallbacks();
-        if (callbacks == nullptr) {
-            PLOG_WARNING << "missing session event callback for ranging started, skipping";
-            return true;
-        }
-        callbacks->OnRangingStarted(this);
-        return false;
-    });
-    m_onRangingStoppedCallback =
-        std::make_shared<::uwb::UwbRegisteredSessionEventCallbackTypes::OnRangingStopped>([this]() {
-            auto callbacks = ResolveEventCallbacks();
-            if (callbacks == nullptr) {
-                PLOG_WARNING << "missing session event callback for ranging stopped, skipping";
-                return true;
-            }
-            callbacks->OnRangingStopped(this);
-            return false;
-        });
     m_onPeerPropertiesChangedCallback =
         std::make_shared<::uwb::UwbRegisteredSessionEventCallbackTypes::OnPeerPropertiesChanged>([this](std::vector<::uwb::UwbPeer> peersChanged) {
             auto callbacks = ResolveEventCallbacks();
@@ -82,7 +63,7 @@ UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<::uwb::UwbDevice> devic
             return false;
         });
 
-    m_registeredCallbacksTokens = m_uwbSessionConnector->RegisterSessionEventCallbacks(m_sessionId, { m_onSessionEndedCallback, m_onSessionStatusChangedCallback, m_onRangingStartedCallback, m_onRangingStoppedCallback, m_onPeerPropertiesChangedCallback, m_onSessionMembershipChangedCallback });
+    m_registeredCallbacksTokens = m_uwbSessionConnector->RegisterSessionEventCallbacks(m_sessionId, { m_onSessionEndedCallback, m_onSessionStatusChangedCallback, m_onPeerPropertiesChangedCallback, m_onSessionMembershipChangedCallback });
 }
 
 UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<::uwb::UwbDevice> device, std::shared_ptr<IUwbSessionDdiConnector> uwbSessionConnector, ::uwb::protocol::fira::DeviceType deviceType) :

--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -1,5 +1,6 @@
 
 #include <algorithm>
+#include <format>
 #include <ios>
 #include <memory>
 #include <numeric>
@@ -23,10 +24,10 @@ UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<::uwb::UwbDevice> devic
     m_uwbSessionConnector(std::move(uwbSessionConnector))
 {
     m_onSessionEndedCallback =
-        std::make_shared<::uwb::UwbRegisteredSessionEventCallbackTypes::OnSessionEnded>([this](::uwb::UwbSessionEndReason reason) {
+        std::make_shared<::uwb::UwbRegisteredSessionEventCallbackTypes::OnSessionEnded>([this, sessionId](::uwb::UwbSessionEndReason reason) {
             auto callbacks = ResolveEventCallbacks();
             if (callbacks == nullptr) {
-                PLOG_WARNING << "missing session event callback for UwbSessionEndReason, skipping";
+                PLOG_WARNING << std::format("session {}: missing session event callback for UwbSessionEndReason, skipping", sessionId);
                 return true;
             }
 
@@ -34,10 +35,10 @@ UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<::uwb::UwbDevice> devic
             return false;
         });
     m_onSessionStatusChangedCallback =
-        std::make_shared<::uwb::UwbRegisteredSessionEventCallbackTypes::OnSessionStatusChanged>([this](::uwb::protocol::fira::UwbSessionState state, std::optional<::uwb::protocol::fira::UwbSessionReasonCode> reasonCode) {
+        std::make_shared<::uwb::UwbRegisteredSessionEventCallbackTypes::OnSessionStatusChanged>([this, sessionId](::uwb::protocol::fira::UwbSessionState state, std::optional<::uwb::protocol::fira::UwbSessionReasonCode> reasonCode) {
             auto callbacks = ResolveEventCallbacks();
             if (callbacks == nullptr) {
-                PLOG_WARNING << "missing session event callback for session status changed, skipping";
+                PLOG_WARNING << std::format("session {}: missing session event callback for session status changed, skipping", sessionId);
                 return true;
             }
 
@@ -45,10 +46,10 @@ UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<::uwb::UwbDevice> devic
             return false;
         });
     m_onPeerPropertiesChangedCallback =
-        std::make_shared<::uwb::UwbRegisteredSessionEventCallbackTypes::OnPeerPropertiesChanged>([this](std::vector<::uwb::UwbPeer> peersChanged) {
+        std::make_shared<::uwb::UwbRegisteredSessionEventCallbackTypes::OnPeerPropertiesChanged>([this, sessionId](std::vector<::uwb::UwbPeer> peersChanged) {
             auto callbacks = ResolveEventCallbacks();
             if (callbacks == nullptr) {
-                PLOG_WARNING << "missing session event callback for ranging data, skipping";
+                PLOG_WARNING << std::format("session {}: missing session event callback for ranging data, skipping", sessionId);
                 return true;
             }
             
@@ -56,10 +57,10 @@ UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<::uwb::UwbDevice> devic
             return false;
         });
     m_onSessionMembershipChangedCallback =
-        std::make_shared<::uwb::UwbRegisteredSessionEventCallbackTypes::OnSessionMembershipChanged>([this](std::vector<::uwb::UwbPeer> peersAdded, std::vector<::uwb::UwbPeer> peersRemoved) {
+        std::make_shared<::uwb::UwbRegisteredSessionEventCallbackTypes::OnSessionMembershipChanged>([this, sessionId](std::vector<::uwb::UwbPeer> peersAdded, std::vector<::uwb::UwbPeer> peersRemoved) {
             auto callbacks = ResolveEventCallbacks();
             if (callbacks == nullptr) {
-                PLOG_WARNING << "missing session event callback for peer list changes, skipping";
+                PLOG_WARNING << std::format("session {}: missing session event callback for peer list changes, skipping", sessionId);
                 return true;
             }
 
@@ -83,33 +84,31 @@ UwbSession::GetUwbSessionConnector() noexcept
 void
 UwbSession::ConfigureImpl(const std::vector<::uwb::protocol::fira::UwbApplicationConfigurationParameter> configParams)
 {
-    PLOG_VERBOSE << "ConfigureImpl";
-
     UwbSessionType sessionType = UwbSessionType::RangingSession;
 
     // Request a new session from the driver.
     auto sessionInitResultFuture = m_uwbSessionConnector->SessionInitialize(m_sessionId, sessionType);
     if (!sessionInitResultFuture.valid()) {
-        PLOG_ERROR << "failed to initialize session";
+        PLOG_ERROR << std::format("session {}: failed to initialize", m_sessionId);
         throw UwbException(UwbStatusGeneric::Rejected);
     }
 
     UwbStatus statusSessionInit = sessionInitResultFuture.get();
     if (!IsUwbStatusOk(statusSessionInit)) {
-        LOG_ERROR << "failed to initialize session, " << ToString(statusSessionInit);
+        LOG_ERROR << std::format("session {}: failed to initialize, status={}", m_sessionId, ToString(statusSessionInit));
         throw UwbException(statusSessionInit);
     }
 
     // Set the application configuration parameters for the session.
     auto setAppConfigParamsFuture = m_uwbSessionConnector->SetApplicationConfigurationParameters(m_sessionId, configParams);
     if (!setAppConfigParamsFuture.valid()) {
-        PLOG_ERROR << "failed to set the application configuration parameters";
+        PLOG_ERROR << std::format("session {}: failed to set the application configuration parameters", m_sessionId);
         throw UwbException(UwbStatusGeneric::Rejected);
     }
 
     auto [statusSetParameters, resultSetParameters] = setAppConfigParamsFuture.get();
     if (!IsUwbStatusOk(statusSetParameters)) {
-        LOG_ERROR << "failed to set application configuration parameters, " << ToString(statusSetParameters);
+        LOG_ERROR << std::format("session {}: failed to set application configuration parameters, status={}", m_sessionId, ToString(statusSetParameters));
         throw UwbException(statusSetParameters);
     }
 
@@ -119,7 +118,7 @@ UwbSession::ConfigureImpl(const std::vector<::uwb::protocol::fira::UwbApplicatio
     //       accessor that just returns the vector entries with statusSetParameter != Ok
     for (const auto &[statusSetParameter, applicationConfigurationParameterType] : resultSetParameters) {
         if (!IsUwbStatusOk(statusSetParameter)) {
-            LOG_ERROR << "failed to set application configuration parameter " << magic_enum::enum_name(applicationConfigurationParameterType) << ", status=" << ToString(statusSetParameter);
+            LOG_ERROR << std::format("session {}: failed to set application configuration parameter {}, status={}", m_sessionId, magic_enum::enum_name(applicationConfigurationParameterType), ToString(statusSetParameter));
         }
     }
 }
@@ -132,7 +131,7 @@ UwbSession::StartRangingImpl()
     uint32_t sessionId = GetId();
     auto resultFuture = m_uwbSessionConnector->SessionRangingStart(sessionId);
     if (!resultFuture.valid()) {
-        PLOG_ERROR << "failed to start ranging for session id " << sessionId;
+        PLOG_ERROR << std::format("session {}: failed to start ranging", sessionId);
         status = UwbStatusGeneric::Failed;
         return; /* TODO: uwbStatus */
     }
@@ -140,7 +139,7 @@ UwbSession::StartRangingImpl()
     try {
         status = resultFuture.get();
     } catch (std::exception &e) {
-        PLOG_ERROR << "caught exception attempting to start ranging for session id " << sessionId << "(" << e.what() << ")";
+        PLOG_ERROR << "session {}: caught exception attempting to start ranging, error={}", sessionId, e.what();
         status = UwbStatusGeneric::Failed;
     }
 
@@ -155,7 +154,7 @@ UwbSession::StopRangingImpl()
     uint32_t sessionId = GetId();
     auto resultFuture = m_uwbSessionConnector->SessionRangingStop(sessionId);
     if (!resultFuture.valid()) {
-        PLOG_ERROR << "failed to stop ranging for session id " << sessionId;
+        PLOG_ERROR << std::format("session {}: failed to stop ranging", sessionId);
         status = UwbStatusGeneric::Failed;
         return; /* TODO: uwbStatus */
     }
@@ -163,7 +162,7 @@ UwbSession::StopRangingImpl()
     try {
         status = resultFuture.get();
     } catch (std::exception &e) {
-        PLOG_ERROR << "caught exception attempting to stop ranging for session id " << sessionId << "(" << e.what() << ")";
+        PLOG_ERROR << std::format("session {}: caught exception attempting to stop ranging, error={}", sessionId, e.what());
         status = UwbStatusGeneric::Failed;
     }
 
@@ -171,28 +170,29 @@ UwbSession::StopRangingImpl()
 }
 
 UwbStatus
-UwbSession::TryAddControleeImpl([[maybe_unused]] ::uwb::UwbMacAddress controleeMacAddress)
+UwbSession::TryAddControleeImpl(::uwb::UwbMacAddress controleeMacAddress)
 {
-    PLOG_VERBOSE << "TryAddControleeImpl";
     if (!m_uwbSessionConnector) {
-        PLOG_WARNING << "No associated connector";
+        PLOG_WARNING << std::format("session {}: no associated connector", m_sessionId);
         return UwbStatusGeneric::Failed;
     }
 
     auto params = GetApplicationConfigurationParameters({ UwbApplicationConfigurationParameterType::DestinationMacAddresses });
     if (std::size(params) != 1) {
-        throw std::runtime_error("GetApplicationConfigurationParameters() for 1 parameter did not return exactly 1 result. This is a bug!");
+        throw std::runtime_error(std::format("session {}: GetApplicationConfigurationParameters() for 1 parameter did not return exactly 1 result. This is a bug!", m_sessionId));
     }
+
     auto macAddresses = std::get<std::unordered_set<::uwb::UwbMacAddress>>(params.front().Value);
     auto [_, inserted] = macAddresses.insert(controleeMacAddress);
     if (!inserted) {
-        PLOG_INFO << "controleeMacAddress already added, skipping";
+        PLOG_INFO << std::format("session {}: controleeMacAddress already added, skipping", m_sessionId);
         return UwbStatusSession::AddressAlreadyPresent;
     }
+
     UwbApplicationConfigurationParameter dstMacAddresses{ .Type = UwbApplicationConfigurationParameterType::DestinationMacAddresses, .Value = macAddresses };
     UwbApplicationConfigurationParameter numControlees{ .Type = UwbApplicationConfigurationParameterType::NumberOfControlees, .Value = static_cast<uint8_t>(std::size(macAddresses)) };
 
-    SetApplicationConfigurationParameters({ numControlees, dstMacAddresses });
+    SetApplicationConfigurationParameters({ std::move(numControlees), std::move(dstMacAddresses ) });
 
     return UwbStatusGeneric::Ok;
 }
@@ -204,7 +204,7 @@ UwbSession::GetApplicationConfigurationParametersImpl(std::vector<::uwb::protoco
 
     auto resultFuture = m_uwbSessionConnector->GetApplicationConfigurationParameters(sessionId, requestedTypes);
     if (!resultFuture.valid()) {
-        PLOG_ERROR << "failed to obtain application configuration parameters for session id " << sessionId;
+        PLOG_ERROR << std::format("session {}: failed to obtain application configuration parameters", sessionId);
         throw UwbException(UwbStatusGeneric::Failed);
     }
 
@@ -215,10 +215,10 @@ UwbSession::GetApplicationConfigurationParametersImpl(std::vector<::uwb::protoco
         }
         return applicationConfigurationParameters;
     } catch (UwbException &uwbException) {
-        PLOG_ERROR << "caught exception attempting to obtain application configuration parameters for session id " << sessionId << " (" << ToString(uwbException.Status) << ")";
+        PLOG_ERROR << std::format("session {}: caught exception attempting to obtain application configuration parameters, status={}", sessionId, ToString(uwbException.Status));
         throw uwbException;
     } catch (std::exception &e) {
-        PLOG_ERROR << "caught unexpected exception attempting to obtain application configuration parameters for session id " << sessionId << " (" << e.what() << ")";
+        PLOG_ERROR << std::format("session {}: caught unexpected exception attempting to obtain application configuration parameters, error={}", sessionId, e.what());
         throw e;
     }
 }
@@ -237,10 +237,10 @@ UwbSession::SetApplicationConfigurationParametersImpl(std::vector<::uwb::protoco
             throw UwbException(uwbStatus);
         }
     } catch (UwbException &uwbException) {
-        PLOG_ERROR << "caught exception attempting to set application configuration parameters for session id " << sessionId << " (" << ToString(uwbException.Status) << ")";
+        PLOG_ERROR << std::format("session {}: caught exception attempting to set application configuration parameters, status={}", sessionId, ToString(uwbException.Status));
         throw uwbException;
     } catch (std::exception &e) {
-        PLOG_ERROR << "caught unexpected exception attempting to obtain application configuration parameters for session id " << sessionId << " (" << e.what() << ")";
+        PLOG_ERROR << std::format("session {}: caught unexpected exception attempting to obtain application configuration parameters, error={}", sessionId, e.what());
         throw e;
     }
 }
@@ -263,10 +263,10 @@ UwbSession::GetSessionStateImpl()
         }
         return sessionState;
     } catch (UwbException &uwbException) {
-        PLOG_ERROR << "caught exception attempting to obtain session state for session id " << sessionId << " (" << ToString(uwbException.Status) << ")";
+        PLOG_ERROR << std::format("session {}: caught exception attempting to obtain session state, status={}", sessionId, ToString(uwbException.Status));
         throw uwbException;
     } catch (std::exception &e) {
-        PLOG_ERROR << "caught unexpected exception attempting to obtain session state for session id " << sessionId << " (" << e.what() << ")";
+        PLOG_ERROR << std::format("session {}: caught unexpected exception attempting to obtain session state, error={}", sessionId, e.what());
         throw e;
     }
 }
@@ -277,17 +277,17 @@ UwbSession::DestroyImpl()
     uint32_t sessionId = GetId();
     auto resultFuture = m_uwbSessionConnector->SessionDeinitialize(sessionId);
     if (!resultFuture.valid()) {
-        PLOG_ERROR << "failed to issue device deinitialization request for session id " << sessionId;
+        PLOG_ERROR << std::format("session {}: failed to issue device deinitialization request", sessionId);
         throw UwbException(UwbStatusGeneric::Rejected);
     }
 
     try {
         resultFuture.get();
     } catch (UwbException &uwbException) {
-        PLOG_ERROR << "caught exception attempting to to deinitialize for session id " << sessionId << " (" << ToString(uwbException.Status) << ")";
+        PLOG_ERROR << std::format("session {}: caught exception attempting to to deinitialize, status={}", sessionId, ToString(uwbException.Status));
         throw uwbException;
     } catch (std::exception &e) {
-        PLOG_ERROR << "caught unexpected exception attempting to deinitialize for session id " << sessionId << " (" << e.what() << ")";
+        PLOG_ERROR << std::format("session {}: caught unexpected exception attempting to deinitialize, error={}", sessionId, e.what());
         throw e;
     }
 }

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbConnector.hxx
@@ -30,8 +30,6 @@ namespace uwb
  */
 class RegisteredSessionCallbackToken;
 class OnSessionEndedToken;
-class OnRangingStartedToken;
-class OnRangingStoppedToken;
 class OnPeerPropertiesChangedToken;
 class OnSessionMembershipChangedToken;
 
@@ -265,8 +263,6 @@ private:
     mutable std::shared_mutex m_eventCallbacksGate;
     std::unordered_map<uint32_t, std::vector<std::shared_ptr<::uwb::OnSessionEndedToken>>> m_onSessionEndedCallbacks;
     std::unordered_map<uint32_t, std::vector<std::shared_ptr<::uwb::OnSessionStatusChangedToken>>> m_onSessionStatusChangedCallbacks;
-    std::unordered_map<uint32_t, std::vector<std::shared_ptr<::uwb::OnRangingStartedToken>>> m_onRangingStartedCallbacks;
-    std::unordered_map<uint32_t, std::vector<std::shared_ptr<::uwb::OnRangingStoppedToken>>> m_onRangingStoppedCallbacks;
     std::unordered_map<uint32_t, std::vector<std::shared_ptr<::uwb::OnPeerPropertiesChangedToken>>> m_onPeerPropertiesChangedCallbacks;
     std::unordered_map<uint32_t, std::vector<std::shared_ptr<::uwb::OnSessionMembershipChangedToken>>> m_onSessionMembershipChangedCallbacks;
 

--- a/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
+++ b/windows/devices/uwb/include/windows/devices/uwb/UwbSession.hxx
@@ -129,8 +129,6 @@ private:
     std::shared_ptr<IUwbSessionDdiConnector> m_uwbSessionConnector;
     std::shared_ptr<::uwb::UwbRegisteredSessionEventCallbackTypes::OnSessionEnded> m_onSessionEndedCallback;
     std::shared_ptr<::uwb::UwbRegisteredSessionEventCallbackTypes::OnSessionStatusChanged> m_onSessionStatusChangedCallback;
-    std::shared_ptr<::uwb::UwbRegisteredSessionEventCallbackTypes::OnRangingStarted> m_onRangingStartedCallback;
-    std::shared_ptr<::uwb::UwbRegisteredSessionEventCallbackTypes::OnRangingStopped> m_onRangingStoppedCallback;
     std::shared_ptr<::uwb::UwbRegisteredSessionEventCallbackTypes::OnPeerPropertiesChanged> m_onPeerPropertiesChangedCallback;
     std::shared_ptr<::uwb::UwbRegisteredSessionEventCallbackTypes::OnSessionMembershipChanged> m_onSessionMembershipChangedCallback;
     ::uwb::UwbRegisteredSessionEventCallbackTokens m_registeredCallbacksTokens;


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

* Ensure session logging is consistent.
* Ensure coding style is consistent.
* Ensure ranging started and ranging stopped events fire.

### Technical Details

* Add "Session XXXX" prefix to all session log lines.
* Add explicit callbacks for session events in top-level `UwbSession` and invoke them from `UwbConnector` registered callbacks to consolidate processing.
* Remove `OnRangingStarted` and `OnRangingStopped` from `UwbRegisteredSessionEventCallbacks` as these are higher level concepts that don't map directly to events from the driver.
* Update logging in Windows UwbSession to use `std::format` instead of i/o manipulators.

### Test Results

Ran `nocli.exe driver uwb range --SessionId 1234 start --DeviceRole 1 --MultiNodeMode 1 --NumberOfControlees 1 --DeviceMacAddress 12:34 --DestinationMacAddresses 67:89 --DeviceType 1` and verified output looks as expected.

### Reviewer Focus

Consider whether any `std::format` lines have mismatched specifiers and associated arguments.

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
