### PR TITLE
Add WinRT event handlers to nocli service range start command

### DIFF
--- a/windows/devices/uwb/UwbSession.cxx
+++ b/windows/devices/uwb/UwbSession.cxx
@@ -20,7 +20,7 @@ using namespace windows::devices::uwb;
 using namespace ::uwb::protocol::fira;
 
 UwbSession::UwbSession(uint32_t sessionId, std::weak_ptr<::uwb::UwbDevice> device, std::shared_ptr<IUwbSessionDdiConnector> uwbSessionConnector, std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks, ::uwb::protocol::fira::DeviceType deviceType) :
-    ::uwb::UwbSession(sessionId, std::move(device), std::move(callbacks), deviceType),
+    ::uwb::UwbSession(sessionId, std::move(device), callbacks, deviceType),
     m_uwbSessionConnector(std::move(uwbSessionConnector))
 {
     m_onSessionEndedCallback =

--- a/windows/tools/nocli/NearObjectCliHandlerWindows.cxx
+++ b/windows/tools/nocli/NearObjectCliHandlerWindows.cxx
@@ -172,16 +172,16 @@ NearObjectCliHandlerWindows::HandleStartRanging(::uwb::protocol::fira::DeviceTyp
     auto session = sessionCreateResult.Session();
 
     // Register event handlers.
-    m_sessionEndedEventToken = session.SessionEnded(winrt::auto_revoke, [&](auto&& sender, auto&& sessionEndedEventArgs) {
+    m_sessionEndedEventToken = session.SessionEnded(winrt::auto_revoke, [session](auto&& sender, auto&& sessionEndedEventArgs) {
         PLOG_INFO << std::format("session {} ended, reason={}", session.Id(), magic_enum::enum_name(sessionEndedEventArgs.EndReason()));
     });
-    m_rangingStartedEventToken = session.RangingStarted(winrt::auto_revoke, [&](auto&& sender, [[maybe_unused]] auto&& rangingStartedEventArgs) {
+    m_rangingStartedEventToken = session.RangingStarted(winrt::auto_revoke, [session](auto&& sender, [[maybe_unused]] auto&& rangingStartedEventArgs) {
         PLOG_INFO << std::format("sesion {} ranging started", session.Id());
     });
-    m_rangingStoppedEventToken = session.RangingStopped(winrt::auto_revoke, [&]([[maybe_unused]] auto&& sender, [[maybe_unused]] auto&& rangingStoppedEventArgs) {
+    m_rangingStoppedEventToken = session.RangingStopped(winrt::auto_revoke, [session]([[maybe_unused]] auto&& sender, [[maybe_unused]] auto&& rangingStoppedEventArgs) {
         PLOG_INFO << std::format("sesion {} ranging stopped", session.Id());
     });
-    m_peerPropertiesChangedEventToken = session.PeerPropertiesChanged(winrt::auto_revoke, [&](auto&& sender, auto&& peerPropertiesChangedEventArgs) {
+    m_peerPropertiesChangedEventToken = session.PeerPropertiesChanged(winrt::auto_revoke, [session](auto&& sender, auto&& peerPropertiesChangedEventArgs) {
         PLOG_INFO << std::format("session {} peer properties changed:", session.Id());
         for (auto&& nearObject : peerPropertiesChangedEventArgs.NearObjectsChanged()) {
             auto spatialProperties = nearObject.SpatialProperties();
@@ -196,7 +196,7 @@ NearObjectCliHandlerWindows::HandleStartRanging(::uwb::protocol::fira::DeviceTyp
                 elevation.has_value() ? std::to_string(elevation.value()) : "-");
         }
     });
-    m_sessionMemembershipChangedEventToken = session.SessionMembershipChanged(winrt::auto_revoke, [&](auto&& sender, auto&& sessionMembershipChangedEventArgs) {
+    m_sessionMemembershipChangedEventToken = session.SessionMembershipChanged(winrt::auto_revoke, [session](auto&& sender, auto&& sessionMembershipChangedEventArgs) {
         auto nearObjectsAdded = sessionMembershipChangedEventArgs.NearObjectsAdded();
         auto nearObjectsRemoved = sessionMembershipChangedEventArgs.NearObjectsRemoved();
         PLOG_INFO << std::format("session {} session membership changed: +{} -{}", session.Id(), nearObjectsAdded.Size(), nearObjectsRemoved.Size());

--- a/windows/tools/nocli/NearObjectCliHandlerWindows.cxx
+++ b/windows/tools/nocli/NearObjectCliHandlerWindows.cxx
@@ -3,7 +3,7 @@
 #include <fstream>
 #include <iostream>
 #include <limits>
-#include <string>
+#include <optional>
 #include <string_view>
 
 #include <magic_enum.hpp>
@@ -185,15 +185,15 @@ NearObjectCliHandlerWindows::HandleStartRanging(::uwb::protocol::fira::DeviceTyp
         PLOG_INFO << std::format("session {} peer properties changed:", session.Id());
         for (auto&& nearObject : peerPropertiesChangedEventArgs.NearObjectsChanged()) {
             auto spatialProperties = nearObject.SpatialProperties();
-            auto distance = spatialProperties.Distance();
-            auto angleAzimuth = spatialProperties.AngleAzimuth();
-            auto angleElevation = spatialProperties.AngleElevation();
-            auto elevation = spatialProperties.Elevation();
+            std::optional<double> distance = spatialProperties.Distance();
+            std::optional<double> angleAzimuth = spatialProperties.AngleAzimuth();
+            std::optional<double> angleElevation = spatialProperties.AngleElevation();
+            std::optional<double> elevation = spatialProperties.Elevation();
             PLOG_INFO << std::format("Distance {} AngleAzimuth {} AngleElevation {} Elevation {}",
-                (distance != nullptr) ? std::to_string(distance.GetDouble()) : std::string("-"),
-                (angleAzimuth != nullptr) ? std::to_string(angleAzimuth.GetDouble()) : std::string("-"),
-                (angleElevation != nullptr) ? std::to_string(angleElevation.GetDouble()) : std::string("-"),
-                (elevation != nullptr) ? std::to_string(elevation.GetDouble()) : "-");
+                distance.has_value() ? std::to_string(distance.value()) : std::string("-"),
+                angleAzimuth.has_value() ? std::to_string(angleAzimuth.value()) : std::string("-"),
+                angleElevation.has_value() ? std::to_string(angleElevation.value()) : std::string("-"),
+                elevation.has_value() ? std::to_string(elevation.value()) : "-");
         }
     });
     m_sessionMemembershipChangedEventToken = session.SessionMembershipChanged(winrt::auto_revoke, [&](auto&& sender, auto&& sessionMembershipChangedEventArgs) {

--- a/windows/tools/nocli/NearObjectCliHandlerWindows.hxx
+++ b/windows/tools/nocli/NearObjectCliHandlerWindows.hxx
@@ -43,6 +43,13 @@ private:
 private:
     std::vector<std::shared_ptr<windows::devices::uwb::UwbDevice>> m_uwbDevices;
     winrt::Windows::Devices::NearObject::INearObjectSessionClient m_sessionClient;
+
+    // Event handler tokens.
+    winrt::Windows::Devices::NearObject::INearObjectSessionEventProducer::SessionEnded_revoker m_sessionEndedEventToken;
+    winrt::Windows::Devices::NearObject::INearObjectSessionEventProducer::RangingStarted_revoker m_rangingStartedEventToken;
+    winrt::Windows::Devices::NearObject::INearObjectSessionEventProducer::RangingStopped_revoker m_rangingStoppedEventToken;
+    winrt::Windows::Devices::NearObject::INearObjectSessionEventProducer::PeerPropertiesChanged_revoker m_peerPropertiesChangedEventToken;
+    winrt::Windows::Devices::NearObject::INearObjectSessionEventProducer::SessionMembershipChanged_revoker m_sessionMemembershipChangedEventToken;
 };
 } // namespace nearobject::cli
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [ ] Feature update
- [ ] Breaking change
- [ ] Non-functional change
- [ ] Documentation
- [ ] Infrastructure

### Goals

Ensure events are communicated to the user via command line when using the `service range start` command.

### Technical Details

* Register handlers for all the `NearObjectSession` events, printing the data to the command line.
* Fix access of moved-from variable `std::weak_ptr<::uwb::UwbSessionEventCallbacks> callbacks` in the `UwbSession` constructor which would cause the session event callbacks not to be resolved.

### Test Results

On-going.

### Reviewer Focus

None

### Future Work

Some `TODOs` were left to be completed once the mac address is added to the `NearObject` type.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
